### PR TITLE
feat(web): preserve guest review drafts

### DIFF
--- a/apps/web/app/(auth)/onboarding/page.tsx
+++ b/apps/web/app/(auth)/onboarding/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation";
 import ProfileOnboardingFlow from "@/components/auth/profile-onboarding-flow";
+import { appendInternalNext, safeInternalPath } from "@/lib/internal-path";
 import { createPageMetadata } from "@/lib/metadata";
 import { isProfileOnboarded } from "@/lib/profile";
 import { supabaseServer } from "@/lib/supabase/server";
@@ -23,14 +24,20 @@ export const metadata = createPageMetadata({
   noIndex: true,
 });
 
-export default async function OnboardingPage() {
+export default async function OnboardingPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ next?: string }>;
+}) {
+  const params = await searchParams;
+  const nextPath = safeInternalPath(params.next);
   const supabase = await supabaseServer();
   const {
     data: { user },
   } = await supabase.auth.getUser();
 
   if (!user) {
-    redirect("/login");
+    redirect(appendInternalNext("/login", nextPath));
   }
 
   const profileQuery = await supabase
@@ -54,11 +61,11 @@ export default async function OnboardingPage() {
 
   if (isProfileOnboarded(profile)) {
     if (profile?.taste_onboarded === false) {
-      redirect("/onboarding/taste");
+      redirect(appendInternalNext("/onboarding/taste", nextPath));
     }
 
-    redirect("/");
+    redirect(nextPath ?? "/");
   }
 
-  return <ProfileOnboardingFlow initialProfile={profile ?? undefined} />;
+  return <ProfileOnboardingFlow initialProfile={profile ?? undefined} nextPath={nextPath} />;
 }

--- a/apps/web/app/(auth)/onboarding/taste/page.tsx
+++ b/apps/web/app/(auth)/onboarding/taste/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 import ReactQueryProvider from "@/app/providers/react-query-provider";
 import { TasteOnboardingForm } from "@/components/auth/taste-onboarding-form";
+import { appendInternalNext, safeInternalPath } from "@/lib/internal-path";
 import { createPageMetadata } from "@/lib/metadata";
 import { isProfileOnboarded } from "@/lib/profile";
 import { supabaseServer } from "@/lib/supabase/server";
@@ -16,14 +17,20 @@ export const metadata = createPageMetadata({
   noIndex: true,
 });
 
-export default async function TasteOnboardingPage() {
+export default async function TasteOnboardingPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ next?: string }>;
+}) {
+  const params = await searchParams;
+  const nextPath = safeInternalPath(params.next);
   const supabase = await supabaseServer();
   const {
     data: { user },
   } = await supabase.auth.getUser();
 
   if (!user) {
-    redirect("/login");
+    redirect(appendInternalNext("/login", nextPath));
   }
 
   const profileQuery = await supabase
@@ -39,11 +46,11 @@ export default async function TasteOnboardingPage() {
   const profile = profileQuery.data;
 
   if (!isProfileOnboarded(profile)) {
-    redirect("/onboarding");
+    redirect(appendInternalNext("/onboarding", nextPath));
   }
 
   if (profile?.taste_onboarded) {
-    redirect("/");
+    redirect(nextPath ?? "/");
   }
 
   const [{ data: tags }, { data: selectedTags }] = await Promise.all([
@@ -66,6 +73,7 @@ export default async function TasteOnboardingPage() {
       <TasteOnboardingForm
         tags={(tags ?? []) as PreferenceTag[]}
         initialSelectedTagIds={(selectedTags ?? []).map((tag) => tag.tag_id)}
+        nextPath={nextPath}
       />
     </ReactQueryProvider>
   );

--- a/apps/web/app/auth/callback/route.ts
+++ b/apps/web/app/auth/callback/route.ts
@@ -1,14 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { getPostAuthRedirect } from "@/lib/auth/post-auth-redirect";
+import { safeInternalPath } from "@/lib/internal-path";
 import { supabaseServer } from "@/lib/supabase/server";
-
-function safeInternalPath(value: string | null) {
-  if (!value?.startsWith("/") || value.startsWith("//")) {
-    return null;
-  }
-
-  return value;
-}
 
 export async function GET(request: NextRequest) {
   const url = new URL(request.url);
@@ -25,7 +18,9 @@ export async function GET(request: NextRequest) {
       return null;
     }
 
-    const redirectTo = explicitNext ?? (await getPostAuthRedirect(supabase, data.user.id));
+    const redirectTo = await getPostAuthRedirect(supabase, data.user.id, {
+      next: explicitNext,
+    });
     return NextResponse.redirect(new URL(redirectTo, url.origin));
   }
 
@@ -46,6 +41,10 @@ export async function GET(request: NextRequest) {
       loginUrl.searchParams.set("error_code", callbackErrorCode);
     }
 
+    if (explicitNext) {
+      loginUrl.searchParams.set("next", explicitNext);
+    }
+
     return NextResponse.redirect(loginUrl);
   }
 
@@ -60,10 +59,15 @@ export async function GET(request: NextRequest) {
 
     const loginUrl = new URL("/login", url.origin);
     loginUrl.searchParams.set("error", "auth_callback_failed");
+    if (explicitNext) {
+      loginUrl.searchParams.set("next", explicitNext);
+    }
     return NextResponse.redirect(loginUrl);
   }
 
-  const redirectTo = explicitNext ?? (await getPostAuthRedirect(supabase, data.user.id));
+  const redirectTo = await getPostAuthRedirect(supabase, data.user.id, {
+    next: explicitNext,
+  });
 
   return NextResponse.redirect(new URL(redirectTo, url.origin));
 }

--- a/apps/web/components/app-sidebar.tsx
+++ b/apps/web/components/app-sidebar.tsx
@@ -140,7 +140,6 @@ export default function AppSidebar({
 
   const canShowOwnedReviews = Boolean(profile) && sidebarReviews.length > 0;
   const reviewEntryLabel = profile ? "New review" : "Find a track";
-  const reviewEntryIntent = profile ? "review" : "search";
 
   return (
     <TooltipProvider delayDuration={80}>
@@ -163,7 +162,7 @@ export default function AppSidebar({
           <div className="group-data-[collapsible=icon]:hidden">
             <NewReviewDialog
               isAuthenticated={Boolean(profile)}
-              intent={reviewEntryIntent}
+              intent="review"
               trigger={
                 <button
                   type="button"
@@ -184,7 +183,7 @@ export default function AppSidebar({
           <div className="hidden group-data-[collapsible=icon]:block">
             <NewReviewDialog
               isAuthenticated={Boolean(profile)}
-              intent={reviewEntryIntent}
+              intent="review"
               trigger={
                 <button
                   type="button"

--- a/apps/web/components/app-sidebar.tsx
+++ b/apps/web/components/app-sidebar.tsx
@@ -139,6 +139,8 @@ export default function AppSidebar({
     : [];
 
   const canShowOwnedReviews = Boolean(profile) && sidebarReviews.length > 0;
+  const reviewEntryLabel = profile ? "New review" : "Find a track";
+  const reviewEntryIntent = profile ? "review" : "search";
 
   return (
     <TooltipProvider delayDuration={80}>
@@ -161,6 +163,7 @@ export default function AppSidebar({
           <div className="group-data-[collapsible=icon]:hidden">
             <NewReviewDialog
               isAuthenticated={Boolean(profile)}
+              intent={reviewEntryIntent}
               trigger={
                 <button
                   type="button"
@@ -168,7 +171,7 @@ export default function AppSidebar({
                 >
                   <span className="inline-flex items-center gap-2">
                     <ReviewGlyphIcon className="size-4" />
-                    <span>New review</span>
+                    <span>{reviewEntryLabel}</span>
                   </span>
                   <Kbd className="border border-sidebar-border/80 bg-foreground/[0.06] px-1.5 text-[0.6rem] text-muted-foreground">
                     N
@@ -181,10 +184,11 @@ export default function AppSidebar({
           <div className="hidden group-data-[collapsible=icon]:block">
             <NewReviewDialog
               isAuthenticated={Boolean(profile)}
+              intent={reviewEntryIntent}
               trigger={
                 <button
                   type="button"
-                  aria-label="New review"
+                  aria-label={reviewEntryLabel}
                   className="mx-auto flex size-9 items-center justify-center rounded-[0.7rem] border border-sidebar-border/70 bg-[var(--kocteau-surface-control)] text-sidebar-foreground shadow-[inset_0_1px_0_rgba(255,255,255,0.04)] transition-[color,background-color,transform] hover:bg-[var(--kocteau-surface-control-hover)] active:scale-[0.96]"
                 >
                   <ReviewGlyphIcon className="size-4" />

--- a/apps/web/components/auth/otp-auth-page-client.tsx
+++ b/apps/web/components/auth/otp-auth-page-client.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Field, FieldError, FieldGroup, FieldLabel } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
 import { InputOTP, InputOTPGroup, InputOTPSlot } from "@/components/ui/input-otp";
+import { appendInternalNext, safeInternalPath } from "@/lib/internal-path";
 import { isProfileOnboarded } from "@/lib/profile";
 import { supabaseBrowser } from "@/lib/supabase/client";
 import { getFirstFieldError } from "@/lib/validation/errors";
@@ -27,8 +28,23 @@ type ClientPostAuthProfile = {
 const resendCooldownSeconds = 60;
 const otpLength = 6;
 
-function getEmailRedirectTo() {
-  return `${window.location.origin}/auth/callback`;
+function getRequestedNextPath() {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  return safeInternalPath(new URLSearchParams(window.location.search).get("next"));
+}
+
+function getEmailRedirectTo(nextPath?: string | null) {
+  const callbackUrl = new URL("/auth/callback", window.location.origin);
+  const safeNextPath = safeInternalPath(nextPath);
+
+  if (safeNextPath) {
+    callbackUrl.searchParams.set("next", safeNextPath);
+  }
+
+  return callbackUrl.toString();
 }
 
 const copyByMode: Record<
@@ -80,6 +96,15 @@ export default function OtpAuthPageClient({ mode }: OtpAuthPageClientProps) {
   const [verifying, setVerifying] = useState(false);
   const [redirecting, setRedirecting] = useState(false);
   const [resendIn, setResendIn] = useState(0);
+  const [requestedNextPath, setRequestedNextPath] = useState<string | null>(null);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      setRequestedNextPath(getRequestedNextPath());
+    }, 0);
+
+    return () => window.clearTimeout(timer);
+  }, []);
 
   useEffect(() => {
     if (resendIn <= 0) {
@@ -98,6 +123,7 @@ export default function OtpAuthPageClient({ mode }: OtpAuthPageClientProps) {
     const hash = new URLSearchParams(window.location.hash.replace(/^#/, ""));
     const errorCode = query.get("error_code") ?? hash.get("error_code");
     const hasAuthError = Boolean(errorCode || query.get("error") || hash.get("error"));
+    const nextPath = safeInternalPath(query.get("next"));
 
     if (!hasAuthError) {
       return;
@@ -111,7 +137,19 @@ export default function OtpAuthPageClient({ mode }: OtpAuthPageClientProps) {
           : "We could not open that link. Enter the latest code.",
       );
     }, 0);
-    window.history.replaceState(null, "", window.location.pathname);
+    const cleanSearch = new URLSearchParams();
+
+    if (nextPath) {
+      cleanSearch.set("next", nextPath);
+    }
+
+    window.history.replaceState(
+      null,
+      "",
+      cleanSearch.toString()
+        ? `${window.location.pathname}?${cleanSearch.toString()}`
+        : window.location.pathname,
+    );
 
     return () => window.clearTimeout(timer);
   }, []);
@@ -130,6 +168,7 @@ export default function OtpAuthPageClient({ mode }: OtpAuthPageClientProps) {
 
   const getPostAuthRedirect = useCallback(async () => {
     const { data: auth } = await supabase.auth.getUser();
+    const nextPath = getRequestedNextPath();
 
     if (!auth.user) {
       return null;
@@ -155,14 +194,14 @@ export default function OtpAuthPageClient({ mode }: OtpAuthPageClientProps) {
       : profileQuery.data;
 
     if (!isProfileOnboarded(profile)) {
-      return "/onboarding";
+      return appendInternalNext("/onboarding", nextPath);
     }
 
     if (profile?.taste_onboarded === false) {
-      return "/onboarding/taste";
+      return appendInternalNext("/onboarding/taste", nextPath);
     }
 
-    return "/";
+    return nextPath ?? "/";
   }, [supabase]);
 
   const redirectAfterAuth = useCallback(async (options?: { retry?: boolean }) => {
@@ -209,7 +248,7 @@ export default function OtpAuthPageClient({ mode }: OtpAuthPageClientProps) {
     const { error } = await supabase.auth.signInWithOtp({
       email: parsed.data.email,
       options: {
-        emailRedirectTo: getEmailRedirectTo(),
+        emailRedirectTo: getEmailRedirectTo(getRequestedNextPath()),
         shouldCreateUser: true,
       },
     });
@@ -302,7 +341,11 @@ export default function OtpAuthPageClient({ mode }: OtpAuthPageClientProps) {
       title={shellTitle}
       description={shellDescription}
       alternateLabel={step === "email" ? copy.alternateLabel : undefined}
-      alternateHref={step === "email" ? copy.alternateHref : undefined}
+      alternateHref={
+        step === "email"
+          ? appendInternalNext(copy.alternateHref, requestedNextPath)
+          : undefined
+      }
       alternateCta={step === "email" ? copy.alternateCta : undefined}
       footer={
         <span className="inline-flex items-center gap-1">

--- a/apps/web/components/auth/profile-onboarding-flow.tsx
+++ b/apps/web/components/auth/profile-onboarding-flow.tsx
@@ -22,6 +22,7 @@ import {
   createAvatarPresetSvg,
   type AvatarPresetId,
 } from "@/lib/avatar-presets";
+import { appendInternalNext } from "@/lib/internal-path";
 import { supabaseBrowser } from "@/lib/supabase/client";
 import { getFirstFieldError } from "@/lib/validation/errors";
 import { profileEditorSchema } from "@/lib/validation/schemas";
@@ -127,8 +128,10 @@ function getProfileStepError({
 
 export default function ProfileOnboardingFlow({
   initialProfile,
+  nextPath = null,
 }: {
   initialProfile?: Partial<ProfileDraft>;
+  nextPath?: string | null;
 }) {
   const router = useRouter();
   const supabase = supabaseBrowser();
@@ -356,7 +359,7 @@ export default function ProfileOnboardingFlow({
     if (authError || !user) {
       setMessage("You are not signed in. Please log in again.");
       setSaving(false);
-      router.replace("/login");
+      router.replace(appendInternalNext("/login", nextPath));
       return;
     }
 
@@ -390,7 +393,7 @@ export default function ProfileOnboardingFlow({
 
       startTransition(() => {
         router.refresh();
-        router.replace("/onboarding/taste");
+        router.replace(appendInternalNext("/onboarding/taste", nextPath));
       });
     } catch (error) {
       const profileError = error as Error & { code?: string };

--- a/apps/web/components/auth/taste-onboarding-form.tsx
+++ b/apps/web/components/auth/taste-onboarding-form.tsx
@@ -17,6 +17,7 @@ import { cn } from "@/lib/utils";
 type TasteOnboardingFormProps = {
   tags: PreferenceTag[];
   initialSelectedTagIds?: string[];
+  nextPath?: string | null;
 };
 
 type SaveTasteResponse = {
@@ -42,6 +43,7 @@ const tasteSteps = [
 export function TasteOnboardingForm({
   tags,
   initialSelectedTagIds = [],
+  nextPath = null,
 }: TasteOnboardingFormProps) {
   const router = useRouter();
   const visibleTagIds = useMemo(() => new Set(tags.map((tag) => tag.id)), [tags]);
@@ -52,7 +54,7 @@ export function TasteOnboardingForm({
   );
   const [error, setError] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
-  const [redirectTo, setRedirectTo] = useState("/?welcome=kocteau");
+  const [redirectTo, setRedirectTo] = useState(nextPath ?? "/?welcome=kocteau");
   const currentStep = tasteSteps[currentStepIndex];
   const selectedCount = selectedIds.size;
   const missingCount = Math.max(tasteOnboardingMinTags - selectedCount, 0);
@@ -114,7 +116,7 @@ export function TasteOnboardingForm({
         throw new Error(data.error || "We could not save your taste profile.");
       }
 
-      setRedirectTo(data.redirectTo || "/?welcome=kocteau");
+      setRedirectTo(nextPath ?? data.redirectTo ?? "/?welcome=kocteau");
       setCurrentStepIndex(1);
     } catch (submitError) {
       setError(

--- a/apps/web/components/feed-review-cta.tsx
+++ b/apps/web/components/feed-review-cta.tsx
@@ -23,13 +23,17 @@ export default function FeedReviewCta({
   isAuthenticated,
   className,
 }: FeedReviewCtaProps) {
+  const primaryLabel = isAuthenticated ? "Review a track" : "Find a track";
+  const helper = isAuthenticated
+    ? "Search a track and leave a signal for your feed."
+    : "Browse freely. Log in only when you publish.";
   const trigger = (
     <button
       type="button"
       className="inline-flex h-9 min-w-0 items-center justify-center gap-2 rounded-[0.56rem] bg-foreground px-3.5 text-[13px] font-medium text-background transition-[background-color,transform] duration-150 ease-[var(--kocteau-ease)] hover:bg-foreground/88 active:scale-[0.96]"
     >
       <ReviewGlyphIcon className="size-3.5 shrink-0" />
-      <span>Review a track</span>
+      <span>{primaryLabel}</span>
     </button>
   );
 
@@ -68,13 +72,14 @@ export default function FeedReviewCta({
             Find something to review.
           </h2>
           <p className="max-w-[22rem] text-pretty text-[13px] leading-5 text-muted-foreground/82 sm:text-[13.5px]">
-            Search a track and leave a signal for your feed.
+            {helper}
           </p>
         </div>
 
         <div className="flex shrink-0 items-center gap-2">
           <NewReviewDialog
             isAuthenticated={isAuthenticated}
+            intent={isAuthenticated ? "review" : "search"}
             trigger={trigger}
           />
           <Link

--- a/apps/web/components/feed-review-cta.tsx
+++ b/apps/web/components/feed-review-cta.tsx
@@ -79,7 +79,7 @@ export default function FeedReviewCta({
         <div className="flex shrink-0 items-center gap-2">
           <NewReviewDialog
             isAuthenticated={isAuthenticated}
-            intent={isAuthenticated ? "review" : "search"}
+            intent="review"
             trigger={trigger}
           />
           <Link

--- a/apps/web/components/mobile-bottom-bar.tsx
+++ b/apps/web/components/mobile-bottom-bar.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Bell, Bookmark, Home, Search, UserRound } from "lucide-react";
+import { Bell, Home, Search, UserRound } from "lucide-react";
 import NewReviewDialog from "@/components/new-review-dialog";
 import ReviewGlyphIcon from "@/components/review-glyph-icon";
 import { cn } from "@/lib/utils";
@@ -62,7 +62,7 @@ function NavTab({
 export default function MobileBottomBar({ profile }: MobileBottomBarProps) {
   const pathname = usePathname();
 
-  const leftItems: NavItem[] = [
+  const primaryItems: NavItem[] = [
     {
       href: "/",
       label: "Feed",
@@ -77,7 +77,7 @@ export default function MobileBottomBar({ profile }: MobileBottomBarProps) {
     },
   ];
 
-  const rightItems: NavItem[] = [
+  const secondaryItems: NavItem[] = [
     ...(profile
       ? [
           {
@@ -95,12 +95,6 @@ export default function MobileBottomBar({ profile }: MobileBottomBarProps) {
         ]
       : [
           {
-            href: "/saved",
-            label: "Saved",
-            icon: Bookmark,
-            active: (current: string) => current.startsWith("/saved"),
-          },
-          {
             href: "/login",
             label: "Log in",
             icon: UserRound,
@@ -109,6 +103,8 @@ export default function MobileBottomBar({ profile }: MobileBottomBarProps) {
           },
         ]),
   ];
+  const navItems = [...primaryItems, ...secondaryItems];
+  const reviewEntryLabel = profile ? "New review" : "Find a track";
 
   return (
     <nav className="fixed inset-x-0 bottom-[calc(env(safe-area-inset-bottom)+0.85rem)] z-50 px-3 md:hidden">
@@ -118,24 +114,29 @@ export default function MobileBottomBar({ profile }: MobileBottomBarProps) {
       />
 
       <div className="relative z-10 mx-auto flex w-full max-w-[24rem] justify-center">
-        <div className="mobile-liquid-bar grid w-full grid-cols-[auto_auto_auto_auto_1px_auto] items-center justify-between rounded-full p-1">
-          {leftItems.map((item) => (
-            <NavTab key={item.href} item={item} pathname={pathname} />
-          ))}
-          {rightItems.map((item) => (
+        <div
+          className={cn(
+            "mobile-liquid-bar grid w-full items-center justify-between rounded-full p-1",
+            profile
+              ? "grid-cols-[auto_auto_auto_auto_1px_auto]"
+              : "grid-cols-[auto_auto_auto_1px_auto]",
+          )}
+        >
+          {navItems.map((item) => (
             <NavTab key={item.href} item={item} pathname={pathname} />
           ))}
           <span className="mx-1 h-7 w-px shrink-0 bg-foreground/10" aria-hidden="true" />
           <NewReviewDialog
             isAuthenticated={Boolean(profile)}
+            intent={profile ? "review" : "search"}
             trigger={
               <button
                 type="button"
-                aria-label="New review"
+                aria-label={reviewEntryLabel}
                 className="flex size-10 items-center justify-center rounded-[0.9rem] border border-sidebar-border/70 bg-[var(--kocteau-surface-control)] text-foreground shadow-none transition-[transform,background-color,border-color] duration-150 ease-out hover:bg-[var(--kocteau-surface-control-hover)] active:scale-[0.96]"
               >
                 <ReviewGlyphIcon className="size-[1.05rem]" />
-                <span className="sr-only">New review</span>
+                <span className="sr-only">{reviewEntryLabel}</span>
               </button>
             }
             triggerLabelClassName="sr-only"

--- a/apps/web/components/mobile-bottom-bar.tsx
+++ b/apps/web/components/mobile-bottom-bar.tsx
@@ -133,7 +133,7 @@ export default function MobileBottomBar({ profile }: MobileBottomBarProps) {
               <button
                 type="button"
                 aria-label={reviewEntryLabel}
-                className="flex size-10 items-center justify-center rounded-[0.9rem] border border-sidebar-border/70 bg-[var(--kocteau-surface-control)] text-foreground shadow-none transition-[transform,background-color,border-color] duration-150 ease-out hover:bg-[var(--kocteau-surface-control-hover)] active:scale-[0.96]"
+                className="flex size-10 items-center justify-center rounded-full border border-sidebar-border/70 bg-[var(--kocteau-surface-control)] text-foreground shadow-none transition-[transform,background-color,border-color] duration-150 ease-out hover:bg-[var(--kocteau-surface-control-hover)] active:scale-[0.96]"
               >
                 <ReviewGlyphIcon className="size-[1.05rem]" />
                 <span className="sr-only">{reviewEntryLabel}</span>

--- a/apps/web/components/mobile-bottom-bar.tsx
+++ b/apps/web/components/mobile-bottom-bar.tsx
@@ -128,7 +128,7 @@ export default function MobileBottomBar({ profile }: MobileBottomBarProps) {
           <span className="mx-1 h-7 w-px shrink-0 bg-foreground/10" aria-hidden="true" />
           <NewReviewDialog
             isAuthenticated={Boolean(profile)}
-            intent={profile ? "review" : "search"}
+            intent="review"
             trigger={
               <button
                 type="button"

--- a/apps/web/components/new-review-dialog.tsx
+++ b/apps/web/components/new-review-dialog.tsx
@@ -1,15 +1,11 @@
 "use client";
 
 import {
-  cloneElement,
-  isValidElement,
   startTransition,
   useCallback,
   useEffect,
   useMemo,
   useState,
-  type MouseEvent as ReactMouseEvent,
-  type ReactElement,
   type ReactNode,
 } from "react";
 import dynamic from "next/dynamic";
@@ -30,7 +26,7 @@ import type { NewReviewFormProps, NewReviewFormStep } from "@/components/new-rev
 import { DialogDescription } from "@/components/ui/dialog";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { Search } from "lucide-react";
-import { toastAuthRequired } from "@/lib/feedback";
+import { readPendingReviewDraft, type StoredPendingReviewDraft } from "@/lib/pending-review-draft";
 import { cn } from "@/lib/utils";
 import ReviewGlyphIcon from "@/components/review-glyph-icon";
 
@@ -70,6 +66,7 @@ export default function NewReviewDialog({
   triggerVariant = "default",
   trigger,
   showTrigger = true,
+  listenToComposeUrl = !showTrigger,
   open: controlledOpen,
   defaultOpen = false,
   onOpenChange,
@@ -85,8 +82,9 @@ export default function NewReviewDialog({
   triggerLabel?: string;
   triggerShortcut?: ReactNode;
   triggerVariant?: NewReviewDialogTriggerVariant;
-  trigger?: React.ReactNode;
+  trigger?: ReactNode;
   showTrigger?: boolean;
+  listenToComposeUrl?: boolean;
   open?: boolean;
   defaultOpen?: boolean;
   onOpenChange?: (open: boolean) => void;
@@ -102,10 +100,10 @@ export default function NewReviewDialog({
   const searchParams = useSearchParams();
   const prefersReducedMotion = useReducedMotion();
   const isSearchIntent = intent === "search";
-  const canOpenDialog = isAuthenticated || isSearchIntent;
   const usesUrlComposeState =
-    !isSearchIntent && initialQuery === undefined && initialSelection === undefined;
+    listenToComposeUrl && !isSearchIntent && initialQuery === undefined && initialSelection === undefined;
   const shouldOpenFromUrl = usesUrlComposeState && searchParams.get("compose") === "1";
+  const shouldRestoreDraftFromUrl = shouldOpenFromUrl && searchParams.get("draft") === "review";
   const initialQueryFromUrl = useMemo(() => searchParams.get("reviewQuery")?.trim() ?? "", [searchParams]);
   const initialSelectionFromUrl = useMemo(() => {
     const provider = searchParams.get("composeProvider");
@@ -127,8 +125,13 @@ export default function NewReviewDialog({
       entity_id: null,
     } satisfies InitialSelection;
   }, [searchParams]);
+  const [restoredDraft, setRestoredDraft] = useState<StoredPendingReviewDraft | null>(null);
   const resolvedInitialQuery = initialQuery ?? initialQueryFromUrl;
-  const resolvedInitialSelection = initialSelection ?? initialSelectionFromUrl;
+  const resolvedInitialSelection =
+    initialSelection ?? initialSelectionFromUrl ?? restoredDraft?.selection ?? null;
+  const resolvedInitialRating = restoredDraft?.rating ?? null;
+  const resolvedInitialTitle = restoredDraft?.title ?? "";
+  const resolvedInitialBody = restoredDraft?.body ?? "";
   const [formStep, setFormStep] = useState<NewReviewFormStep>(
     isSearchIntent ? "search" : resolvedInitialSelection ? "compose" : "search",
   );
@@ -152,6 +155,7 @@ export default function NewReviewDialog({
     next.delete("composeArtist");
     next.delete("composeCover");
     next.delete("composeDeezer");
+    next.delete("draft");
 
     startTransition(() => {
       router.replace(next.toString() ? `${pathname}?${next.toString()}` : pathname, {
@@ -177,15 +181,14 @@ export default function NewReviewDialog({
   }
 
   useEffect(() => {
-    if (!shouldOpenFromUrl || isAuthenticated) {
-      return;
-    }
+    const timer = window.setTimeout(() => {
+      setRestoredDraft(shouldRestoreDraftFromUrl ? readPendingReviewDraft() : null);
+    }, 0);
 
-    toastAuthRequired("create-review");
-    clearComposeParams();
-  }, [clearComposeParams, isAuthenticated, shouldOpenFromUrl]);
+    return () => window.clearTimeout(timer);
+  }, [shouldRestoreDraftFromUrl]);
 
-  const resolvedOpen = canOpenDialog && (controlledOpen ?? (shouldOpenFromUrl || internalOpen));
+  const resolvedOpen = shouldOpenFromUrl || (controlledOpen ?? internalOpen);
 
   function renderStepDots() {
     return (
@@ -266,29 +269,7 @@ export default function NewReviewDialog({
     )
   );
 
-  const resolvedTrigger = !canOpenDialog && isValidElement(baseTrigger)
-    ? cloneElement(
-        baseTrigger as ReactElement<{
-          onClick?: (event: ReactMouseEvent<HTMLElement>) => void;
-        }>,
-        {
-          onClick: (event: ReactMouseEvent<HTMLElement>) => {
-            const originalOnClick = (
-              baseTrigger.props as { onClick?: (event: ReactMouseEvent<HTMLElement>) => void }
-            ).onClick;
-            originalOnClick?.(event);
-
-            if (!event.defaultPrevented) {
-              toastAuthRequired("create-review");
-            }
-          },
-        },
-      )
-    : baseTrigger;
-
-  if (!canOpenDialog) {
-    return showTrigger ? <>{resolvedTrigger}</> : null;
-  }
+  const resolvedTrigger = baseTrigger;
 
   if (isMobile) {
     return (
@@ -318,11 +299,15 @@ export default function NewReviewDialog({
             <div className="min-h-0 flex-1 overflow-hidden">
               <NewReviewForm
                 intent={intent}
+                isAuthenticated={isAuthenticated}
                 onStepChange={setFormStep}
                 showCancelAction={false}
                 primaryActionFullWidth
                 initialQuery={resolvedInitialQuery}
                 initialSelection={resolvedInitialSelection}
+                initialRating={resolvedInitialRating}
+                initialTitle={resolvedInitialTitle}
+                initialBody={resolvedInitialBody}
                 redirectToOnSuccess={redirectToOnSuccess}
                 onSearchResultOpen={() => handleOpenChange(false)}
                 onCancel={() => handleOpenChange(false)}
@@ -370,10 +355,14 @@ export default function NewReviewDialog({
           <div className="min-h-0 flex-1 overflow-hidden">
             <NewReviewForm
               intent={intent}
+              isAuthenticated={isAuthenticated}
               onStepChange={setFormStep}
               showCancelAction={false}
               initialQuery={resolvedInitialQuery}
               initialSelection={resolvedInitialSelection}
+              initialRating={resolvedInitialRating}
+              initialTitle={resolvedInitialTitle}
+              initialBody={resolvedInitialBody}
               redirectToOnSuccess={redirectToOnSuccess}
               onSearchResultOpen={() => handleOpenChange(false)}
               onCancel={() => handleOpenChange(false)}

--- a/apps/web/components/new-review-dialog.tsx
+++ b/apps/web/components/new-review-dialog.tsx
@@ -242,7 +242,7 @@ export default function NewReviewDialog({
       >
         <Search className="size-3.5 shrink-0 text-muted-foreground/78" />
         <span className={cn("min-w-0 flex-1 truncate text-[13px]", triggerLabelClassName)}>
-          {triggerLabel ?? "Find a track to review..."}
+          {triggerLabel ?? "Find a track to review…"}
         </span>
         {resolvedTriggerShortcut ? (
           <Kbd className="ml-auto h-5 shrink-0 rounded-md border-transparent bg-foreground/[0.055] px-1.5 text-[0.6rem] text-muted-foreground/90">

--- a/apps/web/components/new-review-form.tsx
+++ b/apps/web/components/new-review-form.tsx
@@ -423,7 +423,7 @@ export default function NewReviewForm({
           reviewError.message ||
             (isEditMode
               ? "We couldn't update this review right now."
-              : "Ocurrió un error al crear la reseña. Intenta nuevamente."),
+              : "We couldn't publish this review right now."),
         );
       }
     } finally {
@@ -475,7 +475,7 @@ export default function NewReviewForm({
                 setFieldErrors((current) => ({ ...current, selected: undefined }));
               }}
               onKeyDown={handleSearchKeyDown}
-              placeholder="Search tracks to review..."
+              placeholder="Search tracks to review…"
               disabled={saving}
               autoFocus
               className="h-10 shrink-0 rounded-[0.7rem] border-border/24 bg-[var(--kocteau-surface-control)] pl-10 text-[13px] shadow-[inset_0_1px_0_rgba(255,255,255,0.04)] placeholder:text-muted-foreground/72"
@@ -517,7 +517,7 @@ export default function NewReviewForm({
               {isFetching && results.length > 0 ? (
                 <div className="flex items-center gap-2 px-4 py-3 text-xs text-muted-foreground">
                   <LoaderCircle className="size-3.5 animate-spin" />
-                  Updating results...
+                  Updating results…
                 </div>
               ) : null}
 

--- a/apps/web/components/new-review-form.tsx
+++ b/apps/web/components/new-review-form.tsx
@@ -16,6 +16,12 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Textarea } from "@/components/ui/textarea";
 import { useDeezerSearch } from "@/hooks/use-deezer-search";
 import { toastActionSuccess } from "@/lib/feedback";
+import {
+  clearPendingReviewDraft,
+  getPendingReviewDraftLoginPath,
+  readPendingReviewDraft,
+  savePendingReviewDraft,
+} from "@/lib/pending-review-draft";
 import { cn } from "@/lib/utils";
 import { ApiError, createApiError, getFirstFieldError } from "@/lib/validation/errors";
 import { createReviewSchema, updateReviewSchema } from "@/lib/validation/schemas";
@@ -52,6 +58,7 @@ export type PublishReviewResponse = {
 export type NewReviewFormProps = {
   mode?: "create" | "edit";
   intent?: "review" | "search";
+  isAuthenticated?: boolean;
   reviewId?: string | null;
   onSuccess?: (payload: PublishReviewResponse) => void;
   onCancel?: () => void;
@@ -73,6 +80,7 @@ export type NewReviewFormStep = "search" | "compose";
 export default function NewReviewForm({
   mode = "create",
   intent = "review",
+  isAuthenticated = true,
   reviewId = null,
   onSuccess,
   onCancel,
@@ -315,6 +323,23 @@ export default function NewReviewForm({
       return;
     }
 
+    if (!isAuthenticated && !isEditMode) {
+      const draftSaved = savePendingReviewDraft({
+        selection: selected,
+        rating,
+        title,
+        body,
+      });
+
+      if (!draftSaved) {
+        setErrorMsg("We couldn't keep this draft. Please copy it before logging in.");
+        return;
+      }
+
+      window.location.assign(getPendingReviewDraftLoginPath());
+      return;
+    }
+
     const optimisticSnapshot =
       isEditMode && reviewId ? getReviewCacheSnapshot(queryClient) : null;
 
@@ -360,6 +385,16 @@ export default function NewReviewForm({
         selected?.entity_id !== payload.entityId;
 
       toastActionSuccess(isEditMode ? "Review updated." : "Review published.");
+      if (!isEditMode) {
+        const pendingDraft = readPendingReviewDraft();
+
+        if (
+          pendingDraft?.selection.provider === selected.provider &&
+          pendingDraft.selection.provider_id === selected.provider_id
+        ) {
+          clearPendingReviewDraft();
+        }
+      }
       void queryClient.invalidateQueries({ queryKey: feedKeys.all });
       onSuccess?.(payload);
       resetAll();

--- a/apps/web/components/search-page-client.tsx
+++ b/apps/web/components/search-page-client.tsx
@@ -132,18 +132,36 @@ function SearchTypeTabs({
   activeType: SearchEntityType;
   query: string;
 }) {
-  return (
-    <div className="kocteau-feed-tabs mobile-liquid-panel relative grid min-w-0 grid-cols-3 gap-0.5 overflow-hidden rounded-[var(--kocteau-radius-control)] p-0.5 max-lg:w-full lg:w-[17.25rem]">
-      <span
-        aria-hidden="true"
-        className="pointer-events-none absolute left-1/3 top-1/2 h-5 w-px -translate-x-1/2 -translate-y-1/2 rounded-full bg-border/42"
-      />
-      <span
-        aria-hidden="true"
-        className="pointer-events-none absolute left-2/3 top-1/2 h-5 w-px -translate-x-1/2 -translate-y-1/2 rounded-full bg-border/42"
-      />
+  const visibleTabs = searchEntityTabs.filter((tab) => tab.enabled);
 
-      {searchEntityTabs.map((tab) => {
+  if (visibleTabs.length <= 1) {
+    return null;
+  }
+
+  const isThreeColumn = visibleTabs.length >= 3;
+
+  return (
+    <div
+      className={cn(
+        "kocteau-feed-tabs mobile-liquid-panel relative grid min-w-0 gap-0.5 overflow-hidden rounded-[var(--kocteau-radius-control)] p-0.5 max-lg:w-full lg:w-[17.25rem]",
+        isThreeColumn ? "grid-cols-3" : "grid-cols-2",
+      )}
+    >
+      <span
+        aria-hidden="true"
+        className={cn(
+          "pointer-events-none absolute top-1/2 h-5 w-px -translate-x-1/2 -translate-y-1/2 rounded-full bg-border/42",
+          isThreeColumn ? "left-1/3" : "left-1/2",
+        )}
+      />
+      {isThreeColumn ? (
+        <span
+          aria-hidden="true"
+          className="pointer-events-none absolute left-2/3 top-1/2 h-5 w-px -translate-x-1/2 -translate-y-1/2 rounded-full bg-border/42"
+        />
+      ) : null}
+
+      {visibleTabs.map((tab) => {
         const isActive = activeType === tab.value;
         const className = cn(
           "relative z-10 inline-flex h-8 min-w-0 items-center justify-center rounded-[0.62rem] px-2 text-[13px] font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/70 focus-visible:ring-offset-0",
@@ -393,7 +411,7 @@ export default function SearchPageClient({
           {error ? <p className="mt-3 text-sm text-destructive">{error.message}</p> : null}
 
           {!hasQuery ? (
-            <section className="overflow-hidden rounded-[1rem] border border-border/24 bg-[var(--kocteau-surface)] shadow-none">
+            <section className="overflow-hidden rounded-[var(--kocteau-radius-card)] border border-border/24 bg-[var(--kocteau-surface)] shadow-none">
               <div className="divide-y divide-border/16">
                 {recentSearches.length > 0 ? (
                   <div>
@@ -442,11 +460,11 @@ export default function SearchPageClient({
           {hasQuery ? (
             <section className="space-y-3">
               {showSkeletonResults ? (
-                <div className="overflow-hidden rounded-[1rem] border border-border/24 bg-[var(--kocteau-surface)] shadow-[inset_0_1px_0_rgba(255,255,255,0.035)]">
+                <div className="overflow-hidden rounded-[var(--kocteau-radius-card)] border border-border/24 bg-[var(--kocteau-surface)] shadow-[inset_0_1px_0_rgba(255,255,255,0.035)]">
                   <div className="space-y-0 divide-y divide-border/16">
                     {Array.from({ length: 5 }).map((_, index) => (
                       <div key={index} className="flex items-center gap-3 px-3 py-3">
-                        <Skeleton className="size-14 rounded-[0.75rem] bg-foreground/[0.07]" />
+                        <Skeleton className="size-14 rounded-[0.68rem] bg-foreground/[0.07]" />
                         <div className="min-w-0 flex-1 space-y-2">
                           <Skeleton className="h-3 w-16 bg-foreground/[0.055]" />
                           <Skeleton className="h-4 w-2/5 bg-foreground/[0.075]" />
@@ -459,7 +477,7 @@ export default function SearchPageClient({
               ) : null}
 
               {!showSkeletonResults && normalizedQuery.length > 0 && normalizedQuery.length < 2 ? (
-                <Empty className="rounded-[1rem] border-border/24 bg-[var(--kocteau-surface)] px-6 py-9 shadow-[inset_0_1px_0_rgba(255,255,255,0.035)]">
+                <Empty className="rounded-[var(--kocteau-radius-card)] border-border/24 bg-[var(--kocteau-surface)] px-6 py-9 shadow-[inset_0_1px_0_rgba(255,255,255,0.035)]">
                   <EmptyHeader>
                     <EmptyMedia variant="icon">
                       <Search className="size-4" />
@@ -473,7 +491,7 @@ export default function SearchPageClient({
               ) : null}
 
               {!showSkeletonResults && normalizedQuery.length >= 2 && results.length === 0 ? (
-                <Empty className="rounded-[1rem] border-border/24 bg-[var(--kocteau-surface)] px-6 py-9 shadow-[inset_0_1px_0_rgba(255,255,255,0.035)]">
+                <Empty className="rounded-[var(--kocteau-radius-card)] border-border/24 bg-[var(--kocteau-surface)] px-6 py-9 shadow-[inset_0_1px_0_rgba(255,255,255,0.035)]">
                   <EmptyHeader>
                     <EmptyMedia variant="icon">
                       <Search className="size-4" />
@@ -487,7 +505,7 @@ export default function SearchPageClient({
               ) : null}
 
               {results.length > 0 ? (
-                <div className="overflow-hidden rounded-[1rem] border border-border/24 bg-[var(--kocteau-surface)] shadow-[inset_0_1px_0_rgba(255,255,255,0.035)]">
+                <div className="overflow-hidden rounded-[var(--kocteau-radius-card)] border border-border/24 bg-[var(--kocteau-surface)] shadow-[inset_0_1px_0_rgba(255,255,255,0.035)]">
                   <div className="flex items-center justify-between gap-3 border-b border-border/18 px-4 py-2.5">
                     <SearchSectionLabel>{resultCountLabel ?? "Matches"}</SearchSectionLabel>
                     <div className="hidden items-center gap-1.5 text-[11px] text-muted-foreground/64 sm:flex">
@@ -542,7 +560,7 @@ export default function SearchPageClient({
                               sizes="56px"
                               quality={78}
                               variant="card"
-                              className="size-14 shrink-0 rounded-[0.75rem] bg-muted/50 shadow-[0_0_0_1px_rgba(255,255,255,0.055)]"
+                              className="size-14 shrink-0 rounded-[0.68rem] bg-muted/50 shadow-[0_0_0_1px_rgba(255,255,255,0.055)]"
                               iconClassName="size-5"
                             />
 
@@ -586,7 +604,7 @@ export default function SearchPageClient({
                       <PrefetchLink
                         href={`/track/${track.entityId}`}
                         queryWarmup={{ kind: "track", id: track.entityId }}
-                        className="block overflow-hidden rounded-[1rem] border border-border/22 bg-[var(--kocteau-surface)] p-2 shadow-[inset_0_1px_0_rgba(255,255,255,0.035)] hover:bg-[var(--kocteau-surface-raised)]"
+                        className="block overflow-hidden rounded-[var(--kocteau-radius-card)] border border-border/22 bg-[var(--kocteau-surface)] p-2 shadow-[inset_0_1px_0_rgba(255,255,255,0.035)] hover:bg-[var(--kocteau-surface-raised)]"
                       >
                         <div className="space-y-2.5">
                           <EntityCoverImage
@@ -595,7 +613,7 @@ export default function SearchPageClient({
                             sizes="(max-width: 639px) 46vw, (max-width: 1023px) 30vw, 220px"
                             quality={82}
                             variant="card"
-                            className="aspect-square w-full rounded-[0.8rem] bg-muted/50 shadow-[0_0_0_1px_rgba(255,255,255,0.055)]"
+                            className="aspect-square w-full rounded-[0.68rem] bg-muted/50 shadow-[0_0_0_1px_rgba(255,255,255,0.055)]"
                             iconClassName="size-6"
                           />
 
@@ -617,7 +635,7 @@ export default function SearchPageClient({
                   ))}
                 </div>
               ) : (
-                <Empty className="rounded-[1rem] border-border/24 bg-[var(--kocteau-surface)] px-6 py-9 shadow-[inset_0_1px_0_rgba(255,255,255,0.035)]">
+                <Empty className="rounded-[var(--kocteau-radius-card)] border-border/24 bg-[var(--kocteau-surface)] px-6 py-9 shadow-[inset_0_1px_0_rgba(255,255,255,0.035)]">
                   <EmptyHeader>
                     <EmptyMedia variant="icon">
                       <Music2 className="size-4" />

--- a/apps/web/components/who-to-follow-rail.tsx
+++ b/apps/web/components/who-to-follow-rail.tsx
@@ -41,10 +41,10 @@ export default function WhoToFollowRail({
   const profiles = data?.profiles ?? [];
 
   return (
-    <aside className="hidden lg:block" aria-label="Fresh voices">
+    <aside className="hidden lg:block" aria-label="Writers to notice">
       <div className="sticky top-1 space-y-3 pt-1">
         <p className="px-1 text-[12px] font-medium leading-none text-muted-foreground/70">
-          Fresh voices
+          Writers to notice
         </p>
 
         {isLoading ? (
@@ -79,7 +79,7 @@ export default function WhoToFollowRail({
                             {primaryLabel}
                           </p>
                           <p className="truncate text-[12px] text-muted-foreground/78">
-                            @{profile.username}
+                            Reviewing lately
                           </p>
                         </div>
                       </div>
@@ -101,7 +101,7 @@ export default function WhoToFollowRail({
           </div>
         ) : (
           <div className="border-t border-border/28 px-1 py-3 text-[13px] text-muted-foreground/78">
-            No fresh voices yet.
+            No writers to notice yet.
           </div>
         )}
       </div>

--- a/apps/web/lib/auth/post-auth-redirect.ts
+++ b/apps/web/lib/auth/post-auth-redirect.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import type { SupabaseClient } from "@supabase/supabase-js";
+import { appendInternalNext, safeInternalPath } from "@/lib/internal-path";
 import { isProfileOnboarded } from "@/lib/profile";
 import type { Database } from "@/lib/supabase/database.types";
 
@@ -13,7 +14,11 @@ export type PostAuthProfile = {
 export async function getPostAuthRedirect(
   supabase: SupabaseClient<Database>,
   userId: string,
+  options?: {
+    next?: string | null;
+  },
 ) {
+  const nextPath = safeInternalPath(options?.next);
   const profileQuery = await supabase
     .from("profiles")
     .select("username, onboarded, taste_onboarded")
@@ -38,12 +43,12 @@ export async function getPostAuthRedirect(
     !needsOnboarding && profile?.taste_onboarded === false;
 
   if (needsOnboarding) {
-    return "/onboarding";
+    return appendInternalNext("/onboarding", nextPath);
   }
 
   if (needsTasteOnboarding) {
-    return "/onboarding/taste";
+    return appendInternalNext("/onboarding/taste", nextPath);
   }
 
-  return "/";
+  return nextPath ?? "/";
 }

--- a/apps/web/lib/internal-path.ts
+++ b/apps/web/lib/internal-path.ts
@@ -1,0 +1,20 @@
+export function safeInternalPath(value: string | null | undefined) {
+  if (!value?.startsWith("/") || value.startsWith("//")) {
+    return null;
+  }
+
+  return value;
+}
+
+export function appendInternalNext(path: string, nextPath: string | null | undefined) {
+  const safeNextPath = safeInternalPath(nextPath);
+
+  if (!safeNextPath) {
+    return path;
+  }
+
+  const url = new URL(path, "https://kocteau.local");
+  url.searchParams.set("next", safeNextPath);
+
+  return `${url.pathname}${url.search}${url.hash}`;
+}

--- a/apps/web/lib/pending-review-draft.test.ts
+++ b/apps/web/lib/pending-review-draft.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  clearPendingReviewDraft,
+  getPendingReviewDraftLoginPath,
+  getPendingReviewDraftReturnPath,
+  readPendingReviewDraft,
+  savePendingReviewDraft,
+  type PendingReviewDraft,
+} from "@/lib/pending-review-draft";
+
+class MemoryStorage implements Storage {
+  private values = new Map<string, string>();
+
+  get length() {
+    return this.values.size;
+  }
+
+  clear() {
+    this.values.clear();
+  }
+
+  getItem(key: string) {
+    return this.values.get(key) ?? null;
+  }
+
+  key(index: number) {
+    return Array.from(this.values.keys())[index] ?? null;
+  }
+
+  removeItem(key: string) {
+    this.values.delete(key);
+  }
+
+  setItem(key: string, value: string) {
+    this.values.set(key, value);
+  }
+}
+
+const draft = {
+  selection: {
+    provider: "deezer",
+    provider_id: "123",
+    type: "track",
+    title: "Sea, Swallow Me",
+    artist_name: "Cocteau Twins",
+    cover_url: "https://example.com/cover.jpg",
+    deezer_url: "https://deezer.page/track/123",
+    entity_id: null,
+  },
+  rating: 4.5,
+  title: "Drowning in softness",
+  body: "Everything feels weightless here.",
+} satisfies PendingReviewDraft;
+
+test("pending review draft can be saved, read, and cleared", () => {
+  const storage = new MemoryStorage();
+
+  savePendingReviewDraft(draft, storage);
+
+  assert.deepEqual(readPendingReviewDraft(storage), {
+    ...draft,
+    createdAt: readPendingReviewDraft(storage)?.createdAt,
+    version: 1,
+  });
+
+  clearPendingReviewDraft(storage);
+  assert.equal(readPendingReviewDraft(storage), null);
+});
+
+test("pending review draft ignores malformed payloads", () => {
+  const storage = new MemoryStorage();
+
+  storage.setItem("kocteau:pending-review-draft", "{");
+
+  assert.equal(readPendingReviewDraft(storage), null);
+});
+
+test("pending review draft routes back to the composer through login", () => {
+  assert.equal(getPendingReviewDraftReturnPath(), "/?compose=1&draft=review");
+  assert.equal(
+    getPendingReviewDraftLoginPath(),
+    "/login?next=%2F%3Fcompose%3D1%26draft%3Dreview",
+  );
+});

--- a/apps/web/lib/pending-review-draft.ts
+++ b/apps/web/lib/pending-review-draft.ts
@@ -1,0 +1,150 @@
+export type PendingReviewDraftSelection = {
+  provider: "deezer";
+  provider_id: string;
+  type: "track";
+  title: string;
+  artist_name: string | null;
+  cover_url: string | null;
+  deezer_url: string | null;
+  entity_id?: string | null;
+};
+
+export type PendingReviewDraft = {
+  selection: PendingReviewDraftSelection;
+  rating: number | null;
+  title: string;
+  body: string;
+};
+
+export type StoredPendingReviewDraft = PendingReviewDraft & {
+  version: 1;
+  createdAt: number;
+};
+
+export const pendingReviewDraftStorageKey = "kocteau:pending-review-draft";
+
+export function getPendingReviewDraftReturnPath() {
+  return "/?compose=1&draft=review";
+}
+
+export function getPendingReviewDraftLoginPath() {
+  const params = new URLSearchParams({
+    next: getPendingReviewDraftReturnPath(),
+  });
+
+  return `/login?${params.toString()}`;
+}
+
+function getBrowserStorage(storage?: Storage) {
+  if (storage) {
+    return storage;
+  }
+
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  return window.localStorage;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function normalizeNullableString(value: unknown) {
+  return typeof value === "string" ? value : null;
+}
+
+function normalizeStoredDraft(value: unknown): StoredPendingReviewDraft | null {
+  if (!isRecord(value) || value.version !== 1) {
+    return null;
+  }
+
+  const selection = value.selection;
+
+  if (!isRecord(selection)) {
+    return null;
+  }
+
+  if (
+    selection.provider !== "deezer" ||
+    selection.type !== "track" ||
+    typeof selection.provider_id !== "string" ||
+    typeof selection.title !== "string"
+  ) {
+    return null;
+  }
+
+  const rating =
+    typeof value.rating === "number" && Number.isFinite(value.rating)
+      ? value.rating
+      : null;
+
+  return {
+    version: 1,
+    createdAt: typeof value.createdAt === "number" ? value.createdAt : Date.now(),
+    selection: {
+      provider: "deezer",
+      provider_id: selection.provider_id,
+      type: "track",
+      title: selection.title,
+      artist_name: normalizeNullableString(selection.artist_name),
+      cover_url: normalizeNullableString(selection.cover_url),
+      deezer_url: normalizeNullableString(selection.deezer_url),
+      entity_id: normalizeNullableString(selection.entity_id),
+    },
+    rating,
+    title: typeof value.title === "string" ? value.title : "",
+    body: typeof value.body === "string" ? value.body : "",
+  };
+}
+
+export function savePendingReviewDraft(
+  draft: PendingReviewDraft,
+  storage?: Storage,
+) {
+  const targetStorage = getBrowserStorage(storage);
+
+  if (!targetStorage) {
+    return false;
+  }
+
+  const storedDraft = {
+    ...draft,
+    version: 1,
+    createdAt: Date.now(),
+  } satisfies StoredPendingReviewDraft;
+
+  targetStorage.setItem(pendingReviewDraftStorageKey, JSON.stringify(storedDraft));
+  return true;
+}
+
+export function readPendingReviewDraft(storage?: Storage) {
+  const targetStorage = getBrowserStorage(storage);
+
+  if (!targetStorage) {
+    return null;
+  }
+
+  const rawDraft = targetStorage.getItem(pendingReviewDraftStorageKey);
+
+  if (!rawDraft) {
+    return null;
+  }
+
+  try {
+    return normalizeStoredDraft(JSON.parse(rawDraft));
+  } catch {
+    return null;
+  }
+}
+
+export function clearPendingReviewDraft(storage?: Storage) {
+  const targetStorage = getBrowserStorage(storage);
+
+  if (!targetStorage) {
+    return;
+  }
+
+  targetStorage.removeItem(pendingReviewDraftStorageKey);
+}


### PR DESCRIPTION
## What changed

Improved the guest review path and a small mobile navigation polish.

- Signed-out users can now search for a track and write a review before logging in.
- When they try to publish, Kocteau saves the review draft locally and sends them through login/onboarding.
- After auth/onboarding, the composer reopens with the saved draft so the user can publish intentionally.
- Preserved `next` redirects across OTP, auth callback, profile onboarding, and taste onboarding.
- Updated guest CTAs to start the review flow instead of only opening search.
- Rounded the mobile bottom bar review action so it matches the other circular nav buttons.

## Why

This reduces friction in the first product loop. A new listener can act on review intent immediately, then authenticate only at the moment publishing requires it, without losing their draft.

## Testing

- [ ] Ran `pnpm check`
- [ ] Added screenshots or a short recording for visible web UI changes
- [ ] Confirmed this does not touch auth, Supabase, recommendations, analytics, CI, or release behavior

Notes:

- Ran `pnpm --filter web lint`
- Ran `pnpm --filter web build`
- Ran pending review draft tests with `tsx`
- Ran `git diff --check`
- Verified local app and login-with-next route return `200`
- No screenshots added for this PR.
- Auth redirect/onboarding return flow was touched, but Supabase/RLS behavior was not changed.

## Changelog impact

No manual `CHANGELOG.md` edit is required. Release Please generates release notes from PR titles and squash commits.

- [x] User-facing web change
- [ ] Developer experience or documentation change
- [ ] Internal-only change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Review drafts are now automatically saved when you start composing without being logged in, allowing you to complete them after signing in.
  * Authentication now preserves your destination, redirecting you back to where you came from after logging in.

* **Improvements**
  * Navigation labels now intelligently adapt based on your authentication status.
  * Refined messaging and labels across discovery features for improved clarity.
  * UI consistency improvements for search results and component styling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/francozeta/kocteau/pull/22?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->