### PR TITLE
Experiment/feed cta polish

### DIFF
--- a/apps/web/app/(main)/page.tsx
+++ b/apps/web/app/(main)/page.tsx
@@ -2,7 +2,6 @@ import { HydrationBoundary, dehydrate } from "@tanstack/react-query";
 import FeedViewTabs from "@/components/feed-view-tabs";
 import FeedReviewList from "@/components/feed-review-list";
 import JsonLd from "@/components/json-ld";
-import NewReviewDialog from "@/components/new-review-dialog";
 import { OnboardingWelcomeFromUrl } from "@/components/auth/onboarding-welcome-dialog";
 import WhoToFollowRail from "@/components/who-to-follow-rail";
 import { getCurrentUser, getCurrentViewerProfile } from "@/lib/auth/server";
@@ -110,28 +109,13 @@ export default async function HomePage({
     }).slice(0, 10),
   );
 
-  function renderFeedSearchTrigger() {
-    return (
-      <NewReviewDialog
-        isAuthenticated={Boolean(user)}
-        triggerVariant="search"
-        triggerLabel="Find a track to review..."
-      />
-    );
-  }
-
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
       <JsonLd data={feedStructuredData} id="home-structured-data" />
       {params.welcome === "kocteau" ? <OnboardingWelcomeFromUrl /> : null}
       <div className="flex h-full min-h-0 flex-col">
         <section className="mx-auto w-full max-w-5xl space-y-5 sm:space-y-6 lg:hidden">
-          <div className="flex flex-col gap-2.5">
-            <div className="min-w-0">
-              {renderFeedSearchTrigger()}
-            </div>
-            <FeedViewTabs activeView={tabActiveView} fullWidth />
-          </div>
+          <FeedViewTabs activeView={tabActiveView} fullWidth />
 
           <div className="space-y-4">
             <FeedReviewList
