### PR TITLE
chore(web): add openpanel analytics

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,13 @@ NEXT_PUBLIC_SUPABASE_URL=...
 NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY=...
 ```
 
+Optional OpenPanel analytics variables:
+
+```env
+NEXT_PUBLIC_OPENPANEL_CLIENT_ID=...
+OPENPANEL_CLIENT_SECRET=...
+```
+
 ## Checks
 
 Before opening a web PR, run:

--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ NEXT_PUBLIC_SUPABASE_URL=...
 NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY=...
 ```
 
+Optional OpenPanel analytics variables:
+
+```env
+NEXT_PUBLIC_OPENPANEL_CLIENT_ID=...
+OPENPANEL_CLIENT_SECRET=...
+```
+
+`NEXT_PUBLIC_OPENPANEL_CLIENT_ID` enables client-side screen view tracking through the first-party `/api/op` proxy. `OPENPANEL_CLIENT_SECRET` also mirrors Kocteau's existing first-party product events to OpenPanel from the server. Session replay is not enabled by default.
+
 Optional production services are configured outside the app:
 
 - Supabase Auth SMTP points to Resend.
@@ -166,6 +175,8 @@ Kocteau uses a small first-party analytics table in Supabase. Events currently t
 - `for_you_fallback`
 
 The goal is product feedback, not surveillance. Events avoid emails, IPs, user agents, and long free-form payloads.
+
+OpenPanel can be enabled for Vercel-friendly analytics by setting `NEXT_PUBLIC_OPENPANEL_CLIENT_ID`. If `OPENPANEL_CLIENT_SECRET` is also set, the same product events are mirrored server-side without adding emails, user agents, or free-form profile fields.
 
 ## Documentation
 

--- a/apps/web/app/(main)/layout.tsx
+++ b/apps/web/app/(main)/layout.tsx
@@ -4,6 +4,7 @@ import Header from "@/components/header";
 import AppSidebar from "@/components/app-sidebar";
 import GlobalShortcuts from "@/components/global-shortcuts";
 import MobileBottomBar from "@/components/mobile-bottom-bar";
+import { OpenPanelIdentify } from "@/components/openpanel-analytics";
 import { RouteHeaderProvider } from "@/components/route-header-context";
 import { getCurrentOnboardingState, getCurrentUser, getCurrentViewerProfile } from "@/lib/auth/server";
 import type { SidebarOwnedReview } from "@/lib/types/sidebar";
