### PR TITLE
feat(web): polish sidebar navigation

### DIFF
--- a/apps/web/app/(main)/layout.tsx
+++ b/apps/web/app/(main)/layout.tsx
@@ -47,11 +47,7 @@ export default async function MainLayout({ children }: { children: React.ReactNo
           <RouteHeaderProvider>
             <GlobalShortcuts isAuthenticated={Boolean(safeProfile)} />
             <div className="kocteau-app-frame flex min-h-svh flex-1 flex-col lg:min-h-0 lg:h-full lg:overflow-hidden lg:rounded-[0.8rem]">
-              <Header
-                profile={safeProfile}
-                initialUnreadCount={initialUnreadCount}
-                initialNotifications={[]}
-              />
+              <Header profile={safeProfile} />
               <main className="mx-auto flex min-h-0 w-full max-w-[82rem] flex-1 flex-col px-3.5 pt-[calc(env(safe-area-inset-top)+4rem)] pb-[calc(env(safe-area-inset-bottom)+6.5rem)] sm:px-6 sm:pt-[calc(env(safe-area-inset-top)+4.75rem)] sm:pb-28 lg:max-w-none lg:overflow-y-auto lg:px-7 lg:pt-3 lg:pb-6 xl:px-8">
                 {children}
               </main>

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -275,6 +275,80 @@
     box-shadow: none;
   }
 
+  .kocteau-sidebar-label,
+  .kocteau-sidebar-shortcut,
+  .kocteau-sidebar-avatar,
+  .kocteau-sidebar-trailing {
+    overflow: hidden;
+    transform-origin: left center;
+    transition-duration: 180ms;
+    transition-property: max-width, opacity, transform, filter, margin;
+    transition-timing-function: var(--kocteau-ease);
+  }
+
+  .kocteau-sidebar-label {
+    display: inline-block;
+    max-width: 11rem;
+    white-space: nowrap;
+  }
+
+  .kocteau-sidebar-shortcut,
+  .kocteau-sidebar-trailing {
+    display: inline-flex;
+    max-width: 3rem;
+  }
+
+  .kocteau-sidebar-avatar {
+    display: inline-flex;
+    max-width: 2rem;
+    transition-duration: 120ms, 160ms, 160ms, 180ms, 180ms;
+    transition-property: opacity, transform, filter, max-width, margin;
+    transition-delay: 0ms, 0ms, 0ms, 60ms, 60ms;
+  }
+
+  .kocteau-sidebar-expand-only {
+    max-height: 24rem;
+    transform-origin: top left;
+    transition-duration: 180ms;
+    transition-property: max-height, opacity, transform, filter, margin, padding;
+    transition-timing-function: var(--kocteau-ease);
+  }
+
+  [data-collapsible="icon"] .kocteau-sidebar-label,
+  [data-collapsible="icon"] .kocteau-sidebar-shortcut,
+  [data-collapsible="icon"] .kocteau-sidebar-avatar,
+  [data-collapsible="icon"] .kocteau-sidebar-trailing {
+    max-width: 0;
+    opacity: 0;
+    transform: translateX(-0.25rem) scale(0.98);
+    filter: blur(5px);
+    pointer-events: none;
+  }
+
+  [data-collapsible="icon"] .kocteau-sidebar-shortcut,
+  [data-collapsible="icon"] .kocteau-sidebar-avatar,
+  [data-collapsible="icon"] .kocteau-sidebar-trailing {
+    margin-left: 0;
+    transform: translateX(-0.125rem) scale(0.86);
+  }
+
+  [data-collapsible="icon"] .kocteau-sidebar-avatar {
+    filter: blur(7px);
+    transition-delay: 0ms;
+  }
+
+  [data-collapsible="icon"] .kocteau-sidebar-expand-only {
+    max-height: 0;
+    margin-top: 0;
+    margin-bottom: 0;
+    padding-top: 0;
+    padding-bottom: 0;
+    opacity: 0;
+    transform: translateY(-0.25rem);
+    filter: blur(5px);
+    pointer-events: none;
+  }
+
   .kocteau-review-card {
     border: 1px solid var(--kocteau-line-soft);
     background: var(--kocteau-surface-raised);
@@ -545,6 +619,15 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .kocteau-sidebar-label,
+  .kocteau-sidebar-shortcut,
+  .kocteau-sidebar-trailing,
+  .kocteau-sidebar-expand-only {
+    transition-duration: 1ms;
+    filter: none !important;
+    transform: none !important;
+  }
+
   .kocteau-review-glow {
     animation: none;
     opacity: 0.24;

--- a/apps/web/components/app-sidebar.tsx
+++ b/apps/web/components/app-sidebar.tsx
@@ -3,7 +3,13 @@
 import { useCallback, useEffect, useRef } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { usePathname } from "next/navigation";
-import { Bell, Bookmark, Compass, MessageSquare, Search } from "lucide-react";
+import {
+  BellSimpleIcon,
+  BookmarkSimpleIcon,
+  ChatCircleTextIcon,
+  HouseIcon,
+  MagnifyingGlassIcon,
+} from "@phosphor-icons/react";
 import BrandLogo from "@/components/brand-logo";
 import NewReviewDialog from "@/components/new-review-dialog";
 import { NavOwnedReviews } from "@/components/nav-owned-reviews";
@@ -103,19 +109,19 @@ export default function AppSidebar({
     {
       title: "Feed",
       url: "/",
-      icon: Compass,
+      icon: HouseIcon,
       isActive: pathname === "/",
     },
     {
       title: "Explore",
       url: "/search",
-      icon: Search,
+      icon: MagnifyingGlassIcon,
       isActive: pathname.startsWith("/search") || pathname.startsWith("/track"),
     },
     {
       title: "Feedback",
       url: FEEDBACK_URL,
-      icon: MessageSquare,
+      icon: ChatCircleTextIcon,
       external: true,
     },
   ];
@@ -125,13 +131,13 @@ export default function AppSidebar({
         {
           title: "Saved",
           url: "/saved",
-          icon: Bookmark,
+          icon: BookmarkSimpleIcon,
           isActive: pathname.startsWith("/saved"),
         },
         {
           title: "Activity",
           url: "/notifications",
-          icon: Bell,
+          icon: BellSimpleIcon,
           isActive: pathname.startsWith("/notifications"),
           badge: unreadCount,
         },
@@ -154,47 +160,32 @@ export default function AppSidebar({
             href="/"
             onClick={closeMobileSidebar}
             queryWarmup={{ kind: "feed" }}
-            className="flex h-10 items-center justify-start rounded-xl px-2 transition-colors hover:bg-sidebar-accent/70 group-data-[collapsible=icon]:mx-auto group-data-[collapsible=icon]:size-9 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0"
+            className="flex h-10 items-center justify-start rounded-xl px-2 transition-[background-color,transform,padding,width,height] duration-[180ms] ease-[var(--kocteau-ease)] hover:bg-sidebar-accent/70 active:scale-[0.96] group-data-[collapsible=icon]:mx-auto group-data-[collapsible=icon]:size-9 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0"
           >
             <BrandLogo priority iconClassName="h-5 w-5" />
           </PrefetchLink>
 
-          <div className="group-data-[collapsible=icon]:hidden">
-            <NewReviewDialog
-              isAuthenticated={Boolean(profile)}
-              intent="review"
-              trigger={
-                <button
-                  type="button"
-                  className="flex h-9 w-full items-center justify-between rounded-[0.7rem] border border-sidebar-border/70 bg-[var(--kocteau-surface-control)] px-2.5 text-[13px] font-medium text-sidebar-foreground shadow-[inset_0_1px_0_rgba(255,255,255,0.04)] transition-[color,background-color,transform,box-shadow] hover:bg-[var(--kocteau-surface-control-hover)] hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.06),0_8px_24px_rgba(0,0,0,0.24)] active:scale-[0.96]"
-                >
-                  <span className="inline-flex items-center gap-2">
-                    <ReviewGlyphIcon className="size-4" />
-                    <span>{reviewEntryLabel}</span>
-                  </span>
+          <NewReviewDialog
+            isAuthenticated={Boolean(profile)}
+            intent="review"
+            trigger={
+              <button
+                type="button"
+                aria-label={reviewEntryLabel}
+                className="flex h-9 w-full items-center justify-between overflow-hidden rounded-[0.7rem] border border-sidebar-border/70 bg-[var(--kocteau-surface-control)] px-2.5 text-[13px] font-medium text-sidebar-foreground shadow-[inset_0_1px_0_rgba(255,255,255,0.04)] transition-[width,height,padding,gap,color,background-color,transform,box-shadow] duration-[180ms] ease-[var(--kocteau-ease)] hover:bg-[var(--kocteau-surface-control-hover)] hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.06),0_8px_24px_rgba(0,0,0,0.24)] active:scale-[0.96] group-data-[collapsible=icon]:mx-auto group-data-[collapsible=icon]:size-9 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:gap-0 group-data-[collapsible=icon]:px-0"
+              >
+                <span className="inline-flex min-w-0 items-center gap-2 transition-[gap] duration-[180ms] ease-[var(--kocteau-ease)] group-data-[collapsible=icon]:gap-0">
+                  <ReviewGlyphIcon className="size-4 shrink-0" />
+                  <span className="kocteau-sidebar-label">{reviewEntryLabel}</span>
+                </span>
+                <span className="kocteau-sidebar-shortcut ml-2">
                   <Kbd className="border border-sidebar-border/80 bg-foreground/[0.06] px-1.5 text-[0.6rem] text-muted-foreground">
                     N
                   </Kbd>
-                </button>
-              }
-            />
-          </div>
-
-          <div className="hidden group-data-[collapsible=icon]:block">
-            <NewReviewDialog
-              isAuthenticated={Boolean(profile)}
-              intent="review"
-              trigger={
-                <button
-                  type="button"
-                  aria-label={reviewEntryLabel}
-                  className="mx-auto flex size-9 items-center justify-center rounded-[0.7rem] border border-sidebar-border/70 bg-[var(--kocteau-surface-control)] text-sidebar-foreground shadow-[inset_0_1px_0_rgba(255,255,255,0.04)] transition-[color,background-color,transform] hover:bg-[var(--kocteau-surface-control-hover)] active:scale-[0.96]"
-                >
-                  <ReviewGlyphIcon className="size-4" />
-                </button>
-              }
-            />
-          </div>
+                </span>
+              </button>
+            }
+          />
         </SidebarHeader>
 
         <SidebarContent className="gap-1.5 px-1 pb-2.5 group-data-[collapsible=icon]:px-0.5 group-data-[collapsible=icon]:pb-1.5">
@@ -204,7 +195,11 @@ export default function AppSidebar({
         </SidebarContent>
 
         <SidebarFooter className="px-1 pb-2.5 pt-2 group-data-[collapsible=icon]:px-0.5 group-data-[collapsible=icon]:py-1.5">
-          <NavUser profile={profile} onNavigate={closeMobileSidebar} />
+          <NavUser
+            profile={profile}
+            onNavigate={closeMobileSidebar}
+            initialUnreadCount={unreadCount}
+          />
         </SidebarFooter>
         <SidebarRail />
       </Sidebar>

--- a/apps/web/components/header-user-menu.tsx
+++ b/apps/web/components/header-user-menu.tsx
@@ -2,7 +2,14 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { AlertCircle, Bell, Bookmark, LogOut, Settings, UserRound } from "lucide-react";
+import {
+  BellSimpleIcon,
+  BookmarkSimpleIcon,
+  GearSixIcon,
+  SignOutIcon,
+  UserCircleIcon,
+  WarningCircleIcon,
+} from "@phosphor-icons/react";
 import UserAvatar from "@/components/user-avatar";
 import {
   AlertDialog,
@@ -86,24 +93,24 @@ export default function HeaderUserMenu({ profile }: HeaderUserMenuProps) {
           </DropdownMenuLabel>
           <DropdownMenuSeparator />
           <DropdownMenuItem onSelect={() => router.push(`/u/${username}`)}>
-            <UserRound className="size-4" />
+            <UserCircleIcon className="size-4" />
             Profile
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={() => router.push("/saved")}>
-            <Bookmark className="size-4" />
+            <BookmarkSimpleIcon className="size-4" />
             Saved reviews
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={() => router.push("/notifications")}>
-            <Bell className="size-4" />
+            <BellSimpleIcon className="size-4" />
             Notifications
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={() => setSettingsOpen(true)}>
-            <Settings className="size-4" />
+            <GearSixIcon className="size-4" />
             Edit profile
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem variant="destructive" onSelect={() => setLogoutOpen(true)}>
-            <LogOut className="size-4" />
+            <SignOutIcon className="size-4" />
             Log out
           </DropdownMenuItem>
         </DropdownMenuContent>
@@ -119,7 +126,7 @@ export default function HeaderUserMenu({ profile }: HeaderUserMenuProps) {
         <AlertDialogContent size="sm">
           <AlertDialogHeader>
             <AlertDialogMedia>
-              <AlertCircle className="size-4" />
+              <WarningCircleIcon className="size-4" />
             </AlertDialogMedia>
             <AlertDialogTitle>Log out?</AlertDialogTitle>
             <AlertDialogDescription>

--- a/apps/web/components/header.tsx
+++ b/apps/web/components/header.tsx
@@ -5,7 +5,6 @@ import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { ChevronLeft, ExternalLink, MoreHorizontal, Share2 } from "lucide-react";
 import BrandLogo from "@/components/brand-logo";
-import NotificationsButton from "@/components/notifications-button";
 import PrefetchLink from "@/components/prefetch-link";
 import { useRouteHeader } from "@/components/route-header-context";
 import { Button } from "@/components/ui/button";
@@ -18,7 +17,6 @@ import {
 import { shareUrl } from "@/lib/share";
 import { cn } from "@/lib/utils";
 import { useSidebar } from "@/components/ui/sidebar";
-import type { NotificationItem } from "@/lib/notifications";
 
 type HeaderProfile = {
   id: string;
@@ -52,12 +50,8 @@ function HamburgerIcon({ className }: { className?: string }) {
 
 export default function Header({
   profile,
-  initialUnreadCount = 0,
-  initialNotifications = [],
 }: {
   profile: HeaderProfile | null;
-  initialUnreadCount?: number;
-  initialNotifications?: NotificationItem[];
 }) {
   const { toggleSidebar } = useSidebar();
   const pathname = usePathname();
@@ -194,14 +188,7 @@ export default function Header({
         </div>
 
         <div className="relative z-10 flex items-center gap-2">
-          {profile ? (
-            <NotificationsButton
-              userId={profile.id}
-              initialUnreadCount={initialUnreadCount}
-              initialNotifications={initialNotifications}
-              triggerClassName="mobile-liquid-button pointer-events-auto size-10 text-muted-foreground hover:text-foreground"
-            />
-          ) : (
+          {profile ? null : (
             <Link href="/login">
               <Button
                 variant="outline"

--- a/apps/web/components/mobile-bottom-bar.tsx
+++ b/apps/web/components/mobile-bottom-bar.tsx
@@ -2,7 +2,13 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Bell, Home, Search, UserRound } from "lucide-react";
+import {
+  BellSimpleIcon,
+  HouseIcon,
+  type Icon,
+  MagnifyingGlassIcon,
+  UserCircleIcon,
+} from "@phosphor-icons/react";
 import NewReviewDialog from "@/components/new-review-dialog";
 import ReviewGlyphIcon from "@/components/review-glyph-icon";
 import { cn } from "@/lib/utils";
@@ -23,7 +29,7 @@ type MobileBottomBarProps = {
 type NavItem = {
   href: string;
   label: string;
-  icon: React.ComponentType<{ className?: string }>;
+  icon: Icon;
   active: (pathname: string) => boolean;
 };
 
@@ -42,13 +48,16 @@ function NavTab({
       href={item.href}
       aria-label={item.label}
       className={cn(
-        "group flex h-10.5 min-w-10.5 items-center justify-center rounded-full border border-transparent text-muted-foreground transition-[transform,color,background-color,border-color,box-shadow] duration-150 ease-out active:scale-[0.96]",
+        "group flex h-10.5 min-w-10.5 items-center justify-center rounded-full border border-transparent text-muted-foreground/70 transition-[transform,color,background-color,border-color,box-shadow] duration-150 ease-out active:scale-[0.96]",
         active
           ? "gap-1.5 border-foreground/10 bg-foreground/10 px-3 text-foreground shadow-[inset_0_1px_0_rgba(255,255,255,0.06)]"
-          : "px-0 hover:border-foreground/10 hover:bg-foreground/7 hover:text-foreground",
+          : "px-0 hover:border-foreground/10 hover:bg-foreground/7 hover:text-foreground/90",
       )}
     >
-      <Icon className={cn("size-[1.04rem] shrink-0", active && "text-foreground")} />
+      <Icon
+        className={cn("size-[1.04rem] shrink-0", active && "text-foreground")}
+        weight={active ? "fill" : "regular"}
+      />
       {active ? (
         <span aria-hidden="true" className="whitespace-nowrap text-[0.68rem] font-medium leading-none">
           {item.label}
@@ -66,13 +75,13 @@ export default function MobileBottomBar({ profile }: MobileBottomBarProps) {
     {
       href: "/",
       label: "Feed",
-      icon: Home,
+      icon: HouseIcon,
       active: (current) => current === "/",
     },
     {
       href: "/search",
       label: "Explore",
-      icon: Search,
+      icon: MagnifyingGlassIcon,
       active: (current) => current.startsWith("/search") || current.startsWith("/track"),
     },
   ];
@@ -83,13 +92,13 @@ export default function MobileBottomBar({ profile }: MobileBottomBarProps) {
           {
             href: "/notifications",
             label: "Activity",
-            icon: Bell,
+            icon: BellSimpleIcon,
             active: (current: string) => current.startsWith("/notifications"),
           },
           {
             href: `/u/${profile.username}`,
             label: "Profile",
-            icon: UserRound,
+            icon: UserCircleIcon,
             active: (current: string) => current.startsWith(`/u/${profile.username}`),
           },
         ]
@@ -97,7 +106,7 @@ export default function MobileBottomBar({ profile }: MobileBottomBarProps) {
           {
             href: "/login",
             label: "Log in",
-            icon: UserRound,
+            icon: UserCircleIcon,
             active: (current: string) =>
               current.startsWith("/login") || current.startsWith("/signup"),
           },

--- a/apps/web/components/nav-main.tsx
+++ b/apps/web/components/nav-main.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import type { LucideIcon } from "lucide-react";
+import type { Icon } from "@phosphor-icons/react";
 import {
   SidebarGroup,
   SidebarGroupContent,
@@ -11,11 +11,12 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
+import { sidebarPrimaryNavButtonClassName } from "@/components/sidebar-nav-styles";
 
 type NavMainItem = {
   title: string;
   url: string;
-  icon: LucideIcon;
+  icon: Icon;
   isActive?: boolean;
   badge?: number | null;
   external?: boolean;
@@ -40,17 +41,17 @@ export function NavMain({
                 isActive={item.isActive}
                 tooltip={item.title}
                 size="lg"
-                className="h-10 rounded-xl text-[13px] font-medium transition-[color,background-color] data-[active=true]:bg-sidebar-accent/82 data-[active=true]:font-medium data-[active=true]:text-sidebar-foreground data-[active=true]:shadow-none data-[active=true]:[&_svg]:text-sidebar-foreground group-data-[collapsible=icon]:mx-auto group-data-[collapsible=icon]:!size-9 group-data-[collapsible=icon]:justify-center"
+                className={sidebarPrimaryNavButtonClassName}
               >
                 {item.external ? (
                   <a href={item.url} target="_blank" rel="noreferrer" onClick={onNavigate}>
-                    <item.icon />
-                    <span className="group-data-[collapsible=icon]:hidden">{item.title}</span>
+                    <item.icon weight={item.isActive ? "fill" : "regular"} />
+                    <span className="kocteau-sidebar-label">{item.title}</span>
                   </a>
                 ) : (
                   <Link href={item.url} onClick={onNavigate}>
-                    <item.icon />
-                    <span className="group-data-[collapsible=icon]:hidden">{item.title}</span>
+                    <item.icon weight={item.isActive ? "fill" : "regular"} />
+                    <span className="kocteau-sidebar-label">{item.title}</span>
                   </Link>
                 )}
               </SidebarMenuButton>

--- a/apps/web/components/nav-owned-reviews.tsx
+++ b/apps/web/components/nav-owned-reviews.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import { ChevronRight, MoreHorizontal, Pin, Star } from "lucide-react";
+import {
+  CaretRightIcon,
+  DotsThreeIcon,
+  PushPinSimpleIcon,
+  StarIcon,
+} from "@phosphor-icons/react";
 import type { EditReviewSelection } from "@/components/edit-review-dialog";
 import EntityCoverImage from "@/components/entity-cover-image";
 import PrefetchLink from "@/components/prefetch-link";
@@ -76,7 +81,7 @@ function OwnedReviewRailItem({
                 </div>
 
                 <span className="inline-flex shrink-0 items-center gap-1 text-[10px] font-medium text-muted-foreground">
-                  <Star className="size-3 fill-current text-amber-400" />
+                  <StarIcon className="size-3 text-amber-400" weight="fill" />
                   {item.rating.toFixed(1)}
                 </span>
               </div>
@@ -84,7 +89,7 @@ function OwnedReviewRailItem({
               <div className="mt-1 flex min-w-0 items-center gap-1.5">
                 {item.is_pinned ? (
                   <span className="inline-flex shrink-0 items-center gap-1 text-[10px] font-medium uppercase text-muted-foreground/90">
-                    <Pin className="size-3" />
+                    <PushPinSimpleIcon className="size-3" weight="fill" />
                     Pinned
                   </span>
                 ) : null}
@@ -116,7 +121,7 @@ function OwnedReviewRailItem({
               className="inline-flex size-7 shrink-0 items-center justify-center rounded-full border border-transparent text-muted-foreground transition-colors hover:bg-sidebar-accent/42 hover:text-sidebar-foreground md:hover:bg-sidebar-accent/35"
               aria-label="Review options"
             >
-              <MoreHorizontal className="size-3.5" />
+              <DotsThreeIcon className="size-3.5" weight="bold" />
             </button>
           }
         />
@@ -138,7 +143,7 @@ export function NavOwnedReviews({
 
   return (
     <Collapsible defaultOpen className="group/collapsible">
-      <SidebarGroup className="px-0 group-data-[collapsible=icon]:hidden">
+      <SidebarGroup className="kocteau-sidebar-expand-only px-0">
         <SidebarGroupLabel asChild>
           <CollapsibleTrigger className="cursor-pointer">
             Recent Reviews
@@ -146,7 +151,7 @@ export function NavOwnedReviews({
         </SidebarGroupLabel>
         <SidebarGroupAction asChild className="top-2.5">
           <CollapsibleTrigger>
-            <ChevronRight className="transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90" />
+            <CaretRightIcon className="transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90" />
             <span className="sr-only">Toggle recent reviews</span>
           </CollapsibleTrigger>
         </SidebarGroupAction>

--- a/apps/web/components/nav-secondary.tsx
+++ b/apps/web/components/nav-secondary.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import type { LucideIcon } from "lucide-react";
+import type { Icon } from "@phosphor-icons/react";
 import {
   SidebarGroup,
   SidebarGroupContent,
@@ -11,11 +11,12 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
+import { sidebarNavButtonClassName } from "@/components/sidebar-nav-styles";
 
 type NavSecondaryItem = {
   title: string;
   url: string;
-  icon: LucideIcon;
+  icon: Icon;
   isActive?: boolean;
   badge?: number | null;
 };
@@ -40,11 +41,11 @@ export function NavSecondary({
                 asChild
                 isActive={item.isActive}
                 tooltip={item.title}
-                className="rounded-xl text-[13px] font-medium transition-[color,background-color] data-[active=true]:bg-sidebar-accent/82 data-[active=true]:font-medium data-[active=true]:text-sidebar-foreground data-[active=true]:shadow-none data-[active=true]:[&_svg]:text-sidebar-foreground group-data-[collapsible=icon]:mx-auto group-data-[collapsible=icon]:!size-9 group-data-[collapsible=icon]:justify-center"
+                className={sidebarNavButtonClassName}
               >
                 <Link href={item.url} onClick={onNavigate}>
-                  <item.icon />
-                  <span className="group-data-[collapsible=icon]:hidden">{item.title}</span>
+                  <item.icon weight={item.isActive ? "fill" : "regular"} />
+                  <span className="kocteau-sidebar-label">{item.title}</span>
                 </Link>
               </SidebarMenuButton>
               {item.badge && item.badge > 0 ? (

--- a/apps/web/components/nav-user.tsx
+++ b/apps/web/components/nav-user.tsx
@@ -3,15 +3,15 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import {
-  AlertCircle,
-  Bell,
-  Bookmark,
-  ChevronsUpDown,
-  LogOut,
-  Settings,
-  Sparkles,
-  UserRound,
-} from "lucide-react";
+  BellSimpleIcon,
+  BookmarkSimpleIcon,
+  GearSixIcon,
+  SignOutIcon,
+  SparkleIcon,
+  UserCircleIcon,
+  WarningCircleIcon,
+} from "@phosphor-icons/react";
+import NotificationsButton from "@/components/notifications-button";
 import ProfileSettingsDialog from "@/components/profile-settings-dialog";
 import {
   AlertDialog,
@@ -54,9 +54,11 @@ type SidebarProfile = {
 export function NavUser({
   profile,
   onNavigate,
+  initialUnreadCount = 0,
 }: {
   profile: SidebarProfile | null;
   onNavigate?: () => void;
+  initialUnreadCount?: number;
 }) {
   const supabase = supabaseBrowser();
   const router = useRouter();
@@ -65,9 +67,9 @@ export function NavUser({
 
   if (!profile) {
     return (
-      <div className="kocteau-sidebar-note rounded-[0.95rem] p-3 text-[13px] leading-5 text-muted-foreground group-data-[collapsible=icon]:hidden">
+      <div className="kocteau-sidebar-expand-only kocteau-sidebar-note rounded-[0.95rem] p-3 text-[13px] leading-5 text-muted-foreground">
         <div className="mb-1.5 flex items-center gap-2 text-sidebar-foreground">
-          <Sparkles className="size-3.5" />
+          <SparkleIcon className="size-3.5" weight="fill" />
           <span className="font-medium">Sign in to participate</span>
         </div>
         <p>
@@ -90,84 +92,98 @@ export function NavUser({
     <>
       <SidebarMenu>
         <SidebarMenuItem>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <SidebarMenuButton
-                size="lg"
-                className="h-12 rounded-xl transition-[color,background-color] data-[state=open]:bg-sidebar-accent/82 data-[state=open]:text-sidebar-accent-foreground group-data-[collapsible=icon]:mx-auto group-data-[collapsible=icon]:!size-9 group-data-[collapsible=icon]:justify-center"
-              >
-                <UserAvatar
-                  avatarUrl={profile.avatar_url}
-                  displayName={profile.display_name}
-                  username={profile.username}
-                  className="size-8 border-sidebar-border after:border-sidebar-border"
-                />
-                <div className="grid flex-1 text-left text-[13px] leading-tight group-data-[collapsible=icon]:hidden">
-                  <span className="truncate font-medium">{displayName}</span>
-                  <span className="truncate text-xs text-muted-foreground">@{username}</span>
-                </div>
-                <ChevronsUpDown className="ml-auto size-4 group-data-[collapsible=icon]:hidden" />
-              </SidebarMenuButton>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent
-              className="w-(--radix-dropdown-menu-trigger-width) min-w-60 rounded-xl border-border bg-popover ring-border/70"
-              side="bottom"
-              align="end"
-              sideOffset={8}
-            >
-              <DropdownMenuLabel className="p-0 font-normal">
-                <div className="flex items-center gap-2 px-2 py-2 text-left text-sm">
-                  <UserAvatar
-                    avatarUrl={profile.avatar_url}
-                    displayName={profile.display_name}
-                    username={profile.username}
-                    className="size-8"
-                  />
-                  <div className="grid flex-1 text-left text-sm leading-tight">
+          <div className="flex w-full items-center gap-1.5 rounded-[0.75rem] group-data-[collapsible=icon]:justify-center">
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <SidebarMenuButton
+                  size="lg"
+                  className="h-11 min-w-0 flex-1 rounded-[0.68rem] px-2 text-sidebar-foreground/78 transition-[color,background-color,width,height,padding] hover:text-sidebar-foreground data-[state=open]:bg-sidebar-accent/82 data-[state=open]:text-sidebar-accent-foreground group-data-[collapsible=icon]:mx-auto group-data-[collapsible=icon]:!size-9 group-data-[collapsible=icon]:grow-0 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0"
+                >
+                  <span className="kocteau-sidebar-avatar shrink-0">
+                    <UserAvatar
+                      avatarUrl={profile.avatar_url}
+                      displayName={profile.display_name}
+                      username={profile.username}
+                      className="size-8 border-sidebar-border after:border-sidebar-border"
+                    />
+                  </span>
+                  <div className="kocteau-sidebar-label grid flex-1 text-left text-[13px] leading-tight">
                     <span className="truncate font-medium">{displayName}</span>
                     <span className="truncate text-xs text-muted-foreground">@{username}</span>
                   </div>
-                </div>
-              </DropdownMenuLabel>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem
-                onSelect={() => {
-                  onNavigate?.();
-                  router.push(`/u/${username}`);
-                }}
+                </SidebarMenuButton>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent
+                className="w-(--radix-dropdown-menu-trigger-width) min-w-60 rounded-[0.9rem] border-border bg-popover ring-border/70"
+                side="bottom"
+                align="end"
+                sideOffset={8}
               >
-                <UserRound className="size-4" />
-                Profile
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onSelect={() => {
-                  onNavigate?.();
-                  router.push("/saved");
-                }}
-              >
-                <Bookmark className="size-4" />
-                Saved reviews
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onSelect={() => {
-                  onNavigate?.();
-                  router.push("/notifications");
-                }}
-              >
-                <Bell className="size-4" />
-                Activity
-              </DropdownMenuItem>
-              <DropdownMenuItem onSelect={() => setSettingsOpen(true)}>
-                <Settings className="size-4" />
-                Edit profile
-              </DropdownMenuItem>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem variant="destructive" onSelect={() => setLogoutOpen(true)}>
-                <LogOut className="size-4" />
-                Log out
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+                <DropdownMenuLabel className="p-0 font-normal">
+                  <div className="flex items-center gap-2 px-2 py-2 text-left text-sm">
+                    <UserAvatar
+                      avatarUrl={profile.avatar_url}
+                      displayName={profile.display_name}
+                      username={profile.username}
+                      className="size-8"
+                    />
+                    <div className="grid flex-1 text-left text-sm leading-tight">
+                      <span className="truncate font-medium">{displayName}</span>
+                      <span className="truncate text-xs text-muted-foreground">@{username}</span>
+                    </div>
+                  </div>
+                </DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  onSelect={() => {
+                    onNavigate?.();
+                    router.push(`/u/${username}`);
+                  }}
+                >
+                  <UserCircleIcon className="size-4" />
+                  Profile
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onSelect={() => {
+                    onNavigate?.();
+                    router.push("/saved");
+                  }}
+                >
+                  <BookmarkSimpleIcon className="size-4" />
+                  Saved reviews
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onSelect={() => {
+                    onNavigate?.();
+                    router.push("/notifications");
+                  }}
+                >
+                  <BellSimpleIcon className="size-4" />
+                  Activity
+                </DropdownMenuItem>
+                <DropdownMenuItem onSelect={() => setSettingsOpen(true)}>
+                  <GearSixIcon className="size-4" />
+                  Edit profile
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem variant="destructive" onSelect={() => setLogoutOpen(true)}>
+                  <SignOutIcon className="size-4" />
+                  Log out
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+
+            <NotificationsButton
+              userId={profile.id}
+              initialUnreadCount={initialUnreadCount}
+              initialNotifications={[]}
+              contentSide="top"
+              contentAlign="end"
+              contentSideOffset={7}
+              contentClassName="!w-[16rem] max-w-[calc(100vw-1rem)] rounded-[0.76rem] border-sidebar-border/70 bg-sidebar p-0 sm:!w-[16rem] md:bg-sidebar"
+              triggerClassName="kocteau-sidebar-trailing size-8 rounded-full border-sidebar-border/55 bg-transparent text-sidebar-foreground/52 hover:bg-sidebar-accent/80 hover:text-sidebar-foreground md:border-sidebar-border/55 md:bg-transparent"
+            />
+          </div>
         </SidebarMenuItem>
       </SidebarMenu>
 
@@ -181,7 +197,7 @@ export function NavUser({
         <AlertDialogContent size="sm">
           <AlertDialogHeader>
             <AlertDialogMedia>
-              <AlertCircle className="size-4" />
+              <WarningCircleIcon className="size-4" />
             </AlertDialogMedia>
             <AlertDialogTitle>Log out?</AlertDialogTitle>
             <AlertDialogDescription>

--- a/apps/web/components/notification-list.tsx
+++ b/apps/web/components/notification-list.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import Link from "next/link";
-import { Check, ChevronRight, Heart, MessageCircle } from "lucide-react";
+import {
+  CheckIcon,
+  ChatCircleTextIcon,
+  HeartIcon,
+} from "@phosphor-icons/react";
 import {
   groupNotifications,
   notificationHref,
@@ -71,8 +75,7 @@ export default function NotificationList({
   return (
     <div
       className={cn(
-        "divide-y divide-border/25",
-        compact ? "" : "overflow-hidden rounded-[1.55rem] border border-border/30 bg-card/18",
+        compact ? "" : "divide-y divide-border/25 overflow-hidden rounded-[1.55rem] border border-border/30 bg-card/18",
       )}
     >
       {entries.map((entry) => {
@@ -83,13 +86,54 @@ export default function NotificationList({
           ? !notification.read_at
           : entry.notifications.some((item) => !item.read_at);
         const href = notificationHref(notification);
+        const body = getGroupedBody(entry);
+
+        if (compact) {
+          return (
+            <Link
+              key={entry.kind === "single" ? notification.id : entry.id}
+              href={href}
+              className="grid grid-cols-[1.5rem_minmax(0,1fr)_auto] items-center gap-2.5 border-b border-sidebar-border/52 px-3 py-2.5 text-left transition-colors last:border-b-0 hover:bg-sidebar-accent/52"
+            >
+              <UserAvatar
+                avatarUrl={notification.actor?.avatar_url}
+                displayName={notification.actor?.display_name ?? null}
+                username={notification.actor?.username ?? null}
+                size="sm"
+              />
+              <p className="min-w-0 truncate text-[12px] leading-5 text-sidebar-foreground/62">
+                {entry.kind === "single" ? (
+                  <>
+                    {unread ? (
+                      <span className="mr-1.5 inline-flex size-1.5 translate-y-[-1px] rounded-full bg-sidebar-foreground" />
+                    ) : null}
+                    <span className="font-medium text-sidebar-foreground/88">
+                      {actorLabel}
+                    </span>{" "}
+                    {body}
+                  </>
+                ) : (
+                  <>
+                    {unread ? (
+                      <span className="mr-1.5 inline-flex size-1.5 translate-y-[-1px] rounded-full bg-sidebar-foreground" />
+                    ) : null}
+                    {body}
+                  </>
+                )}
+              </p>
+              <span className="text-[11px] text-sidebar-foreground/42">
+                {timestamp}
+              </span>
+            </Link>
+          );
+        }
 
         return (
           <div
             key={entry.kind === "single" ? notification.id : entry.id}
             className={cn(
               "group relative flex gap-3 transition-colors hover:bg-muted/14",
-              compact ? "rounded-[1.15rem] px-3 py-3" : "px-4 py-4",
+              compact ? "rounded-[0.68rem] px-2.5 py-2.5" : "px-4 py-4",
             )}
           >
             <div className="pt-0.5">
@@ -104,7 +148,7 @@ export default function NotificationList({
             <div className="min-w-0 flex-1">
               <div className="flex items-start justify-between gap-3">
                 <div className="min-w-0 space-y-1.5">
-                  <div className="flex items-center gap-2 text-sm">
+                  <div className="flex items-center gap-2 text-[13px]">
                     {unread ? (
                       <span className="inline-flex h-1.5 w-1.5 shrink-0 rounded-full bg-foreground" />
                     ) : null}
@@ -112,13 +156,13 @@ export default function NotificationList({
                       {actorLabel}
                     </span>
                     {notification.type === "review_liked" ? (
-                      <Heart className="size-3.5 shrink-0 text-muted-foreground" />
+                      <HeartIcon className="size-3.5 shrink-0 text-muted-foreground" />
                     ) : (
-                      <MessageCircle className="size-3.5 shrink-0 text-muted-foreground" />
+                      <ChatCircleTextIcon className="size-3.5 shrink-0 text-muted-foreground" />
                     )}
                   </div>
-                  <p className="line-clamp-2 text-sm leading-6 text-foreground/78">
-                    {getGroupedBody(entry)}
+                  <p className="line-clamp-2 text-[12.5px] leading-5 text-foreground/72">
+                    {body}
                   </p>
                 </div>
                 <span className="shrink-0 pt-0.5 text-[11px] text-muted-foreground">
@@ -126,11 +170,10 @@ export default function NotificationList({
                 </span>
               </div>
 
-              <div className="mt-2 flex flex-wrap items-center gap-1">
-                <Button asChild variant="ghost" size="sm" className="h-7 rounded-full px-2.5 text-xs text-muted-foreground hover:text-foreground">
+              <div className="mt-1.5 flex flex-wrap items-center gap-1">
+                <Button asChild variant="ghost" size="sm" className="h-6 rounded-[0.46rem] px-2 text-[11px] text-muted-foreground hover:text-foreground">
                   <Link href={href}>
                     Open
-                    <ChevronRight className="size-3.5" />
                   </Link>
                 </Button>
 
@@ -139,7 +182,7 @@ export default function NotificationList({
                     type="button"
                     variant="ghost"
                     size="sm"
-                    className="h-7 rounded-full px-2.5 text-xs text-muted-foreground hover:text-foreground"
+                    className="h-6 rounded-[0.46rem] px-2 text-[11px] text-muted-foreground hover:text-foreground"
                     disabled={isMarkingAsRead}
                     onClick={() => {
                       if (entry.kind === "single") {
@@ -150,7 +193,7 @@ export default function NotificationList({
                       entry.notifications.forEach((item) => onMarkAsRead(item.id));
                     }}
                   >
-                    <Check className="size-3.5" />
+                    <CheckIcon className="size-3.5" />
                     Mark read
                   </Button>
                 ) : null}

--- a/apps/web/components/notifications-button.tsx
+++ b/apps/web/components/notifications-button.tsx
@@ -2,12 +2,11 @@
 
 import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
-import { Bell } from "lucide-react";
+import { BellSimpleIcon } from "@phosphor-icons/react";
 import { useNotifications } from "@/hooks/use-notifications";
 import type { NotificationItem } from "@/lib/notifications";
 import NotificationList from "@/components/notification-list";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { Empty, EmptyHeader, EmptyMedia, EmptyTitle } from "@/components/ui/empty";
 import {
   Popover,
   PopoverContent,
@@ -27,6 +26,10 @@ type NotificationsButtonProps = {
   initialUnreadCount: number;
   initialNotifications: NotificationItem[];
   triggerClassName?: string;
+  contentClassName?: string;
+  contentAlign?: "start" | "center" | "end";
+  contentSide?: "top" | "right" | "bottom" | "left";
+  contentSideOffset?: number;
 };
 
 export default function NotificationsButton({
@@ -34,6 +37,10 @@ export default function NotificationsButton({
   initialUnreadCount,
   initialNotifications,
   triggerClassName,
+  contentClassName,
+  contentAlign = "end",
+  contentSide,
+  contentSideOffset = 12,
 }: NotificationsButtonProps) {
   const [open, setOpen] = useState(false);
   const hasAutoMarkedRef = useRef(false);
@@ -91,7 +98,7 @@ export default function NotificationsButton({
           variant="ghost"
           size="icon"
           className={cn(
-            "relative h-9 w-9 rounded-full border border-border/46 bg-card/18 text-muted-foreground shadow-[inset_0_1px_0_rgba(255,255,255,0.03)] transition-colors hover:bg-muted/40 hover:text-foreground md:border-border/40 md:bg-background/65",
+            "relative h-9 w-9 rounded-[0.68rem] border border-border/46 bg-card/18 text-muted-foreground shadow-[inset_0_1px_0_rgba(255,255,255,0.03)] transition-colors hover:bg-muted/40 hover:text-foreground md:border-border/40 md:bg-background/65",
             triggerClassName,
             unreadCount > 0 && "text-foreground",
           )}
@@ -101,9 +108,9 @@ export default function NotificationsButton({
               : "Notifications"
           }
         >
-          <Bell className="size-4" />
+          <BellSimpleIcon className="size-4" weight={unreadCount > 0 ? "fill" : "regular"} />
           {unreadCount > 0 ? (
-            <span className="absolute -right-1 -top-1 inline-flex min-w-5 items-center justify-center rounded-full bg-foreground px-1.5 py-0.5 text-[10px] font-semibold leading-none text-background shadow-sm">
+            <span className="absolute -right-1 -top-1 inline-flex min-w-5 items-center justify-center rounded-[0.45rem] bg-foreground px-1.5 py-0.5 text-[10px] font-semibold leading-none text-background shadow-sm">
               {unreadCount > 99 ? "99+" : unreadCount}
             </span>
           ) : null}
@@ -111,15 +118,19 @@ export default function NotificationsButton({
       </PopoverTrigger>
 
       <PopoverContent
-        align="end"
-        className="w-[23rem] gap-0 rounded-[1.8rem] border-border/44 bg-popover/98 p-0 shadow-none sm:w-[25rem] md:border-border/35 md:bg-popover/96"
-        sideOffset={12}
+        align={contentAlign}
+        side={contentSide}
+        className={cn(
+          "w-[23rem] gap-0 overflow-hidden rounded-[1rem] border-border/44 bg-popover p-0 shadow-none sm:w-[25rem] md:border-border/35 md:bg-popover",
+          contentClassName,
+        )}
+        sideOffset={contentSideOffset}
       >
-        <PopoverHeader className="border-b border-border/32 px-4 py-3 md:border-border/25">
-          <div className="flex items-center justify-between gap-3">
-            <div className="space-y-1">
-              <PopoverTitle className="text-sm font-medium">Activity</PopoverTitle>
-              <PopoverDescription className="text-xs">
+        <PopoverHeader className="border-b border-sidebar-border/60 px-3 py-2.5">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0 space-y-0.5">
+              <PopoverTitle className="text-[13px] font-medium text-sidebar-foreground">Activity</PopoverTitle>
+              <PopoverDescription className="truncate text-[11px] text-sidebar-foreground/58">
                 {unreadCount > 0
                   ? `${unreadCount} unread right now`
                   : "You’re all caught up"}
@@ -127,25 +138,25 @@ export default function NotificationsButton({
             </div>
             <Link
               href="/notifications"
-              className="text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+              className="shrink-0 pt-0.5 text-[11px] font-medium text-sidebar-foreground/58 transition-colors hover:text-sidebar-foreground"
             >
               View all
             </Link>
           </div>
         </PopoverHeader>
 
-        <ScrollArea className="max-h-[28rem]">
-          <div className="p-2.5">
+        <ScrollArea className="max-h-[18rem]">
+          <div>
             {isLoadingNotifications ? (
-              <div className="flex justify-center px-3 py-8">
+              <div className="flex justify-center px-3 py-7">
                 <Spinner className="size-4 text-muted-foreground/70" />
               </div>
             ) : isFetchingNotifications && notifications.length === 0 ? (
-              <div className="flex justify-center px-3 py-8">
+              <div className="flex justify-center px-3 py-7">
                 <Spinner className="size-4 text-muted-foreground/70" />
               </div>
             ) : isNotificationsError ? (
-              <Alert className="rounded-2xl border-border/46 bg-card/58 p-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)] md:border-border/40 md:bg-card/50">
+              <Alert className="rounded-[0.64rem] border-border/46 bg-card p-3 shadow-none md:border-border/40 md:bg-card">
                 <AlertTitle>Notifications unavailable</AlertTitle>
                 <AlertDescription>
                   {notificationsError instanceof Error
@@ -161,14 +172,14 @@ export default function NotificationsButton({
                 onMarkAsRead={handleMarkAsRead}
               />
             ) : (
-              <Empty className="rounded-[1.5rem] border-border/34 bg-card/26 px-4 py-9 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)] md:border-border/25 md:bg-card/20">
-                <EmptyHeader>
-                  <EmptyMedia variant="icon">
-                    <Bell className="size-4" />
-                  </EmptyMedia>
-                  <EmptyTitle>No notifications yet</EmptyTitle>
-                </EmptyHeader>
-              </Empty>
+              <div className="flex min-h-32 flex-col items-center justify-center gap-3 px-4 py-8 text-center">
+                <span className="flex size-8 items-center justify-center rounded-full bg-sidebar-accent text-sidebar-foreground/62">
+                  <BellSimpleIcon className="size-4" />
+                </span>
+                <p className="text-[13px] font-medium text-sidebar-foreground">
+                  No notifications yet
+                </p>
+              </div>
             )}
           </div>
         </ScrollArea>

--- a/apps/web/components/sidebar-nav-styles.ts
+++ b/apps/web/components/sidebar-nav-styles.ts
@@ -1,0 +1,4 @@
+export const sidebarNavButtonClassName =
+  "rounded-xl text-[13px] font-medium text-sidebar-foreground/58 transition-[color,background-color] hover:text-sidebar-foreground hover:[&_svg]:text-sidebar-foreground/82 data-[active=true]:bg-sidebar-accent/82 data-[active=true]:font-medium data-[active=true]:text-sidebar-foreground data-[active=true]:shadow-none data-[active=true]:[&_svg]:text-sidebar-foreground [&_svg]:text-sidebar-foreground/52 group-data-[collapsible=icon]:mx-auto group-data-[collapsible=icon]:!size-9 group-data-[collapsible=icon]:justify-center";
+
+export const sidebarPrimaryNavButtonClassName = `h-10 ${sidebarNavButtonClassName}`;

--- a/apps/web/components/ui/sidebar.tsx
+++ b/apps/web/components/ui/sidebar.tsx
@@ -22,7 +22,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip"
-import { IconLayoutSidebar } from "@tabler/icons-react"
+import { SidebarSimpleIcon } from "@phosphor-icons/react"
 
 const SIDEBAR_COOKIE_NAME = "sidebar_state"
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7
@@ -217,7 +217,7 @@ function Sidebar({
       <div
         data-slot="sidebar-gap"
         className={cn(
-          "relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear",
+          "relative w-(--sidebar-width) bg-transparent transition-[width] duration-[240ms] ease-[var(--kocteau-ease)]",
           "group-data-[collapsible=offcanvas]:w-0",
           "group-data-[side=right]:rotate-180",
           variant === "floating" || variant === "inset"
@@ -229,7 +229,7 @@ function Sidebar({
         data-slot="sidebar-container"
         data-side={side}
         className={cn(
-          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear data-[side=left]:left-0 data-[side=left]:group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)] data-[side=right]:right-0 data-[side=right]:group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)] md:flex",
+          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-[240ms] ease-[var(--kocteau-ease)] data-[side=left]:left-0 data-[side=left]:group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)] data-[side=right]:right-0 data-[side=right]:group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)] md:flex",
           // Adjust the padding for floating and inset variants.
           variant === "floating" || variant === "inset"
             ? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]"
@@ -242,7 +242,7 @@ function Sidebar({
           data-sidebar="sidebar"
           data-slot="sidebar-inner"
           className={cn(
-            "flex size-full flex-col bg-sidebar",
+            "flex size-full flex-col overflow-hidden bg-sidebar transition-[background-color,box-shadow] duration-[240ms] ease-[var(--kocteau-ease)]",
             variant === "floating" && "rounded-lg border border-sidebar-border shadow-sm",
             variant === "inset" && side === "left" && "border-r border-sidebar-border",
             variant === "inset" && side === "right" && "border-l border-sidebar-border",
@@ -275,7 +275,7 @@ function SidebarTrigger({
       }}
       {...props}
     >
-      <IconLayoutSidebar />
+      <SidebarSimpleIcon />
       <span className="sr-only">Toggle Sidebar</span>
     </Button>
   )
@@ -293,7 +293,7 @@ function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
       onClick={toggleSidebar}
       title="Toggle Sidebar"
       className={cn(
-        "absolute inset-y-0 z-20 hidden w-4 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:start-1/2 after:w-[2px] hover:after:bg-sidebar-border sm:flex ltr:-translate-x-1/2 rtl:-translate-x-1/2",
+        "absolute inset-y-0 z-20 hidden w-4 transition-[width,transform,background-color] duration-[180ms] ease-[var(--kocteau-ease)] group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:start-1/2 after:w-[2px] after:transition-colors after:duration-[180ms] after:ease-[var(--kocteau-ease)] hover:after:bg-sidebar-border sm:flex ltr:-translate-x-1/2 rtl:-translate-x-1/2",
         "in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",
         "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
         "group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full hover:group-data-[collapsible=offcanvas]:bg-sidebar",
@@ -312,7 +312,7 @@ function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
       data-slot="sidebar-inset"
       className={cn(
         /* md:peer-data-[variant=inset]:m-2 */
-        "relative flex w-full flex-1 flex-col bg-background  md:peer-data-[variant=inset]:ml-0  md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
+        "relative flex w-full flex-1 flex-col bg-background transition-[margin,border-radius] duration-[240ms] ease-[var(--kocteau-ease)] md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
         className
       )}
       {...props}
@@ -413,7 +413,7 @@ function SidebarGroupLabel({
       data-slot="sidebar-group-label"
       data-sidebar="group-label"
       className={cn(
-        "flex h-8 shrink-0 items-center rounded-md px-2 text-xs text-sidebar-foreground/70 ring-sidebar-ring outline-hidden transition-[margin,opacity] duration-200 ease-linear group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0 focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        "flex h-8 shrink-0 items-center overflow-hidden rounded-md px-2 text-xs text-sidebar-foreground/70 ring-sidebar-ring outline-hidden transition-[height,opacity,transform,filter,padding] duration-[180ms] ease-[var(--kocteau-ease)] group-data-[collapsible=icon]:h-0 group-data-[collapsible=icon]:-translate-y-1 group-data-[collapsible=icon]:px-0 group-data-[collapsible=icon]:opacity-0 group-data-[collapsible=icon]:blur-[1.5px] focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
         className
       )}
       {...props}
@@ -433,7 +433,7 @@ function SidebarGroupAction({
       data-slot="sidebar-group-action"
       data-sidebar="group-action"
       className={cn(
-        "absolute top-3.5 right-3 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground ring-sidebar-ring outline-hidden transition-transform group-data-[collapsible=icon]:hidden after:absolute after:-inset-2 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 md:after:hidden [&>svg]:size-4 [&>svg]:shrink-0",
+        "absolute top-3.5 right-3 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground ring-sidebar-ring outline-hidden transition-[opacity,transform,background-color,color] duration-[180ms] ease-[var(--kocteau-ease)] group-data-[collapsible=icon]:pointer-events-none group-data-[collapsible=icon]:scale-75 group-data-[collapsible=icon]:opacity-0 after:absolute after:-inset-2 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 md:after:hidden [&>svg]:size-4 [&>svg]:shrink-0",
         className
       )}
       {...props}
@@ -478,7 +478,7 @@ function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
 }
 
 const sidebarMenuButtonVariants = cva(
-  "peer/menu-button group/menu-button flex w-full items-center gap-2 overflow-hidden rounded-[calc(var(--radius-sm)+2px)] p-2 text-left text-xs ring-sidebar-ring outline-hidden transition-[width,height,padding] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-open:hover:bg-sidebar-accent data-open:hover:text-sidebar-accent-foreground data-active:bg-sidebar-accent data-active:font-medium data-active:text-sidebar-accent-foreground [&_svg]:size-4 [&_svg]:shrink-0 [&>span:last-child]:truncate",
+  "peer/menu-button group/menu-button flex w-full items-center gap-2 overflow-hidden rounded-[calc(var(--radius-sm)+2px)] p-2 text-left text-xs ring-sidebar-ring outline-hidden transition-[width,height,padding,gap,background-color,color,box-shadow] duration-[180ms] ease-[var(--kocteau-ease)] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:gap-0 group-data-[collapsible=icon]:p-2! hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-open:hover:bg-sidebar-accent data-open:hover:text-sidebar-accent-foreground data-active:bg-sidebar-accent data-active:font-medium data-active:text-sidebar-accent-foreground [&_svg]:size-4 [&_svg]:shrink-0 [&>span:last-child]:truncate",
   {
     variants: {
       variant: {
@@ -565,7 +565,7 @@ function SidebarMenuAction({
       data-slot="sidebar-menu-action"
       data-sidebar="menu-action"
       className={cn(
-        "absolute top-1.5 right-1 flex aspect-square w-5 items-center justify-center rounded-[calc(var(--radius-sm)-2px)] p-0 text-sidebar-foreground ring-sidebar-ring outline-hidden transition-transform group-data-[collapsible=icon]:hidden peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[size=default]/menu-button:top-1.5 peer-data-[size=lg]/menu-button:top-2.5 peer-data-[size=sm]/menu-button:top-1 after:absolute after:-inset-2 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 md:after:hidden [&>svg]:size-4 [&>svg]:shrink-0",
+        "absolute top-1.5 right-1 flex aspect-square w-5 items-center justify-center rounded-[calc(var(--radius-sm)-2px)] p-0 text-sidebar-foreground ring-sidebar-ring outline-hidden transition-[opacity,transform,background-color,color] duration-[180ms] ease-[var(--kocteau-ease)] group-data-[collapsible=icon]:pointer-events-none group-data-[collapsible=icon]:scale-75 group-data-[collapsible=icon]:opacity-0 peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[size=default]/menu-button:top-1.5 peer-data-[size=lg]/menu-button:top-2.5 peer-data-[size=sm]/menu-button:top-1 after:absolute after:-inset-2 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 md:after:hidden [&>svg]:size-4 [&>svg]:shrink-0",
         showOnHover &&
           "group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 peer-data-active/menu-button:text-sidebar-accent-foreground aria-expanded:opacity-100 md:opacity-0",
         className
@@ -584,7 +584,7 @@ function SidebarMenuBadge({
       data-slot="sidebar-menu-badge"
       data-sidebar="menu-badge"
       className={cn(
-        "pointer-events-none absolute right-1 flex h-5 min-w-5 items-center justify-center rounded-[calc(var(--radius-sm)-2px)] px-1 text-xs font-medium text-sidebar-foreground tabular-nums select-none group-data-[collapsible=icon]:hidden peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[size=default]/menu-button:top-1.5 peer-data-[size=lg]/menu-button:top-2.5 peer-data-[size=sm]/menu-button:top-1 peer-data-active/menu-button:text-sidebar-accent-foreground",
+        "pointer-events-none absolute right-1 flex h-5 min-w-5 items-center justify-center rounded-[calc(var(--radius-sm)-2px)] px-1 text-xs font-medium text-sidebar-foreground tabular-nums select-none transition-[opacity,transform,color] duration-[160ms] ease-[var(--kocteau-ease)] group-data-[collapsible=icon]:scale-75 group-data-[collapsible=icon]:opacity-0 peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[size=default]/menu-button:top-1.5 peer-data-[size=lg]/menu-button:top-2.5 peer-data-[size=sm]/menu-button:top-1 peer-data-active/menu-button:text-sidebar-accent-foreground",
         className
       )}
       {...props}
@@ -636,7 +636,7 @@ function SidebarMenuSub({ className, ...props }: React.ComponentProps<"ul">) {
       data-slot="sidebar-menu-sub"
       data-sidebar="menu-sub"
       className={cn(
-        "mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-l border-sidebar-border px-2.5 py-0.5 group-data-[collapsible=icon]:hidden",
+        "mx-3.5 flex max-h-64 min-w-0 translate-x-px flex-col gap-1 overflow-hidden border-l border-sidebar-border px-2.5 py-0.5 transition-[max-height,opacity,transform,filter,padding,margin] duration-[180ms] ease-[var(--kocteau-ease)] group-data-[collapsible=icon]:mx-0 group-data-[collapsible=icon]:max-h-0 group-data-[collapsible=icon]:px-0 group-data-[collapsible=icon]:py-0 group-data-[collapsible=icon]:opacity-0 group-data-[collapsible=icon]:blur-[1.5px]",
         className
       )}
       {...props}
@@ -678,7 +678,7 @@ function SidebarMenuSubButton({
       data-size={size}
       data-active={isActive}
       className={cn(
-        "flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 text-sidebar-foreground ring-sidebar-ring outline-hidden group-data-[collapsible=icon]:hidden hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[size=md]:text-xs data-[size=sm]:text-xs data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground",
+        "flex h-7 max-h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 text-sidebar-foreground ring-sidebar-ring outline-hidden transition-[max-height,opacity,transform,filter,padding,background-color,color] duration-[180ms] ease-[var(--kocteau-ease)] group-data-[collapsible=icon]:max-h-0 group-data-[collapsible=icon]:px-0 group-data-[collapsible=icon]:opacity-0 group-data-[collapsible=icon]:blur-[1.5px] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[size=md]:text-xs data-[size=sm]:text-xs data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground",
         className
       )}
       {...props}

--- a/apps/web/components/ui/tooltip.tsx
+++ b/apps/web/components/ui/tooltip.tsx
@@ -42,13 +42,13 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          "z-50 inline-flex w-fit max-w-xs origin-(--radix-tooltip-content-transform-origin) items-center gap-1.5 rounded-md bg-foreground px-3 py-1.5 text-xs text-background has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          "z-50 inline-flex w-fit max-w-xs origin-(--radix-tooltip-content-transform-origin) items-center gap-1.5 rounded-[0.58rem] border border-border/55 bg-[var(--kocteau-canvas)] px-2.5 py-1.5 text-[11px] font-medium text-foreground/88 shadow-[0_10px_28px_rgba(0,0,0,0.34)] has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           className
         )}
         {...props}
       >
         {children}
-        <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground" />
+        <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] border-l border-t border-border/55 bg-[var(--kocteau-canvas)] fill-[var(--kocteau-canvas)]" />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   )

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,7 @@
     "@hugeicons/react": "^1.1.6",
     "@origin-space/image-cropper": "^0.1.9",
     "@paper-design/shaders-react": "^0.0.76",
+    "@phosphor-icons/react": "^2.1.10",
     "@sentry/nextjs": "10",
     "@supabase/ssr": "^0.9.0",
     "@supabase/supabase-js": "^2.98.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,6 +141,9 @@ importers:
       '@paper-design/shaders-react':
         specifier: ^0.0.76
         version: 0.0.76(@types/react@19.2.14)(react@19.2.4)
+      '@phosphor-icons/react':
+        specifier: ^2.1.10
+        version: 2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@sentry/nextjs':
         specifier: '10'
         version: 10.46.0(@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.105.4)
@@ -1797,6 +1800,13 @@ packages:
 
   '@paper-design/shaders@0.0.76':
     resolution: {integrity: sha512-AcNDY4J66YQHUfQYFInkCP7M9VOje0od7wLpOR7LtCmc532opJy6ll+h1W9zBovz8tt9U7OADUmJ/qKEXyOX/A==}
+
+  '@phosphor-icons/react@2.1.10':
+    resolution: {integrity: sha512-vt8Tvq8GLjheAZZYa+YG/pW7HDbov8El/MANW8pOAz4eGxrwhnbfrQZq0Cp4q8zBEu8NIhHdnr+r8thnfRSNYA==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: '>= 16.8'
+      react-dom: '>= 16.8'
 
   '@prisma/instrumentation@7.4.2':
     resolution: {integrity: sha512-r9JfchJF1Ae6yAxcaLu/V1TGqBhAuSDe3mRNOssBfx1rMzfZ4fdNvrgUBwyb/TNTGXFxlH9AZix5P257x07nrg==}
@@ -9503,6 +9513,11 @@ snapshots:
       '@types/react': 19.2.14
 
   '@paper-design/shaders@0.0.76': {}
+
+  '@phosphor-icons/react@2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   '@prisma/instrumentation@7.4.2(@opentelemetry/api@1.9.1)':
     dependencies:


### PR DESCRIPTION
## What changed

- Polished the sidebar collapse/expand motion with CSS-only transitions, stronger blur, and smoother footer behavior.
- Migrated primary navigation/profile/sidebar icons to Phosphor.
- Updated active/inactive nav icon states to use `fill` / `regular`.
- Moved notifications into the sidebar footer beside the profile control.
- Redesigned the notifications popover to feel like a compact sidebar extension.
- Updated collapsed-sidebar tooltips to better match Kocteau’s dark UI.

## Why

To make the main navigation feel more intentional, editorial, and responsive while reducing visual noise and improving the collapsed sidebar experience.

## Testing

- [ ] Ran `pnpm check`
- [x] Added screenshots or a short recording for visible web UI changes
- [x] Confirmed this does not touch auth, Supabase, recommendations, analytics, CI, or release behavior

## Changelog impact

No manual `CHANGELOG.md` edit is required. Release Please generates release notes from PR titles and squash commits.

- [x] User-facing web change
- [ ] Developer experience or documentation change
- [ ] Internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added collapsible sidebar with smooth animations and reduced-motion support.

* **Style**
  * Updated app iconography with a refreshed icon system throughout the interface.
  * Refined notifications button UI with improved customization options.
  * Enhanced tooltip and header styling for better visual consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/francozeta/kocteau/pull/24?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->