@@ -150,13 +134,8 @@ export default async function HomePage({
               className="mx-auto grid w-full gap-5 lg:grid-cols-[minmax(0,44rem)_16rem] lg:justify-center xl:gap-6"
             >
               <div className="min-w-0 space-y-4">
-                <div className="grid gap-2.5 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-center">
-                  <div className="min-w-0">
-                    {renderFeedSearchTrigger()}
-                  </div>
-                  <div className="justify-self-start xl:justify-self-end">
-                    <FeedViewTabs activeView={tabActiveView} />
-                  </div>
+                <div className="flex justify-start">
+                  <FeedViewTabs activeView={tabActiveView} />
                 </div>
 
                 <FeedReviewList

--- a/apps/web/app/(main)/page.tsx
+++ b/apps/web/app/(main)/page.tsx
@@ -115,7 +115,7 @@ export default async function HomePage({
       {params.welcome === "kocteau" ? <OnboardingWelcomeFromUrl /> : null}
       <div className="flex h-full min-h-0 flex-col">
         <section className="mx-auto w-full max-w-5xl space-y-5 sm:space-y-6 lg:hidden">
-          <FeedViewTabs activeView={tabActiveView} fullWidth />
+          {user ? <FeedViewTabs activeView={tabActiveView} fullWidth /> : null}
 
           <div className="space-y-4">
             <FeedReviewList
@@ -134,9 +134,11 @@ export default async function HomePage({
               className="mx-auto grid w-full gap-5 lg:grid-cols-[minmax(0,44rem)_16rem] lg:justify-center xl:gap-6"
             >
               <div className="min-w-0 space-y-4">
-                <div className="flex justify-start">
-                  <FeedViewTabs activeView={tabActiveView} />
-                </div>
+                {user ? (
+                  <div className="flex justify-start">
+                    <FeedViewTabs activeView={tabActiveView} />
+                  </div>
+                ) : null}
 
                 <FeedReviewList
                   view={activeView}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -51,7 +51,7 @@
 
 :root {
   color-scheme: light;
-  --radius: 0.625rem;
+  --radius: 0.5rem;
   --kocteau-gray-1: oklch(0.162 0 0);
   --kocteau-gray-2: oklch(0.195 0 0);
   --kocteau-gray-3: oklch(0.254 0 0);
@@ -123,8 +123,8 @@
     0 0 0 1px var(--kocteau-line);
   --kocteau-shadow-control:
     0 0 0 1px var(--kocteau-line-soft);
-  --kocteau-radius-card: 1.05rem;
-  --kocteau-radius-control: 0.95rem;
+  --kocteau-radius-card: 0.82rem;
+  --kocteau-radius-control: 0.68rem;
   --kocteau-ease: cubic-bezier(0.2, 0, 0, 1);
 }
 
@@ -189,8 +189,8 @@
     0 0 0 1px color-mix(in oklch, var(--kocteau-gray-12) 7%, transparent);
   --kocteau-shadow-control:
     0 0 0 1px color-mix(in oklch, var(--kocteau-gray-12) 5.5%, transparent);
-  --kocteau-radius-card: 0.95rem;
-  --kocteau-radius-control: 0.78rem;
+  --kocteau-radius-card: 0.74rem;
+  --kocteau-radius-control: 0.62rem;
   background-image: none;
 }
 

--- a/apps/web/components/feed-review-cta.tsx
+++ b/apps/web/components/feed-review-cta.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import Link from "next/link";
+import { Search } from "lucide-react";
+import NewReviewDialog from "@/components/new-review-dialog";
+import ReviewGlyphIcon from "@/components/review-glyph-icon";
+import { cn } from "@/lib/utils";
+
+const DitheringShader = dynamic(
+  () => import("@paper-design/shaders-react").then((mod) => mod.Dithering),
+  {
+    ssr: false,
+  },
+);
+
+type FeedReviewCtaProps = {
+  isAuthenticated: boolean;
+  className?: string;
+};
+
+export default function FeedReviewCta({
+  isAuthenticated,
+  className,
+}: FeedReviewCtaProps) {
+  const trigger = (
+    <button
+      type="button"
+      className="inline-flex h-9 min-w-0 items-center justify-center gap-2 rounded-[0.56rem] bg-foreground px-3.5 text-[13px] font-medium text-background transition-[background-color,transform] duration-150 ease-[var(--kocteau-ease)] hover:bg-foreground/88 active:scale-[0.96]"
+    >
+      <ReviewGlyphIcon className="size-3.5 shrink-0" />
+      <span>Review a track</span>
+    </button>
+  );
+
+  return (
+    <section
+      aria-label="Review prompt"
+      className={cn(
+        "kocteau-review-card relative isolate min-h-[9.5rem] overflow-hidden rounded-[var(--kocteau-radius-card)] px-4 py-4 sm:min-h-[10.25rem] sm:px-5 sm:py-5",
+        className,
+      )}
+    >
+      <div className="pointer-events-none absolute inset-0 overflow-hidden opacity-35 mix-blend-screen">
+        <DitheringShader
+          colorBack="#050505"
+          colorFront="#f4f4f5"
+          height={460}
+          scale={0.64}
+          shape="swirl"
+          size={2}
+          speed={0.26}
+          style={{ height: "100%", width: "100%" }}
+          type="4x4"
+          width={900}
+        />
+      </div>
+
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_74%_26%,rgba(255,255,255,0.13),transparent_24rem),linear-gradient(90deg,rgba(5,5,5,0.94),rgba(5,5,5,0.58)_50%,rgba(5,5,5,0.82))]" />
+      <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(180deg,rgba(255,255,255,0.045),transparent_36%,rgba(0,0,0,0.22))]" />
+
+      <div className="relative z-10 flex min-h-[7.5rem] flex-col justify-between gap-4 sm:min-h-[8rem] sm:flex-row sm:items-end">
+        <div className="max-w-[25rem] space-y-2">
+          <p className="text-[11px] font-medium uppercase tracking-[0.16em] text-muted-foreground/76">
+            Review
+          </p>
+          <h2 className="text-balance font-serif text-[1.42rem] font-semibold leading-[1.08] text-foreground sm:text-[1.7rem]">
+            Find something to review.
+          </h2>
+          <p className="max-w-[22rem] text-pretty text-[13px] leading-5 text-muted-foreground/82 sm:text-[13.5px]">
+            Search a track and leave a signal for your feed.
+          </p>
+        </div>
+
+        <div className="flex shrink-0 items-center gap-2">
+          <NewReviewDialog
+            isAuthenticated={isAuthenticated}
+            trigger={trigger}
+          />
+          <Link
+            href="/search"
+            className="inline-flex h-9 items-center justify-center gap-2 rounded-[0.56rem] bg-foreground/[0.07] px-3 text-[13px] font-medium text-foreground/86 transition-[background-color,color,transform] duration-150 ease-[var(--kocteau-ease)] hover:bg-foreground/[0.11] hover:text-foreground active:scale-[0.96]"
+          >
+            <Search className="size-3.5" />
+            <span>Explore</span>
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/components/feed-review-list.tsx
+++ b/apps/web/components/feed-review-list.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useRef } from "react";
 import Link from "next/link";
 import { useInfiniteQuery } from "@tanstack/react-query";
+import FeedReviewCta from "@/components/feed-review-cta";
 import FeedStarterLayer from "@/components/feed-starter-layer";
 import { Music2, Sparkles, UsersRound } from "lucide-react";
 import { FeedReviewCard } from "@/components/review-route-cards";
@@ -254,6 +255,7 @@ export default function FeedReviewList({
     isAuthenticated &&
     visibleStarterTracks.length > 0 &&
     reviews.length < 4;
+  const showReviewCta = view === "for-you" || view === "latest";
 
   if (reviews.length === 0) {
     if (showStarterLayer) {
@@ -270,6 +272,10 @@ export default function FeedReviewList({
 
   return (
     <div className="space-y-3.5">
+      {showReviewCta ? (
+        <FeedReviewCta isAuthenticated={isAuthenticated} />
+      ) : null}
+
       {reviews.map((review, index) => {
         const author = review.author;
 

--- a/apps/web/components/header.tsx
+++ b/apps/web/components/header.tsx
@@ -206,7 +206,7 @@ export default function Header({
               <Button
                 variant="outline"
                 size="sm"
-                className="mobile-liquid-button pointer-events-auto h-10 rounded-full px-4 text-foreground md:border-border/30"
+                className="mobile-liquid-button pointer-events-auto h-10 rounded-full px-4 text-foreground md:h-8 md:rounded-[0.62rem] md:border-border/30 md:px-3 md:text-xs"
               >
                 Log in
               </Button>

--- a/apps/web/components/review-card-body.tsx
+++ b/apps/web/components/review-card-body.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
+
+type ReviewCardBodyProps = {
+  body: string;
+  className?: string;
+  clampLines?: 3 | 4 | 5;
+};
+
+export default function ReviewCardBody({
+  body,
+  className,
+  clampLines,
+}: ReviewCardBodyProps) {
+  const bodyRef = useRef<HTMLParagraphElement | null>(null);
+  const [expanded, setExpanded] = useState(false);
+  const [hasOverflow, setHasOverflow] = useState(false);
+  const isCollapsed = Boolean(clampLines && !expanded);
+  const likelyNeedsToggle = Boolean(
+    clampLines &&
+      body.trim().length >
+        (clampLines === 5 ? 420 : clampLines === 4 ? 280 : 220),
+  );
+  const canToggle = hasOverflow || likelyNeedsToggle;
+
+  useEffect(() => {
+    if (!clampLines || expanded) {
+      return;
+    }
+
+    const node = bodyRef.current;
+
+    if (!node) {
+      return;
+    }
+
+    const syncOverflow = () => {
+      setHasOverflow(node.scrollHeight > node.clientHeight + 1);
+    };
+
+    syncOverflow();
+
+    const observer = new ResizeObserver(syncOverflow);
+    observer.observe(node);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [body, clampLines, expanded]);
+
+  return (
+    <div className="space-y-1.5">
+      <p
+        ref={bodyRef}
+        className={cn(
+          className,
+          isCollapsed && clampLines === 3 && "line-clamp-3",
+          isCollapsed && clampLines === 4 && "line-clamp-4",
+          isCollapsed && clampLines === 5 && "line-clamp-5",
+        )}
+      >
+        {body}
+      </p>
+
+      {canToggle ? (
+        <button
+          aria-expanded={expanded}
+          className="inline-flex h-8 items-center rounded-[0.48rem] pr-2 text-[12.5px] font-medium text-muted-foreground/82 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30"
+          data-prevent-review-link="true"
+          onClick={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            setExpanded((current) => !current);
+          }}
+          type="button"
+        >
+          {expanded ? "Show less" : "Read more"}
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/components/review-card.tsx
+++ b/apps/web/components/review-card.tsx
@@ -2,6 +2,7 @@ import type { ComponentPropsWithoutRef, ReactNode } from "react";
 import { Star } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import EntityCoverImage from "@/components/entity-cover-image";
+import ReviewCardBody from "@/components/review-card-body";
 import UserAvatar from "@/components/user-avatar";
 import { cn } from "@/lib/utils";
 
@@ -336,19 +337,16 @@ export default function ReviewCard({
               ) : null}
 
               {review.body ? (
-                <p
+                <ReviewCardBody
+                  body={review.body}
+                  clampLines={bodyClampLines}
                   className={cn(
                     "font-serif text-pretty text-foreground/86",
                     usesBalancedCopy
                       ? "text-[14.5px] leading-[1.68] sm:text-[14.95px]"
                       : "text-[14.8px] leading-[1.64] sm:text-[15.1px]",
-                    bodyClampLines === 3 && "line-clamp-3",
-                    bodyClampLines === 4 && "line-clamp-4",
-                    bodyClampLines === 5 && "line-clamp-5",
                   )}
-                >
-                  {review.body}
-                </p>
+                />
               ) : (
                 <p className="text-[13.5px] leading-6 text-muted-foreground/78">Only a rating was left for this track.</p>
               )}
@@ -365,16 +363,11 @@ export default function ReviewCard({
             ) : null}
 
             {review.body ? (
-              <p
-                className={cn(
-                  "font-serif text-[14.95px] leading-[1.64] text-pretty text-foreground/84",
-                  bodyClampLines === 3 && "line-clamp-3",
-                  bodyClampLines === 4 && "line-clamp-4",
-                  bodyClampLines === 5 && "line-clamp-5",
-                )}
-              >
-                {review.body}
-              </p>
+              <ReviewCardBody
+                body={review.body}
+                clampLines={bodyClampLines}
+                className="font-serif text-[14.95px] leading-[1.64] text-pretty text-foreground/84"
+              />
             ) : (
               <p className="text-sm text-muted-foreground/78">Only a rating was left for this track.</p>
             )}

--- a/apps/web/components/who-to-follow-rail.tsx
+++ b/apps/web/components/who-to-follow-rail.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { motion, useReducedMotion } from "motion/react";
 import FollowProfileButton from "@/components/follow-profile-button";
 import { WhoToFollowRailSkeleton } from "@/components/feed-loading-skeletons";
 import PrefetchLink from "@/components/prefetch-link";
@@ -35,7 +34,6 @@ export default function WhoToFollowRail({
   isAuthenticated,
 }: WhoToFollowRailProps) {
   const isDesktop = useDesktopRail();
-  const prefersReducedMotion = useReducedMotion();
   const { data, isLoading } = useQuery({
     ...activeProfilesQueryOptions(4),
     enabled: isDesktop,
@@ -53,24 +51,13 @@ export default function WhoToFollowRail({
           <WhoToFollowRailSkeleton showHeading={false} />
         ) : profiles.length > 0 ? (
           <div className="border-t border-border/32">
-            {profiles.map((profile, index) => {
+            {profiles.map((profile) => {
               const primaryLabel = profile.display_name ?? `@${profile.username}`;
 
               return (
-                <motion.div
+                <div
                   key={profile.id}
                   className="kocteau-rail-row border-b border-border/24 px-1 py-3"
-                  initial={prefersReducedMotion ? false : { opacity: 0, y: 6 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={
-                    prefersReducedMotion
-                      ? { duration: 0 }
-                      : {
-                          duration: 0.16,
-                          ease: "easeOut",
-                          delay: Math.min(index * 0.02, 0.06),
-                        }
-                  }
                 >
                   <div className="flex items-start gap-2.5">
                     <PrefetchLink
@@ -108,7 +95,7 @@ export default function WhoToFollowRail({
                       />
                     ) : null}
                   </div>
-                </motion.div>
+                </div>
               );
             })}
           </div>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,6 +16,7 @@
     "@hugeicons/core-free-icons": "^4.0.0",
     "@hugeicons/react": "^1.1.6",
     "@origin-space/image-cropper": "^0.1.9",
+    "@paper-design/shaders-react": "^0.0.76",
     "@sentry/nextjs": "10",
     "@supabase/ssr": "^0.9.0",
     "@supabase/supabase-js": "^2.98.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,9 @@ importers:
       '@origin-space/image-cropper':
         specifier: ^0.1.9
         version: 0.1.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@paper-design/shaders-react':
+        specifier: ^0.0.76
+        version: 0.0.76(@types/react@19.2.14)(react@19.2.4)
       '@sentry/nextjs':
         specifier: '10'
         version: 10.46.0(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.105.4)
@@ -1782,6 +1785,18 @@ packages:
     peerDependencies:
       react: ^19.1.0
       react-dom: ^19.1.0
+
+  '@paper-design/shaders-react@0.0.76':
+    resolution: {integrity: sha512-uPJWrYRf6cJdO2H+fuXlahaqz0QjYglNAyUTaRfIInpzCa/d6guxBIK003soAZQFuQ035yg9FhtfFzKNWm+a5A==}
+    peerDependencies:
+      '@types/react': 19.2.14
+      react: ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@paper-design/shaders@0.0.76':
+    resolution: {integrity: sha512-AcNDY4J66YQHUfQYFInkCP7M9VOje0od7wLpOR7LtCmc532opJy6ll+h1W9zBovz8tt9U7OADUmJ/qKEXyOX/A==}
 
   '@prisma/instrumentation@7.4.2':
     resolution: {integrity: sha512-r9JfchJF1Ae6yAxcaLu/V1TGqBhAuSDe3mRNOssBfx1rMzfZ4fdNvrgUBwyb/TNTGXFxlH9AZix5P257x07nrg==}
@@ -9479,6 +9494,15 @@ snapshots:
     dependencies:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
+
+  '@paper-design/shaders-react@0.0.76(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@paper-design/shaders': 0.0.76
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@paper-design/shaders@0.0.76': {}
 
   '@prisma/instrumentation@7.4.2(@opentelemetry/api@1.9.1)':
     dependencies:


### PR DESCRIPTION
## What changed

Refined the feed experience with a quieter review CTA and cleaner unauthenticated layout.

- Added an experimental animated review CTA for the feed.
- Removed the duplicated “Find a track to review…” launcher from the feed.
- Hid feed tabs for signed-out users.
- Added “Read more” / “Show less” behavior for longer review text.
- Reduced border radius across the web UI for a sharper editorial feel.
- Removed the Fresh voices animation.
- Made the desktop `Log in` button thinner while keeping the mobile size intact.

### Before 
<img width="1366" height="601" alt="{80448A1F-79F5-437A-9475-88C86269E7E8}" src="https://github.com/user-attachments/assets/6b5c72e2-fab2-4c63-89f5-e33cf0eafea8" />
 ### After
 
<img width="1366" height="608" alt="{789EFAE1-D990-4187-9049-861E681F4E15}" src="https://github.com/user-attachments/assets/76ff6452-2ee5-4f0f-b4a6-557bcaa1a137" />


## Why

The feed is Kocteau’s primary surface. These changes reduce repeated actions, make reviews easier to read, and give signed-out users a cleaner first impression while keeping the interface dark, minimal, and review-first.

## Testing

- [ ] Ran `pnpm check`
- [x] Added screenshots or a short recording for visible web UI changes
- [x] Confirmed this does not touch auth, Supabase, recommendations, analytics, CI, or release behavior

Notes:

- Ran `pnpm --filter web lint`
- Ran `pnpm --filter web build`
- Ran `git diff --check`
- Verified the Vercel preview deployment is `Ready`

## Changelog impact

No manual `CHANGELOG.md` edit is required. Release Please generates release notes from PR titles and squash commits.

- [x] User-facing web change
- [ ] Developer experience or documentation change
- [ ] Internal-only change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added review call-to-action card in the feed with explore option
  * Added expandable review text with "Read more/Show less" toggle

* **Style**
  * Updated border radius values across the design system
  * Refined "Log in" button appearance
  * Removed animations from the follow section

* **Improvements**
  * Feed content now requires authentication

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/francozeta/kocteau/pull/20?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->