@@ -28,6 +29,7 @@ export default async function MainLayout({ children }: { children: React.ReactNo
 
   return (
     <ReactQueryProvider>
+      {safeProfile ? <OpenPanelIdentify profileId={safeProfile.id} /> : null}
       <SidebarProvider
         defaultOpen={true}
         style={

--- a/apps/web/app/api/op/[...op]/route.ts
+++ b/apps/web/app/api/op/[...op]/route.ts
@@ -1,0 +1,105 @@
+import { NextResponse } from "next/server";
+
+const DEFAULT_OPENPANEL_API_URL = "https://api.openpanel.dev";
+const DEFAULT_OPENPANEL_SCRIPT_URL = "https://openpanel.dev/op1.js";
+
+function getBaseUrl(value: string | undefined, fallback: string) {
+  const url = value?.trim() || fallback;
+
+  return url.replace(/\/$/, "");
+}
+
+function buildForwardHeaders(req: Request) {
+  const headers = new Headers();
+  const clientId = req.headers.get("openpanel-client-id");
+  const origin = req.headers.get("origin");
+
+  headers.set("Content-Type", "application/json");
+
+  if (clientId) {
+    headers.set("openpanel-client-id", clientId);
+  }
+
+  if (origin) {
+    headers.set("origin", origin);
+  }
+
+  return headers;
+}
+
+async function proxyScript(req: Request) {
+  const url = new URL(req.url);
+  const scriptUrl = new URL(
+    getBaseUrl(process.env.OPENPANEL_SCRIPT_URL, DEFAULT_OPENPANEL_SCRIPT_URL),
+  );
+
+  url.searchParams.forEach((value, key) => {
+    scriptUrl.searchParams.set(key, value);
+  });
+
+  const response = await fetch(scriptUrl, {
+    next: {
+      revalidate: 86_400,
+    },
+  });
+
+  if (!response.ok) {
+    return NextResponse.json(
+      { error: "Failed to fetch OpenPanel script." },
+      { status: response.status },
+    );
+  }
+
+  return new Response(await response.text(), {
+    headers: {
+      "Cache-Control": "public, max-age=86400, stale-while-revalidate=86400",
+      "Content-Type": "text/javascript; charset=utf-8",
+    },
+  });
+}
+
+async function proxyTrack(req: Request) {
+  const url = new URL(req.url);
+  const trackIndex = url.pathname.indexOf("/track");
+
+  if (trackIndex === -1) {
+    return NextResponse.json({ error: "Not found." }, { status: 404 });
+  }
+
+  const apiUrl = getBaseUrl(
+    process.env.OPENPANEL_API_URL,
+    DEFAULT_OPENPANEL_API_URL,
+  );
+  const trackPath = url.pathname.slice(trackIndex);
+  const response = await fetch(`${apiUrl}${trackPath}`, {
+    method: req.method,
+    headers: buildForwardHeaders(req),
+    body: req.method === "POST" ? await req.text() : undefined,
+    cache: "no-store",
+  });
+  const headers = new Headers();
+  const contentType = response.headers.get("content-type");
+
+  if (contentType) {
+    headers.set("Content-Type", contentType);
+  }
+
+  return new Response(await response.text(), {
+    status: response.status,
+    headers,
+  });
+}
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+
+  if (url.pathname.endsWith("/op1.js")) {
+    return proxyScript(req);
+  }
+
+  return proxyTrack(req);
+}
+
+export async function POST(req: Request) {
+  return proxyTrack(req);
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Merriweather } from "next/font/google";
 import "./globals.css";
 import JsonLd from "@/components/json-ld";
+import OpenPanelAnalytics from "@/components/openpanel-analytics";
 import { cn } from "@/lib/utils";
 import { Toaster } from "@/components/ui/sonner";
 import { getMetadataBase } from "@/lib/metadata";
@@ -60,6 +61,7 @@ export default function RootLayout({
         className={`${geist.className} antialiased dark`}
       >
         <JsonLd data={buildSiteGraphJsonLd()} id="site-structured-data" />
+        <OpenPanelAnalytics />
         {children}
         <Toaster position="bottom-right" richColors />
       </body>

--- a/apps/web/components/openpanel-analytics.tsx
+++ b/apps/web/components/openpanel-analytics.tsx
@@ -1,0 +1,39 @@
+import {
+  IdentifyComponent,
+  OpenPanelComponent,
+} from "@openpanel/nextjs";
+
+const openPanelClientId = process.env.NEXT_PUBLIC_OPENPANEL_CLIENT_ID?.trim();
+const openPanelDisabled =
+  process.env.NEXT_PUBLIC_OPENPANEL_DISABLED === "true" ||
+  process.env.NODE_ENV === "test";
+
+export default function OpenPanelAnalytics() {
+  if (!openPanelClientId || openPanelDisabled) {
+    return null;
+  }
+
+  return (
+    <OpenPanelComponent
+      apiUrl="/api/op"
+      scriptUrl="/api/op/op1.js"
+      clientId={openPanelClientId}
+      trackScreenViews={true}
+      globalProperties={{
+        app: "kocteau",
+        environment:
+          process.env.NEXT_PUBLIC_VERCEL_ENV ??
+          process.env.NODE_ENV ??
+          "development",
+      }}
+    />
+  );
+}
+
+export function OpenPanelIdentify({ profileId }: { profileId: string }) {
+  if (!openPanelClientId || openPanelDisabled) {
+    return null;
+  }
+
+  return <IdentifyComponent profileId={profileId} />;
+}

--- a/apps/web/lib/analytics/openpanel-server.ts
+++ b/apps/web/lib/analytics/openpanel-server.ts
@@ -1,0 +1,69 @@
+import "server-only";
+
+import {
+  OpenPanelBase,
+  type TrackProperties,
+} from "@openpanel/nextjs";
+import type { AnalyticsEventInput } from "@/lib/validation/schemas";
+
+type OpenPanelServerClient = InstanceType<typeof OpenPanelBase>;
+
+type TrackOpenPanelServerEventOptions = AnalyticsEventInput & {
+  profileId: string;
+};
+
+let openPanelServerClient: OpenPanelServerClient | null | undefined;
+
+function getOpenPanelServerClient() {
+  if (openPanelServerClient !== undefined) {
+    return openPanelServerClient;
+  }
+
+  const clientId = process.env.NEXT_PUBLIC_OPENPANEL_CLIENT_ID?.trim();
+  const clientSecret = process.env.OPENPANEL_CLIENT_SECRET?.trim();
+
+  if (!clientId || !clientSecret) {
+    openPanelServerClient = null;
+    return openPanelServerClient;
+  }
+
+  const apiUrl = process.env.OPENPANEL_API_URL?.trim() || undefined;
+
+  openPanelServerClient = new OpenPanelBase({
+    apiUrl,
+    clientId,
+    clientSecret,
+    sdk: "kocteau-web-server",
+  });
+
+  return openPanelServerClient;
+}
+
+export async function trackOpenPanelServerEvent({
+  profileId,
+  eventType,
+  source,
+  metadata,
+}: TrackOpenPanelServerEventOptions) {
+  const openPanel = getOpenPanelServerClient();
+
+  if (!openPanel) {
+    return;
+  }
+
+  const properties = {
+    ...metadata,
+    source,
+    profileId,
+  } satisfies TrackProperties;
+
+  try {
+    await openPanel.track(eventType, properties);
+  } catch (error) {
+    console.warn("[analytics.trackOpenPanelServerEvent] skipped", {
+      eventType,
+      source,
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+}

--- a/apps/web/lib/analytics/server.ts
+++ b/apps/web/lib/analytics/server.ts
@@ -1,7 +1,9 @@
 import "server-only";
 
+import { after } from "next/server";
 import type { Json } from "@/lib/supabase/database.types";
 import type { supabaseServer } from "@/lib/supabase/server";
+import { trackOpenPanelServerEvent } from "@/lib/analytics/openpanel-server";
 import type { AnalyticsEventInput } from "@/lib/validation/schemas";
 
 type SupabaseServerClient = Awaited<ReturnType<typeof supabaseServer>>;
@@ -36,4 +38,13 @@ export async function trackServerAnalyticsEvent(
       message: error.message ?? null,
     });
   }
+
+  after(() =>
+    trackOpenPanelServerEvent({
+      profileId: userId,
+      eventType,
+      source,
+      metadata,
+    }),
+  );
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,7 @@
     "@hookform/resolvers": "^5.2.2",
     "@hugeicons/core-free-icons": "^4.0.0",
     "@hugeicons/react": "^1.1.6",
+    "@openpanel/nextjs": "^1.5.0",
     "@origin-space/image-cropper": "^0.1.9",
     "@sentry/nextjs": "10",
     "@supabase/ssr": "^0.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,9 @@ importers:
       '@hugeicons/react':
         specifier: ^1.1.6
         version: 1.1.6(react@19.2.4)
+      '@openpanel/nextjs':
+        specifier: ^1.5.0
+        version: 1.5.0(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@origin-space/image-cropper':
         specifier: ^0.1.9
         version: 0.1.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1561,6 +1564,19 @@ packages:
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
+  '@openpanel/nextjs@1.5.0':
+    resolution: {integrity: sha512-CuEUdYb8LZxrsoO1+6EXKaCp6tJtEeQzStaEUVBwpewV50mp0pOf3JOboH4K61nIBy3CDLLpbnzUw3iMgrqSYQ==}
+    peerDependencies:
+      next: ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@openpanel/sdk@1.3.0':
+    resolution: {integrity: sha512-VK/1oawBjGdxA+oYtqcWlNXlLT1zRJ9tslHoMvqqsqlcLNOhH26ltcHpyGp5RhtIF7uIkCltiicALfFN7fyldw==}
+
+  '@openpanel/web@1.4.0':
+    resolution: {integrity: sha512-uOEjQ8NVeiswTg0GXlxoWlFyOp//Rf3teQKBFbXy3yRelUYjH7pM0ZxGuBRC2ev4Bpn2zs+G1Kk8xGo2pzfbUg==}
+
   '@opentelemetry/api-logs@0.207.0':
     resolution: {integrity: sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ==}
     engines: {node: '>=8.0.0'}
@@ -2751,6 +2767,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rrweb/types@2.0.0-alpha.20':
+    resolution: {integrity: sha512-RbnDgKxA/odwB1R4gF7eUUj+rdSrq6ROQJsnMw7MIsGzlbSYvJeZN8YY4XqU0G6sKJvXI6bSzk7w/G94jNwzhw==}
+
+  '@rrweb/utils@2.0.0-alpha.20':
+    resolution: {integrity: sha512-MTQOmhPRe39C0fYaCnnVYOufQsyGzwNXpUStKiyFSfGLUJrzuwhbRoUAKR5w6W2j5XuA0bIz3ZDIBztkquOhLw==}
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
@@ -3135,6 +3157,9 @@ packages:
   '@types/cors@2.8.19':
     resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
 
+  '@types/css-font-loading-module@0.0.7':
+    resolution: {integrity: sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==}
+
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
 
@@ -3453,6 +3478,9 @@ packages:
     resolution: {integrity: sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==}
     engines: {node: '>=10.0.0'}
 
+  '@xstate/fsm@1.6.5':
+    resolution: {integrity: sha512-b5o1I6aLNeYlU/3CPlj/Z91ybk1gUsKT+5NAJI+2W4UjvS5KLG28K9v5UvNoFVjHV8PajVZ00RH3vnjyQO7ZAw==}
+
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
 
@@ -3716,6 +3744,10 @@ packages:
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
+
+  base64-arraybuffer@1.0.2:
+    resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
+    engines: {node: '>= 0.6.0'}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -5871,6 +5903,9 @@ packages:
     resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
     engines: {node: '>= 18'}
 
+  mitt@3.0.1:
+    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+
   mkdirp@1.0.4:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
     engines: {node: '>=10'}
@@ -6727,6 +6762,15 @@ packages:
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
+
+  rrdom@2.0.0-alpha.20:
+    resolution: {integrity: sha512-hoqjS4662LtBp82qEz9GrqU36UpEmCvTA2Hns3qdF7cklLFFy3G+0Th8hLytJENleHHWxsB5nWJ3eXz5mSRxdQ==}
+
+  rrweb-snapshot@2.0.0-alpha.20:
+    resolution: {integrity: sha512-YTNf9YVeaGRo/jxY3FKBge2c/Ojd/KTHmuWloUSB+oyPXuY73ZeeG873qMMmhIpqEn7hn7aBF1eWEQmP7wjf8A==}
+
+  rrweb@2.0.0-alpha.20:
+    resolution: {integrity: sha512-CZKDlm+j1VA50Ko3gnMbpvguCAleljsTNXPnVk9aeNP8o6T6kolRbISHyDZpqZ4G+bdDLlQOignPP3jEsXs8Gg==}
 
   run-applescript@7.1.0:
     resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
@@ -9146,6 +9190,21 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
+  '@openpanel/nextjs@1.5.0(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@openpanel/web': 1.4.0
+      next: 16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
+  '@openpanel/sdk@1.3.0': {}
+
+  '@openpanel/web@1.4.0':
+    dependencies:
+      '@openpanel/sdk': 1.3.0
+      '@rrweb/types': 2.0.0-alpha.20
+      rrweb: 2.0.0-alpha.20
+
   '@opentelemetry/api-logs@0.207.0':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -10670,6 +10729,10 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.0':
     optional: true
 
+  '@rrweb/types@2.0.0-alpha.20': {}
+
+  '@rrweb/utils@2.0.0-alpha.20': {}
+
   '@rtsao/scc@1.1.0': {}
 
   '@sec-ant/readable-stream@0.4.1': {}
@@ -11098,6 +11161,8 @@ snapshots:
     dependencies:
       '@types/node': 20.19.35
 
+  '@types/css-font-loading-module@0.0.7': {}
+
   '@types/d3-array@3.2.2': {}
 
   '@types/d3-color@3.1.3': {}
@@ -11446,6 +11511,8 @@ snapshots:
 
   '@xmldom/xmldom@0.8.12': {}
 
+  '@xstate/fsm@1.6.5': {}
+
   '@xtuc/ieee754@1.2.0': {}
 
   '@xtuc/long@4.2.2': {}
@@ -11778,6 +11845,8 @@ snapshots:
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
+
+  base64-arraybuffer@1.0.2: {}
 
   base64-js@1.5.1: {}
 
@@ -14330,6 +14399,8 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
+  mitt@3.0.1: {}
+
   mkdirp@1.0.4: {}
 
   module-details-from-path@1.0.4: {}
@@ -15371,6 +15442,25 @@ snapshots:
       path-to-regexp: 8.3.0
     transitivePeerDependencies:
       - supports-color
+
+  rrdom@2.0.0-alpha.20:
+    dependencies:
+      rrweb-snapshot: 2.0.0-alpha.20
+
+  rrweb-snapshot@2.0.0-alpha.20:
+    dependencies:
+      postcss: 8.5.6
+
+  rrweb@2.0.0-alpha.20:
+    dependencies:
+      '@rrweb/types': 2.0.0-alpha.20
+      '@rrweb/utils': 2.0.0-alpha.20
+      '@types/css-font-loading-module': 0.0.7
+      '@xstate/fsm': 1.6.5
+      base64-arraybuffer: 1.0.2
+      mitt: 3.0.1
+      rrdom: 2.0.0-alpha.20
+      rrweb-snapshot: 2.0.0-alpha.20
 
   run-applescript@7.1.0: {}
 


### PR DESCRIPTION
## What changed

- Added `@openpanel/nextjs` to the web app.
- Mounted OpenPanel client analytics in the root layout for screen views.
- Added signed-in profile identification through OpenPanel when enabled.
- Added a first-party `/api/op` proxy for OpenPanel script and tracking requests.
- Mirrored Kocteau’s existing server-side analytics events to OpenPanel when `OPENPANEL_CLIENT_SECRET` is configured.
- Documented the optional OpenPanel environment variables.

## Why

To enable OpenPanel analytics on Kocteau without exposing secrets in client code and without requiring analytics env vars for local development or CI builds.

## Testing

- [x] Ran `pnpm check`
- [ ] Added screenshots or a short recording for visible web UI changes  
  Not applicable: no visible web UI changes.
- [ ] Confirmed this does not touch auth, Supabase, recommendations, analytics, CI, or release behavior  
  This intentionally touches analytics only.

## Changelog impact

No manual `CHANGELOG.md` edit is required. Release Please generates release notes from PR titles and squash commits.

- [ ] User-facing web change
- [x] Developer experience or documentation change
- [x] Internal-only change
