### PR TITLE
fix(web): center sidebar review action

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -249,13 +249,13 @@
   }
 
   .kocteau-feed-tabs {
-    border: 1px solid var(--kocteau-line-soft);
-    background: var(--kocteau-surface-control);
+    border: 0;
+    background: transparent;
     box-shadow: none;
   }
 
   .kocteau-feed-tab-active {
-    background: color-mix(in oklch, var(--foreground) 8%, var(--kocteau-surface-control));
+    background: color-mix(in oklch, var(--foreground) 7%, transparent);
     box-shadow: none;
   }
 
@@ -591,7 +591,6 @@
   background:
     radial-gradient(circle at 48% 50%, rgba(255, 255, 255, 0.055), transparent 30rem),
     linear-gradient(180deg, rgba(0, 0, 0, 0.16), rgba(0, 0, 0, 0.52)),
-    url("/background-auth.webp") center / cover no-repeat,
     var(--background);
 }
 
@@ -599,7 +598,7 @@
   content: "";
   position: absolute;
   inset: 0;
-  z-index: 0;
+  z-index: 1;
   pointer-events: none;
   background:
     linear-gradient(90deg, rgba(0, 0, 0, 0.58), transparent 42%, rgba(0, 0, 0, 0.24)),
@@ -610,7 +609,7 @@
   content: "";
   position: absolute;
   inset: 0;
-  z-index: 0;
+  z-index: 2;
   pointer-events: none;
   opacity: 0.2;
   mix-blend-mode: screen;

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -298,6 +298,10 @@
     max-width: 3rem;
   }
 
+  .kocteau-sidebar-shortcut {
+    margin-left: auto;
+  }
+
   .kocteau-sidebar-avatar {
     display: inline-flex;
     max-width: 2rem;
@@ -318,6 +322,8 @@
   [data-collapsible="icon"] .kocteau-sidebar-shortcut,
   [data-collapsible="icon"] .kocteau-sidebar-avatar,
   [data-collapsible="icon"] .kocteau-sidebar-trailing {
+    width: 0;
+    margin-left: 0;
     max-width: 0;
     opacity: 0;
     transform: translateX(-0.25rem) scale(0.98);
@@ -328,7 +334,6 @@
   [data-collapsible="icon"] .kocteau-sidebar-shortcut,
   [data-collapsible="icon"] .kocteau-sidebar-avatar,
   [data-collapsible="icon"] .kocteau-sidebar-trailing {
-    margin-left: 0;
     transform: translateX(-0.125rem) scale(0.86);
   }
 

--- a/apps/web/components/app-sidebar.tsx
+++ b/apps/web/components/app-sidebar.tsx
@@ -9,12 +9,12 @@ import {
   ChatCircleTextIcon,
   HouseIcon,
   MagnifyingGlassIcon,
-  NotePencilIcon,
 } from "@phosphor-icons/react";
 import BrandLogo from "@/components/brand-logo";
 import NewReviewDialog from "@/components/new-review-dialog";
 import { NavOwnedReviews } from "@/components/nav-owned-reviews";
 import PrefetchLink from "@/components/prefetch-link";
+import ReviewGlyphIcon from "@/components/review-glyph-icon";
 import { NavMain } from "@/components/nav-main";
 import { NavSecondary } from "@/components/nav-secondary";
 import { Kbd } from "@/components/ui/kbd";
@@ -175,10 +175,10 @@ export default function AppSidebar({
                 className="flex h-9 w-full items-center justify-start gap-2 overflow-hidden rounded-[0.7rem] border border-sidebar-border/70 bg-[var(--kocteau-surface-control)] px-2.5 text-[13px] font-medium text-sidebar-foreground shadow-[inset_0_1px_0_rgba(255,255,255,0.04)] transition-[width,height,padding,gap,color,background-color,transform,box-shadow] duration-[180ms] ease-[var(--kocteau-ease)] hover:bg-[var(--kocteau-surface-control-hover)] hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.06),0_8px_24px_rgba(0,0,0,0.24)] active:scale-[0.96] group-data-[collapsible=icon]:mx-auto group-data-[collapsible=icon]:size-9 group-data-[collapsible=icon]:!justify-center group-data-[collapsible=icon]:gap-0 group-data-[collapsible=icon]:px-0"
               >
                 <span className="inline-flex min-w-0 items-center justify-center gap-2 transition-[gap] duration-[180ms] ease-[var(--kocteau-ease)] group-data-[collapsible=icon]:gap-0">
-                  <NotePencilIcon className="size-4 shrink-0" weight="regular" />
+                  <ReviewGlyphIcon className="size-4 shrink-0" />
                   <span className="kocteau-sidebar-label">{reviewEntryLabel}</span>
                 </span>
-                <span className="kocteau-sidebar-shortcut ml-auto">
+                <span className="kocteau-sidebar-shortcut">
                   <Kbd className="border border-sidebar-border/80 bg-foreground/[0.06] px-1.5 text-[0.6rem] text-muted-foreground">
                     N
                   </Kbd>

--- a/apps/web/components/app-sidebar.tsx
+++ b/apps/web/components/app-sidebar.tsx
@@ -9,12 +9,12 @@ import {
   ChatCircleTextIcon,
   HouseIcon,
   MagnifyingGlassIcon,
+  NotePencilIcon,
 } from "@phosphor-icons/react";
 import BrandLogo from "@/components/brand-logo";
 import NewReviewDialog from "@/components/new-review-dialog";
 import { NavOwnedReviews } from "@/components/nav-owned-reviews";
 import PrefetchLink from "@/components/prefetch-link";
-import ReviewGlyphIcon from "@/components/review-glyph-icon";
 import { NavMain } from "@/components/nav-main";
 import { NavSecondary } from "@/components/nav-secondary";
 import { Kbd } from "@/components/ui/kbd";
@@ -172,13 +172,13 @@ export default function AppSidebar({
               <button
                 type="button"
                 aria-label={reviewEntryLabel}
-                className="flex h-9 w-full items-center justify-between overflow-hidden rounded-[0.7rem] border border-sidebar-border/70 bg-[var(--kocteau-surface-control)] px-2.5 text-[13px] font-medium text-sidebar-foreground shadow-[inset_0_1px_0_rgba(255,255,255,0.04)] transition-[width,height,padding,gap,color,background-color,transform,box-shadow] duration-[180ms] ease-[var(--kocteau-ease)] hover:bg-[var(--kocteau-surface-control-hover)] hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.06),0_8px_24px_rgba(0,0,0,0.24)] active:scale-[0.96] group-data-[collapsible=icon]:mx-auto group-data-[collapsible=icon]:size-9 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:gap-0 group-data-[collapsible=icon]:px-0"
+                className="flex h-9 w-full items-center justify-start gap-2 overflow-hidden rounded-[0.7rem] border border-sidebar-border/70 bg-[var(--kocteau-surface-control)] px-2.5 text-[13px] font-medium text-sidebar-foreground shadow-[inset_0_1px_0_rgba(255,255,255,0.04)] transition-[width,height,padding,gap,color,background-color,transform,box-shadow] duration-[180ms] ease-[var(--kocteau-ease)] hover:bg-[var(--kocteau-surface-control-hover)] hover:shadow-[inset_0_1px_0_rgba(255,255,255,0.06),0_8px_24px_rgba(0,0,0,0.24)] active:scale-[0.96] group-data-[collapsible=icon]:mx-auto group-data-[collapsible=icon]:size-9 group-data-[collapsible=icon]:!justify-center group-data-[collapsible=icon]:gap-0 group-data-[collapsible=icon]:px-0"
               >
-                <span className="inline-flex min-w-0 items-center gap-2 transition-[gap] duration-[180ms] ease-[var(--kocteau-ease)] group-data-[collapsible=icon]:gap-0">
-                  <ReviewGlyphIcon className="size-4 shrink-0" />
+                <span className="inline-flex min-w-0 items-center justify-center gap-2 transition-[gap] duration-[180ms] ease-[var(--kocteau-ease)] group-data-[collapsible=icon]:gap-0">
+                  <NotePencilIcon className="size-4 shrink-0" weight="regular" />
                   <span className="kocteau-sidebar-label">{reviewEntryLabel}</span>
                 </span>
-                <span className="kocteau-sidebar-shortcut ml-2">
+                <span className="kocteau-sidebar-shortcut ml-auto">
                   <Kbd className="border border-sidebar-border/80 bg-foreground/[0.06] px-1.5 text-[0.6rem] text-muted-foreground">
                     N
                   </Kbd>

--- a/apps/web/components/auth/auth-form-shell.tsx
+++ b/apps/web/components/auth/auth-form-shell.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import Image from "next/image";
 import type { ReactNode } from "react";
 import { ChevronLeft } from "lucide-react";
 import BrandLogo from "@/components/brand-logo";
@@ -32,6 +33,16 @@ export default function AuthFormShell({
 }: AuthFormShellProps) {
   return (
     <main className="kocteau-auth-background relative isolate flex overflow-hidden bg-background text-foreground">
+      <Image
+        src="/background-auth.webp"
+        alt=""
+        fill
+        priority
+        sizes="100vw"
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 z-0 object-cover"
+      />
+
       <Link
         href="/"
         className="absolute left-4 top-4 z-10 inline-flex h-9 items-center gap-1.5 rounded-[0.45rem] px-2.5 text-xs font-medium text-muted-foreground transition-[background-color,color,transform] duration-150 ease-out hover:bg-white/[0.055] hover:text-foreground active:scale-[0.96] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/35 sm:left-6 sm:top-6"
@@ -40,7 +51,7 @@ export default function AuthFormShell({
         Home
       </Link>
 
-      <div className="relative z-[1] mx-auto flex min-h-full w-full items-center justify-center px-5 py-16 sm:px-8">
+      <div className="relative z-[3] mx-auto flex min-h-full w-full items-center justify-center px-5 py-16 sm:px-8">
         <div className={cn("w-full max-w-[25.75rem]", widthClassName)}>
           <div className={cn("flex flex-col gap-6", className)}>
             <FieldGroup className="gap-6">

--- a/apps/web/components/feed-review-list.tsx
+++ b/apps/web/components/feed-review-list.tsx
@@ -312,7 +312,15 @@ export default function FeedReviewList({
         </div>
       ) : (
         <p className="py-3 text-center text-xs text-muted-foreground">
-          You are all caught up.
+          created by{" "}
+          <Link
+            href="https://francozeta.vercel.app/"
+            target="_blank"
+            rel="noreferrer"
+            className="font-medium text-foreground underline underline-offset-4"
+          >
+            francozeta
+          </Link>
         </p>
       )}
     </div>

--- a/apps/web/components/feed-view-tabs.tsx
+++ b/apps/web/components/feed-view-tabs.tsx
@@ -42,32 +42,16 @@ export default function FeedViewTabs({
   fullWidth = false,
   className,
 }: FeedViewTabsProps) {
-  const activeIndex = feedViews.findIndex((view) => view.value === activeView);
   const prefersReducedMotion = useReducedMotion();
 
   return (
     <div
       className={cn(
-        "kocteau-feed-tabs mobile-liquid-panel relative grid min-w-0 grid-cols-3 gap-0.5 overflow-hidden rounded-[var(--kocteau-radius-control)] p-0.5",
+        "kocteau-feed-tabs relative grid min-w-0 grid-cols-3 gap-1 overflow-visible rounded-[var(--kocteau-radius-control)] p-0.5",
         fullWidth ? "w-full" : "w-full max-w-[17.25rem] lg:w-[17.25rem]",
         className,
       )}
     >
-      <span
-        aria-hidden="true"
-        className={cn(
-          "pointer-events-none absolute left-1/3 top-1/2 h-5 w-px -translate-x-1/2 -translate-y-1/2 rounded-full bg-border/42 transition-opacity max-md:hidden",
-          (activeIndex === 0 || activeIndex === 1) && "opacity-0",
-        )}
-      />
-      <span
-        aria-hidden="true"
-        className={cn(
-          "pointer-events-none absolute left-2/3 top-1/2 h-5 w-px -translate-x-1/2 -translate-y-1/2 rounded-full bg-border/42 transition-opacity max-md:hidden",
-          (activeIndex === 1 || activeIndex === 2) && "opacity-0",
-        )}
-      />
-
       {feedViews.map((view) => {
         const isActive = activeView === view.value;
 
@@ -77,7 +61,7 @@ export default function FeedViewTabs({
             href={getFeedViewHref(view.value)}
             aria-current={isActive ? "page" : undefined}
             className={cn(
-              "relative z-10 inline-flex h-8 items-center justify-center rounded-[0.62rem] px-2.5 text-[13px] font-medium text-muted-foreground/84 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/70 focus-visible:ring-offset-0",
+              "relative z-10 inline-flex h-8 items-center justify-center rounded-[0.52rem] px-2.5 text-[13px] font-medium text-muted-foreground/78 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/70 focus-visible:ring-offset-0",
               fullWidth ? "min-w-0 px-2" : "min-w-[5.1rem]",
               isActive ? "text-foreground" : "hover:text-foreground",
             )}
@@ -85,7 +69,7 @@ export default function FeedViewTabs({
             {isActive ? (
               <motion.span
                 layoutId="feed-tab-active"
-                className="kocteau-feed-tab-active absolute inset-0 rounded-[0.62rem]"
+                className="kocteau-feed-tab-active absolute inset-x-1 inset-y-1 rounded-[0.44rem]"
                 transition={
                   prefersReducedMotion
                     ? {

--- a/apps/web/components/nav-user.tsx
+++ b/apps/web/components/nav-user.tsx
@@ -114,9 +114,9 @@ export function NavUser({
                 </SidebarMenuButton>
               </DropdownMenuTrigger>
               <DropdownMenuContent
-                className="w-(--radix-dropdown-menu-trigger-width) min-w-60 rounded-[0.9rem] border-border bg-popover ring-border/70"
-                side="bottom"
-                align="end"
+                className="w-[15rem] min-w-0 rounded-[0.9rem] border-sidebar-border/70 bg-[var(--kocteau-surface-control)] p-1.5 shadow-none ring-sidebar-border/60"
+                side="top"
+                align="start"
                 sideOffset={8}
               >
                 <DropdownMenuLabel className="p-0 font-normal">

--- a/apps/web/components/notification-list.tsx
+++ b/apps/web/components/notification-list.tsx
@@ -75,7 +75,7 @@ export default function NotificationList({
   return (
     <div
       className={cn(
-        compact ? "" : "divide-y divide-border/25 overflow-hidden rounded-[1.55rem] border border-border/30 bg-card/18",
+        compact ? "space-y-0.5 p-1.5" : "divide-y divide-border/25 overflow-hidden rounded-[1.55rem] border border-border/30 bg-card/18",
       )}
     >
       {entries.map((entry) => {
@@ -93,7 +93,7 @@ export default function NotificationList({
             <Link
               key={entry.kind === "single" ? notification.id : entry.id}
               href={href}
-              className="grid grid-cols-[1.5rem_minmax(0,1fr)_auto] items-center gap-2.5 border-b border-sidebar-border/52 px-3 py-2.5 text-left transition-colors last:border-b-0 hover:bg-sidebar-accent/52"
+              className="grid grid-cols-[1.5rem_minmax(0,1fr)_auto] items-center gap-2.5 rounded-[0.56rem] px-2 py-2.5 text-left transition-colors hover:bg-sidebar-accent/58"
             >
               <UserAvatar
                 avatarUrl={notification.actor?.avatar_url}

--- a/apps/web/components/notifications-button.tsx
+++ b/apps/web/components/notifications-button.tsx
@@ -90,6 +90,8 @@ export default function NotificationsButton({
     }
   }
 
+  const showViewAll = notifications.length >= 5 || unreadCount > notifications.length;
+
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
@@ -128,24 +130,26 @@ export default function NotificationsButton({
       >
         <PopoverHeader className="border-b border-sidebar-border/60 px-3 py-2.5">
           <div className="flex items-start justify-between gap-3">
-            <div className="min-w-0 space-y-0.5">
+            <div className="min-w-0">
               <PopoverTitle className="text-[13px] font-medium text-sidebar-foreground">Activity</PopoverTitle>
-              <PopoverDescription className="truncate text-[11px] text-sidebar-foreground/58">
-                {unreadCount > 0
-                  ? `${unreadCount} unread right now`
-                  : "You’re all caught up"}
-              </PopoverDescription>
+              {unreadCount > 0 ? (
+                <PopoverDescription className="truncate text-[11px] text-sidebar-foreground/58">
+                  {unreadCount} unread
+                </PopoverDescription>
+              ) : null}
             </div>
-            <Link
-              href="/notifications"
-              className="shrink-0 pt-0.5 text-[11px] font-medium text-sidebar-foreground/58 transition-colors hover:text-sidebar-foreground"
-            >
-              View all
-            </Link>
+            {showViewAll ? (
+              <Link
+                href="/notifications"
+                className="shrink-0 pt-0.5 text-[11px] font-medium text-sidebar-foreground/58 transition-colors hover:text-sidebar-foreground"
+              >
+                View all
+              </Link>
+            ) : null}
           </div>
         </PopoverHeader>
 
-        <ScrollArea className="max-h-[18rem]">
+        <ScrollArea className="max-h-[24rem]">
           <div>
             {isLoadingNotifications ? (
               <div className="flex justify-center px-3 py-7">
@@ -172,7 +176,7 @@ export default function NotificationsButton({
                 onMarkAsRead={handleMarkAsRead}
               />
             ) : (
-              <div className="flex min-h-32 flex-col items-center justify-center gap-3 px-4 py-8 text-center">
+              <div className="flex min-h-40 flex-col items-center justify-center gap-3 px-4 py-9 text-center">
                 <span className="flex size-8 items-center justify-center rounded-full bg-sidebar-accent text-sidebar-foreground/62">
                   <BellSimpleIcon className="size-4" />
                 </span>

--- a/apps/web/components/ui/tooltip.tsx
+++ b/apps/web/components/ui/tooltip.tsx
@@ -32,7 +32,7 @@ function TooltipTrigger({
 
 function TooltipContent({
   className,
-  sideOffset = 0,
+  sideOffset = 8,
   children,
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Content>) {
@@ -42,13 +42,12 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          "z-50 inline-flex w-fit max-w-xs origin-(--radix-tooltip-content-transform-origin) items-center gap-1.5 rounded-[0.58rem] border border-border/55 bg-[var(--kocteau-canvas)] px-2.5 py-1.5 text-[11px] font-medium text-foreground/88 shadow-[0_10px_28px_rgba(0,0,0,0.34)] has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          "z-50 inline-flex w-fit max-w-xs origin-(--radix-tooltip-content-transform-origin) items-center gap-1.5 rounded-full border border-border/50 bg-[var(--kocteau-canvas)] px-2.5 py-1 text-[11px] font-medium leading-4 text-foreground/88 shadow-[0_8px_24px_rgba(0,0,0,0.32)] has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-full data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           className
         )}
         {...props}
       >
         {children}
-        <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] border-l border-t border-border/55 bg-[var(--kocteau-canvas)] fill-[var(--kocteau-canvas)]" />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   )

--- a/apps/web/components/who-to-follow-rail.tsx
+++ b/apps/web/components/who-to-follow-rail.tsx
@@ -12,6 +12,14 @@ type WhoToFollowRailProps = {
   isAuthenticated: boolean;
 };
 
+const footerLinks = [
+  "Terms",
+  "Privacy",
+  "Cookies",
+  "Accessibility",
+  "More",
+];
+
 function useDesktopRail() {
   const [isDesktop, setIsDesktop] = useState(false);
 
@@ -50,14 +58,14 @@ export default function WhoToFollowRail({
         {isLoading ? (
           <WhoToFollowRailSkeleton showHeading={false} />
         ) : profiles.length > 0 ? (
-          <div className="border-t border-border/32">
+          <div>
             {profiles.map((profile) => {
               const primaryLabel = profile.display_name ?? `@${profile.username}`;
 
               return (
                 <div
                   key={profile.id}
-                  className="kocteau-rail-row border-b border-border/24 px-1 py-3"
+                  className="kocteau-rail-row rounded-[0.62rem] px-1 py-3"
                 >
                   <div className="flex items-start gap-2.5">
                     <PrefetchLink
@@ -100,10 +108,21 @@ export default function WhoToFollowRail({
             })}
           </div>
         ) : (
-          <div className="border-t border-border/28 px-1 py-3 text-[13px] text-muted-foreground/78">
+          <div className="px-1 py-3 text-[13px] text-muted-foreground/78">
             No writers to notice yet.
           </div>
         )}
+
+        <footer className="px-1 pt-2 text-[11px] leading-5 text-muted-foreground/52">
+          <div className="flex flex-wrap gap-x-2 gap-y-0.5">
+            {footerLinks.map((label) => (
+              <a key={label} href="#" className="transition-colors hover:text-muted-foreground">
+                {label}
+              </a>
+            ))}
+          </div>
+          <p>© 2026 Kocteau</p>
+        </footer>
       </div>
     </aside>
   );


### PR DESCRIPTION
## What changed

- Fixed the collapsed sidebar review action alignment.
- Restored the existing Kocteau review glyph used by other review CTAs.
- Prevented the hidden shortcut label from affecting collapsed sidebar layout.

## Why

The review action looked visually off-center because the hidden `N` shortcut still participated in flex layout through auto margin. The icon now centers consistently with the other sidebar icons.

## Testing

- [x] Ran `pnpm check`
- [x] Added screenshots or a short recording for visible web UI changes
- [x] Confirmed this does not touch auth, Supabase, recommendations, analytics, CI, or release behavior

## Changelog impact

No manual `CHANGELOG.md` edit is required. Release Please generates release notes from PR titles and squash commits.

- [x] User-facing web change
- [ ] Developer experience or documentation change
- [ ] Internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified feed tab appearance with cleaner styling
  * Improved sidebar navigation layout in collapsed mode with better spacing
  * Enhanced authentication screen with updated background design
  * Refined tooltip positioning and styling with increased spacing
  * Updated user dropdown menu alignment and styling
  * Visual refinements to notification list and popover layout
  * Improved "who to follow" rail styling with added footer links
  * Better overall spacing and alignment across UI components

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/francozeta/kocteau/pull/26?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->