### PR TITLE
feat(web): refine profile settings and main rail

### DIFF
--- a/apps/web/app/(main)/layout.tsx
+++ b/apps/web/app/(main)/layout.tsx
@@ -5,6 +5,7 @@ import AppSidebar from "@/components/app-sidebar";
 import GlobalShortcuts from "@/components/global-shortcuts";
 import MobileBottomBar from "@/components/mobile-bottom-bar";
 import { RouteHeaderProvider } from "@/components/route-header-context";
+import WhoToFollowRail from "@/components/who-to-follow-rail";
 import { getCurrentOnboardingState, getCurrentUser, getCurrentViewerProfile } from "@/lib/auth/server";
 import type { SidebarOwnedReview } from "@/lib/types/sidebar";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
@@ -49,7 +50,12 @@ export default async function MainLayout({ children }: { children: React.ReactNo
             <div className="kocteau-app-frame flex min-h-svh flex-1 flex-col lg:min-h-0 lg:h-full lg:overflow-hidden lg:rounded-[0.8rem]">
               <Header profile={safeProfile} />
               <main className="mx-auto flex min-h-0 w-full max-w-[82rem] flex-1 flex-col px-3.5 pt-[calc(env(safe-area-inset-top)+4rem)] pb-[calc(env(safe-area-inset-bottom)+6.5rem)] sm:px-6 sm:pt-[calc(env(safe-area-inset-top)+4.75rem)] sm:pb-28 lg:max-w-none lg:overflow-y-auto lg:px-7 lg:pt-3 lg:pb-6 xl:px-8">
-                {children}
+                <div className="mx-auto grid min-h-0 w-full max-w-[76rem] flex-1 gap-5 lg:grid-cols-[minmax(0,44rem)_16rem] lg:items-start lg:justify-center xl:gap-6">
+                  <div className="min-w-0">
+                    {children}
+                  </div>
+                  <WhoToFollowRail isAuthenticated={Boolean(safeProfile)} />
+                </div>
               </main>
             </div>
             <MobileBottomBar profile={safeProfile} />

--- a/apps/web/app/(main)/page.tsx
+++ b/apps/web/app/(main)/page.tsx
@@ -3,7 +3,6 @@ import FeedViewTabs from "@/components/feed-view-tabs";
 import FeedReviewList from "@/components/feed-review-list";
 import JsonLd from "@/components/json-ld";
 import { OnboardingWelcomeFromUrl } from "@/components/auth/onboarding-welcome-dialog";
-import WhoToFollowRail from "@/components/who-to-follow-rail";
 import { getCurrentUser, getCurrentViewerProfile } from "@/lib/auth/server";
 import { isFeedView } from "@/lib/feed-view";
 import { createPageMetadata } from "@/lib/metadata";
@@ -114,8 +113,17 @@ export default async function HomePage({
       <JsonLd data={feedStructuredData} id="home-structured-data" />
       {params.welcome === "kocteau" ? <OnboardingWelcomeFromUrl /> : null}
       <div className="flex h-full min-h-0 flex-col">
-        <section className="mx-auto w-full max-w-5xl space-y-5 sm:space-y-6 lg:hidden">
-          {user ? <FeedViewTabs activeView={tabActiveView} fullWidth /> : null}
+        <section className="mx-auto w-full max-w-5xl space-y-5 sm:space-y-6 lg:mx-0 lg:max-w-none lg:space-y-4">
+          {user ? (
+            <>
+              <div className="lg:hidden">
+                <FeedViewTabs activeView={tabActiveView} fullWidth />
+              </div>
+              <div className="hidden justify-start lg:flex">
+                <FeedViewTabs activeView={tabActiveView} />
+              </div>
+            </>
+          ) : null}
 
           <div className="space-y-4">
             <FeedReviewList
@@ -125,32 +133,6 @@ export default async function HomePage({
               viewer={viewerProfile}
               starterTracks={starterTracks}
             />
-          </div>
-        </section>
-
-        <section className="hidden lg:block">
-          <div className="mx-auto w-full max-w-[76rem]">
-            <div
-              className="mx-auto grid w-full gap-5 lg:grid-cols-[minmax(0,44rem)_16rem] lg:justify-center xl:gap-6"
-            >
-              <div className="min-w-0 space-y-4">
-                {user ? (
-                  <div className="flex justify-start">
-                    <FeedViewTabs activeView={tabActiveView} />
-                  </div>
-                ) : null}
-
-                <FeedReviewList
-                  view={activeView}
-                  initialPage={feedData}
-                  isAuthenticated={Boolean(user)}
-                  viewer={viewerProfile}
-                  starterTracks={starterTracks}
-                />
-              </div>
-
-              <WhoToFollowRail isAuthenticated={Boolean(user)} />
-            </div>
           </div>
         </section>
       </div>

--- a/apps/web/app/(main)/u/[username]/page.tsx
+++ b/apps/web/app/(main)/u/[username]/page.tsx
@@ -1,11 +1,8 @@
 import type { Metadata } from "next";
-import { Suspense } from "react";
 import { notFound } from "next/navigation";
 import JsonLd from "@/components/json-ld";
 import ProfilePageHeader from "@/components/profile-page-header";
 import ProfileRecentReviewsSection from "@/components/profile-recent-reviews-section";
-import { SavedReviewsSectionSkeleton } from "@/components/route-loading-skeletons";
-import SavedReviewsList from "@/components/saved-reviews-list";
 import type { ReviewCardAuthor } from "@/components/review-card";
 import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from "@/components/ui/empty";
 import { ProfileReviewCard } from "@/components/review-route-cards-server";
@@ -20,7 +17,6 @@ import {
   type ProfileReview,
 } from "@/lib/queries/profiles";
 import { getViewerFollowsProfile } from "@/lib/queries/profile-follows";
-import { getViewerSavedReviewsBundle } from "@/lib/queries/viewer";
 import { buildProfilePageJsonLd } from "@/lib/structured-data";
 
 function applyViewerStateToReview(
@@ -118,7 +114,7 @@ export default async function UserProfilePage({
   };
 
   return (
-    <div className="mx-auto w-full max-w-6xl space-y-4 sm:space-y-5">
+    <div className="w-full space-y-4 sm:space-y-5">
       <JsonLd
         data={buildProfilePageJsonLd({
           profile,
@@ -157,8 +153,8 @@ export default async function UserProfilePage({
       <div className="space-y-5">
         {hydratedPinnedReview ? (
           <section className="space-y-3">
-            <div className="border-b border-border/32 pb-3 md:border-border/25">
-              <h2 className="text-[11px] font-medium uppercase tracking-[0.22em] text-muted-foreground">
+            <div>
+              <h2 className="text-sm font-semibold tracking-[-0.01em] text-foreground/92">
                 Pinned
               </h2>
             </div>
@@ -180,7 +176,7 @@ export default async function UserProfilePage({
             <ProfileRecentReviewsSection reviews={hydratedReviews} />
 
             <div className="space-y-4 pt-2">
-              <div className="border-b border-border/32 pb-3 md:border-border/25">
+              <div>
                 <h2 className="text-base font-semibold tracking-[-0.01em] text-foreground">
                   Reviews
                 </h2>
@@ -209,50 +205,7 @@ export default async function UserProfilePage({
               </EmptyHeader>
             </Empty>
         ) : null}
-
-        {isOwnProfile && user?.id ? (
-          <Suspense fallback={<SavedReviewsSectionFallback />}>
-            <SavedReviewsSection userId={user.id} isAuthenticated={Boolean(user)} />
-          </Suspense>
-        ) : null}
       </div>
     </div>
   );
-}
-
-async function SavedReviewsSection({
-  userId,
-  isAuthenticated,
-}: {
-  userId: string;
-  isAuthenticated: boolean;
-}) {
-  const { reviews: savedReviews } = await getViewerSavedReviewsBundle(userId);
-
-  return (
-    <section className="space-y-4 border-t border-border/34 pt-8 [contain-intrinsic-size:720px] [content-visibility:auto] md:border-border/30">
-      <div className="border-b border-border/32 pb-4 md:border-border/25">
-        <h2 className="text-[11px] font-medium uppercase tracking-[0.22em] text-muted-foreground">
-          Saved
-        </h2>
-      </div>
-
-      <SavedReviewsList
-        initialReviews={savedReviews}
-        userId={userId}
-        isAuthenticated={isAuthenticated}
-        emptyState={
-        <Empty className="rounded-[1.65rem] border-border/32 bg-card/24 px-6 py-9 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)] md:border-border/20 md:bg-card/18">
-          <EmptyHeader>
-            <EmptyTitle>No saved reviews</EmptyTitle>
-          </EmptyHeader>
-        </Empty>
-        }
-      />
-    </section>
-  );
-}
-
-function SavedReviewsSectionFallback() {
-  return <SavedReviewsSectionSkeleton />;
 }

--- a/apps/web/components/avatar-upload-trigger.tsx
+++ b/apps/web/components/avatar-upload-trigger.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { DragEventHandler } from "react";
-import { Camera, CircleUserRoundIcon } from "lucide-react";
+import { CameraIcon, UserCircleIcon } from "@phosphor-icons/react";
 import { cn } from "@/lib/utils";
 
 type AvatarUploadTriggerProps = {
@@ -55,9 +55,8 @@ export default function AvatarUploadTrigger({
       type="button"
       aria-label={previewUrl ? "Change image" : "Upload image"}
       className={cn(
-        "group relative inline-flex items-center justify-center overflow-hidden rounded-full border border-input border-dashed bg-background outline-none transition-colors hover:bg-accent/50 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
-        previewUrl && "border-transparent bg-transparent",
-        isDragging && "border-foreground/40 bg-accent/50",
+        "group relative inline-flex items-center justify-center overflow-hidden rounded-full border border-white/10 bg-black/24 p-1 outline-none shadow-[inset_0_1px_0_rgba(255,255,255,0.04),0_16px_42px_rgba(0,0,0,0.24)] transition-[background-color,border-color,box-shadow,transform] duration-150 ease-out hover:border-white/16 hover:bg-white/[0.055] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/28",
+        isDragging && "border-foreground/38 bg-white/[0.07] ring-2 ring-ring/24",
         scale.button,
       )}
       data-dragging={isDragging || undefined}
@@ -72,19 +71,22 @@ export default function AvatarUploadTrigger({
         <img
           src={previewUrl}
           alt={alt}
-          className="size-full object-cover"
+          className="size-full rounded-full object-cover"
         />
       ) : (
-        <CircleUserRoundIcon className={cn("text-muted-foreground/70", scale.icon)} />
+        <UserCircleIcon
+          className={cn("text-muted-foreground/70", scale.icon)}
+          weight="regular"
+        />
       )}
 
       <span
         className={cn(
-          "absolute right-0 bottom-0 inline-flex items-center justify-center rounded-full border border-background/80 bg-background/92 text-muted-foreground shadow-sm transition-colors group-hover:text-foreground",
+          "absolute bottom-0 right-0 inline-flex items-center justify-center rounded-full bg-foreground text-background shadow-[0_0_0_3px_var(--kocteau-surface),0_10px_28px_rgba(0,0,0,0.26)] transition-transform duration-150 ease-out group-hover:scale-[1.04]",
           scale.badge,
         )}
       >
-        <Camera className={scale.badgeIcon} />
+        <CameraIcon className={scale.badgeIcon} weight="bold" />
       </span>
     </button>
   );

--- a/apps/web/components/feed-loading-skeletons.tsx
+++ b/apps/web/components/feed-loading-skeletons.tsx
@@ -230,7 +230,7 @@ export default function FeedLoadingSkeleton() {
       aria-label="Loading feed"
       className="flex h-full min-h-0 flex-col"
     >
-      <section className="mx-auto flex w-full max-w-5xl flex-col gap-5 sm:gap-6 lg:hidden">
+      <section className="mx-auto flex w-full max-w-5xl flex-col gap-5 sm:gap-6 lg:mx-0 lg:max-w-none lg:gap-4">
         <div className="flex flex-col gap-2.5">
           <div className="min-w-0">
             <FeedSearchSkeleton />
@@ -241,28 +241,6 @@ export default function FeedLoadingSkeleton() {
         <div className="flex flex-col gap-4">
           <FeedStarterLayerSkeleton />
           <FeedReviewStackSkeleton />
-        </div>
-      </section>
-
-      <section className="hidden lg:block">
-        <div className="mx-auto w-full max-w-[76rem]">
-          <div className="mx-auto grid w-full gap-5 lg:grid-cols-[minmax(0,44rem)_16rem] lg:justify-center xl:gap-6">
-            <div className="flex min-w-0 flex-col gap-4">
-              <div className="grid gap-2.5 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-center">
-                <div className="min-w-0">
-                  <FeedSearchSkeleton />
-                </div>
-                <div className="justify-self-start lg:justify-self-end">
-                  <FeedControlsSkeleton />
-                </div>
-              </div>
-
-              <FeedStarterLayerSkeleton />
-              <FeedReviewStackSkeleton />
-            </div>
-
-            <WhoToFollowRailSkeleton />
-          </div>
         </div>
       </section>
     </div>

--- a/apps/web/components/profile-editor-form.tsx
+++ b/apps/web/components/profile-editor-form.tsx
@@ -2,7 +2,13 @@
 
 import { startTransition, useEffect, useMemo, useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
-import { ArrowLeft, ArrowRight, Check, LoaderCircle } from "lucide-react";
+import {
+  ArrowLeftIcon,
+  ArrowRightIcon,
+  CheckIcon,
+  SpinnerGapIcon,
+  VinylRecordIcon,
+} from "@phosphor-icons/react";
 import AvatarUploadTrigger from "@/components/avatar-upload-trigger";
 import { supabaseBrowser } from "@/lib/supabase/client";
 import AvatarCropDialog from "@/components/avatar-crop-dialog";
@@ -429,7 +435,7 @@ export default function ProfileEditorForm({
                     />
                     {selected ? (
                       <span className="absolute right-2 top-2 inline-flex h-5 w-5 items-center justify-center rounded-full bg-foreground text-background">
-                        <Check className="size-3" />
+                        <CheckIcon className="size-3" weight="bold" />
                       </span>
                     ) : null}
                     <span className="sr-only">{preset.label}</span>
@@ -451,10 +457,188 @@ export default function ProfileEditorForm({
               className="gap-2"
             >
               Next
-              <ArrowRight className="size-4" />
+              <ArrowRightIcon className="size-4" weight="bold" />
             </Button>
           </div>
         </div>
+      </div>
+    );
+  }
+
+  function renderSettingsFields() {
+    const previewUrl = avatarPreview ?? createAvatarPresetDataUrl(avatarPresets[0].id, 640);
+    const showSettingsAvatarSection = settingsSection === "all" || settingsSection === "avatar";
+    const showSettingsProfileSection = settingsSection === "all" || settingsSection === "profile";
+    const showSettingsLinksSection = settingsSection === "all" || settingsSection === "links";
+    const fieldClassName =
+      "h-9 rounded-[0.58rem] border-border/18 bg-black/22 px-3 text-[13px] shadow-none placeholder:text-muted-foreground/42 focus-visible:border-border/42 focus-visible:ring-2 focus-visible:ring-ring/24";
+    const textareaClassName =
+      "min-h-24 resize-none rounded-[0.58rem] border-border/18 bg-black/22 px-3 py-2.5 text-[13px] leading-5 shadow-none placeholder:text-muted-foreground/42 focus-visible:border-border/42 focus-visible:ring-2 focus-visible:ring-ring/24";
+    const labelClassName = "text-[12px] font-medium text-foreground/82";
+
+    return (
+      <div className="space-y-6">
+        {showSettingsAvatarSection ? (
+        <section className="space-y-3">
+          <Label className={cn("justify-center", labelClassName)}>Avatar</Label>
+          <ProfileSettingsAvatarControl
+            previewUrl={previewUrl}
+            selectedPresetId={selectedPresetId}
+            isDragging={isAvatarDragging}
+            onAvatarClick={openAvatarPicker}
+            onAvatarDragEnter={handleAvatarDragEnter}
+            onAvatarDragLeave={handleAvatarDragLeave}
+            onAvatarDragOver={handleAvatarDragOver}
+            onAvatarDrop={handleAvatarDrop}
+            onPresetSelect={handlePresetSelect}
+          />
+
+          {avatarUploadErrors[0] ? (
+            <p className="text-center text-xs text-destructive">{avatarUploadErrors[0]}</p>
+          ) : null}
+        </section>
+        ) : null}
+
+        {showSettingsProfileSection ? (
+        <section className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="display-name" className={labelClassName}>
+              Display name
+            </Label>
+            <Input
+              id="display-name"
+              value={displayName}
+              onChange={(event) => {
+                setDisplayName(event.target.value);
+                setFieldErrors((current) => ({ ...current, display_name: undefined }));
+              }}
+              placeholder="Fran Cocteau"
+              disabled={saving}
+              aria-invalid={Boolean(fieldErrors.display_name)}
+              className={fieldClassName}
+            />
+            <FieldError>{fieldErrors.display_name}</FieldError>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="username" className={labelClassName}>
+              Username
+            </Label>
+            <Input
+              id="username"
+              value={username}
+              onChange={(event) => {
+                setUsername(event.target.value);
+                setFieldErrors((current) => ({ ...current, username: undefined }));
+              }}
+              placeholder="fran_cocteau"
+              disabled={saving}
+              aria-invalid={Boolean(fieldErrors.username)}
+              className={fieldClassName}
+            />
+            <FieldError>{fieldErrors.username}</FieldError>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="bio" className={labelClassName}>
+              Bio
+            </Label>
+            <Textarea
+              id="bio"
+              value={bio}
+              onChange={(event) => {
+                setBio(event.target.value);
+                setFieldErrors((current) => ({ ...current, bio: undefined }));
+              }}
+              placeholder="Taste, mood, records in rotation."
+              disabled={saving}
+              maxLength={280}
+              aria-invalid={Boolean(fieldErrors.bio)}
+              className={textareaClassName}
+            />
+            <FieldError>{fieldErrors.bio}</FieldError>
+          </div>
+        </section>
+        ) : null}
+
+        {showSettingsLinksSection ? (
+        <section className="space-y-4">
+          <p className="text-[12px] font-medium text-foreground/82">Music links</p>
+
+          <div className="space-y-2">
+            <Label htmlFor="spotify-url" className={labelClassName}>
+              Spotify URL
+            </Label>
+            <Input
+              id="spotify-url"
+              value={spotifyUrl}
+              onChange={(event) => {
+                setSpotifyUrl(event.target.value);
+                setFieldErrors((current) => ({ ...current, spotify_url: undefined }));
+              }}
+              placeholder="open.spotify.com/..."
+              disabled={saving}
+              aria-invalid={Boolean(fieldErrors.spotify_url)}
+              className={fieldClassName}
+            />
+            <FieldError>{fieldErrors.spotify_url}</FieldError>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="apple-music-url" className={labelClassName}>
+              Apple Music URL
+            </Label>
+            <Input
+              id="apple-music-url"
+              value={appleMusicUrl}
+              onChange={(event) => {
+                setAppleMusicUrl(event.target.value);
+                setFieldErrors((current) => ({ ...current, apple_music_url: undefined }));
+              }}
+              placeholder="music.apple.com/..."
+              disabled={saving}
+              aria-invalid={Boolean(fieldErrors.apple_music_url)}
+              className={fieldClassName}
+            />
+            <FieldError>{fieldErrors.apple_music_url}</FieldError>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="deezer-url" className={labelClassName}>
+              Deezer URL
+            </Label>
+            <Input
+              id="deezer-url"
+              value={deezerUrl}
+              onChange={(event) => {
+                setDeezerUrl(event.target.value);
+                setFieldErrors((current) => ({ ...current, deezer_url: undefined }));
+              }}
+              placeholder="deezer.com/..."
+              disabled={saving}
+              aria-invalid={Boolean(fieldErrors.deezer_url)}
+              className={fieldClassName}
+            />
+            <FieldError>{fieldErrors.deezer_url}</FieldError>
+          </div>
+        </section>
+        ) : null}
+
+        <Button
+          type="button"
+          onClick={onSubmit}
+          disabled={saving}
+          className="h-9 w-full rounded-[0.58rem] text-[13px] font-semibold"
+        >
+          {saving ? (
+            <>
+              <SpinnerGapIcon className="size-4 animate-spin" />
+              Saving
+            </>
+          ) : (
+            "Save profile"
+          )}
+        </Button>
       </div>
     );
   }
@@ -541,7 +725,7 @@ export default function ProfileEditorForm({
                     />
                     {selected ? (
                       <span className="absolute right-1.5 top-1.5 inline-flex h-4 w-4 items-center justify-center rounded-full bg-foreground text-background">
-                        <Check className="size-2.5" />
+                        <CheckIcon className="size-2.5" weight="bold" />
                       </span>
                     ) : null}
                     <span className="sr-only">{preset.label}</span>
@@ -684,7 +868,7 @@ export default function ProfileEditorForm({
               disabled={saving}
               className="gap-2"
             >
-              <ArrowLeft className="size-4" />
+              <ArrowLeftIcon className="size-4" weight="bold" />
               Back
             </Button>
           ) : null}
@@ -692,7 +876,7 @@ export default function ProfileEditorForm({
           <Button type="button" onClick={onSubmit} disabled={saving}>
             {saving ? (
               <>
-                <LoaderCircle className="size-4 animate-spin" />
+                <SpinnerGapIcon className="size-4 animate-spin" />
                 Saving...
               </>
             ) : mode === "onboarding" ? (
@@ -750,8 +934,123 @@ export default function ProfileEditorForm({
           {step === 1 ? renderAvatarSelection() : renderIdentityFields()}
         </>
       ) : (
-        renderIdentityFields()
+        renderSettingsFields()
       )}
+    </div>
+  );
+}
+
+function ProfileSettingsAvatarControl({
+  previewUrl,
+  selectedPresetId,
+  isDragging,
+  onAvatarClick,
+  onAvatarDragEnter,
+  onAvatarDragLeave,
+  onAvatarDragOver,
+  onAvatarDrop,
+  onPresetSelect,
+}: {
+  previewUrl: string;
+  selectedPresetId: AvatarPresetId | null;
+  isDragging: boolean;
+  onAvatarClick: () => void;
+  onAvatarDragEnter: React.DragEventHandler<HTMLButtonElement>;
+  onAvatarDragLeave: React.DragEventHandler<HTMLButtonElement>;
+  onAvatarDragOver: React.DragEventHandler<HTMLButtonElement>;
+  onAvatarDrop: React.DragEventHandler<HTMLButtonElement>;
+  onPresetSelect: (presetId: AvatarPresetId) => void;
+}) {
+  const [isDiscPickerOpen, setIsDiscPickerOpen] = useState(false);
+
+  return (
+    <div className="relative mx-auto flex w-full max-w-[17rem] justify-center pb-12">
+      <div className="relative">
+        <button
+          type="button"
+          aria-label="Upload profile image"
+          onClick={onAvatarClick}
+          onDragEnter={onAvatarDragEnter}
+          onDragLeave={onAvatarDragLeave}
+          onDragOver={onAvatarDragOver}
+          onDrop={onAvatarDrop}
+          className={cn(
+            "group relative flex size-32 items-center justify-center rounded-full bg-black/24 p-1.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.05),0_18px_52px_rgba(0,0,0,0.32)] transition-[background-color,box-shadow,transform] duration-150 ease-out hover:bg-white/[0.055] active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/28",
+            isDragging && "bg-white/[0.07] ring-2 ring-ring/24",
+          )}
+        >
+          <span className="relative flex size-full items-center justify-center overflow-hidden rounded-full bg-background outline outline-1 outline-white/10">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={previewUrl}
+              alt=""
+              className="size-full rounded-full object-cover"
+            />
+            <span
+              aria-hidden="true"
+              className="absolute inset-0 rounded-full bg-black/0 transition-colors duration-150 ease-out group-hover:bg-black/12"
+            />
+          </span>
+        </button>
+
+        <button
+          type="button"
+          aria-label="Choose a Kocteau disc"
+          aria-expanded={isDiscPickerOpen}
+          onClick={() => setIsDiscPickerOpen((open) => !open)}
+          className={cn(
+            "absolute bottom-1 right-1 flex size-9 items-center justify-center rounded-full bg-foreground text-background shadow-[0_0_0_3px_var(--kocteau-surface),0_12px_32px_rgba(0,0,0,0.36)] transition-[background-color,box-shadow,transform] duration-150 ease-out hover:scale-[1.04] active:scale-[0.96] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30",
+            isDiscPickerOpen && "bg-background text-foreground shadow-[0_0_0_3px_var(--kocteau-surface),inset_0_0_0_1px_rgba(255,255,255,0.14)]",
+          )}
+        >
+          <VinylRecordIcon
+            className={cn(
+              "size-[1.15rem] transition-transform duration-150 ease-out",
+              isDiscPickerOpen && "rotate-45",
+            )}
+            weight="fill"
+          />
+        </button>
+      </div>
+
+      {isDiscPickerOpen ? (
+        <div className="absolute left-1/2 top-[calc(100%-2.3rem)] z-10 w-[15.5rem] -translate-x-1/2 rounded-[0.85rem] border border-border/24 bg-[var(--kocteau-surface)] p-2 shadow-[0_18px_54px_rgba(0,0,0,0.42)]">
+          <div className="grid grid-cols-6 gap-1.5">
+            {avatarPresets.map((preset) => {
+              const selected = selectedPresetId === preset.id;
+
+              return (
+                <button
+                  key={preset.id}
+                  type="button"
+                  aria-label={preset.label}
+                  aria-pressed={selected}
+                  onClick={() => {
+                    onPresetSelect(preset.id);
+                    setIsDiscPickerOpen(false);
+                  }}
+                  className={cn(
+                    "relative flex aspect-square items-center justify-center rounded-[0.58rem] bg-black/20 transition-[background-color,box-shadow,transform] hover:bg-white/[0.055] active:scale-[0.96] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/24",
+                    selected && "bg-white/[0.075] shadow-[inset_0_0_0_1px_rgba(255,255,255,0.18)]",
+                  )}
+                >
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src={createAvatarPresetDataUrl(preset.id, 160)}
+                    alt=""
+                    className="size-7 rounded-full object-cover outline outline-1 outline-white/10"
+                  />
+                  {selected ? (
+                    <span className="absolute right-0.5 top-0.5 inline-flex size-3.5 items-center justify-center rounded-full bg-foreground text-background">
+                      <CheckIcon className="size-2.5" weight="bold" />
+                    </span>
+                  ) : null}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/components/profile-recent-reviews-section.tsx
+++ b/apps/web/components/profile-recent-reviews-section.tsx
@@ -92,7 +92,7 @@ export default function ProfileRecentReviewsSection({
 
   return (
     <section className="space-y-3">
-      <div className="border-b border-border/32 pb-3 md:border-border/25">
+      <div>
         <h2 className="text-base font-semibold tracking-[-0.01em] text-foreground">
           Recent Activity
         </h2>

--- a/apps/web/components/profile-settings-dialog.tsx
+++ b/apps/web/components/profile-settings-dialog.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import { isValidElement, useMemo, useState } from "react";
-import { Disc3, Link2, UserRound } from "lucide-react";
+import {
+  LinkIcon,
+  UserCircleIcon,
+  VinylRecordIcon,
+  type Icon,
+} from "@phosphor-icons/react";
 import { buttonVariants } from "@/components/ui/button";
 import {
   DrawerBase,
@@ -15,10 +20,18 @@ import {
   DrawerBaseTrigger,
   DrawerBaseViewport,
 } from "@/components/ui/drawer-base";
-import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
-import { ScrollArea } from "@/components/ui/scroll-area";
-import UserAvatar from "@/components/user-avatar";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Kbd } from "@/components/ui/kbd";
 import ProfileEditorForm from "@/components/profile-editor-form";
+import UserAvatar from "@/components/user-avatar";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { cn } from "@/lib/utils";
 
@@ -56,26 +69,31 @@ export default function ProfileSettingsDialog({
   const open = controlledOpen ?? uncontrolledOpen;
   const [activeSection, setActiveSection] = useState<"profile" | "avatar" | "links">("profile");
 
-  const settingsNavItems = useMemo(() => ([
-    {
-      id: "profile" as const,
-      label: "Profile",
-      description: "Name, handle, bio",
-      icon: UserRound,
-    },
-    {
-      id: "avatar" as const,
-      label: "Avatar",
-      description: "Photo or default disc",
-      icon: Disc3,
-    },
-    {
-      id: "links" as const,
-      label: "Music links",
-      description: "Spotify, Apple Music, Deezer",
-      icon: Link2,
-    },
-  ]), []);
+  const settingsNavItems = useMemo(
+    () =>
+      [
+        {
+          id: "profile" as const,
+          label: "Profile",
+          icon: UserCircleIcon,
+        },
+        {
+          id: "avatar" as const,
+          label: "Avatar",
+          icon: VinylRecordIcon,
+        },
+        {
+          id: "links" as const,
+          label: "Music links",
+          icon: LinkIcon,
+        },
+      ] satisfies Array<{
+        id: "profile" | "avatar" | "links";
+        label: string;
+        icon: Icon;
+      }>,
+    [],
+  );
 
   function handleOpenChange(nextOpen: boolean) {
     if (controlledOpen === undefined) {
@@ -89,16 +107,23 @@ export default function ProfileSettingsDialog({
     onOpenChange?.(nextOpen);
   }
 
-  function setSection(sectionId: "profile" | "avatar" | "links") {
-    setActiveSection(sectionId);
-  }
+  const triggerNode = trigger ?? (
+    triggerLabel ? (
+      <button
+        type="button"
+        className={triggerClassName ?? buttonVariants({ variant: "outline", size: "sm" })}
+      >
+        {triggerLabel}
+      </button>
+    ) : null
+  );
+  const triggerElement = isValidElement(triggerNode) ? triggerNode : null;
 
-  const content = (
+  const form = (section: "profile" | "avatar" | "links" | "all") => (
     <ProfileEditorForm
       mode="settings"
       initialProfile={profile}
-      settingsLayout="panel"
-      settingsSection={isMobile ? "all" : activeSection}
+      settingsSection={section}
       onSaved={(updatedProfile) => {
         onProfileUpdate?.({
           username: updatedProfile.username,
@@ -114,102 +139,26 @@ export default function ProfileSettingsDialog({
     />
   );
 
-  const activeItem = settingsNavItems.find((item) => item.id === activeSection) ?? settingsNavItems[0];
-  const triggerNode = trigger ?? (
-    triggerLabel ? (
-      <button
-        type="button"
-        className={triggerClassName ?? buttonVariants({ variant: "outline", size: "sm" })}
-      >
-        {triggerLabel}
-      </button>
-    ) : null
-  );
-  const triggerElement = isValidElement(triggerNode) ? triggerNode : null;
-
   if (isMobile) {
     return (
       <DrawerBase open={open} onOpenChange={handleOpenChange} swipeDirection="down">
         {triggerElement ? <DrawerBaseTrigger render={triggerElement} /> : null}
         <DrawerBasePortal>
-          <DrawerBaseBackdrop />
-          <DrawerBaseViewport>
-            <DrawerBaseContent className="max-h-[92dvh]">
-              <DrawerBaseHandle />
-              <DrawerBaseHeader className="border-b border-border/34 px-5 py-4 text-left md:border-border/25">
-                <DrawerBaseTitle className="text-left">{activeItem.label}</DrawerBaseTitle>
-                <DrawerBaseDescription className="text-left">
-                  {activeItem.description}
+          <DrawerBaseBackdrop className="bg-black/84" />
+          <DrawerBaseViewport className="p-1.5">
+            <DrawerBaseContent className="mb-0 max-h-[min(92dvh,44rem)] !rounded-[1rem] !border border-border/44 bg-[var(--kocteau-surface)] shadow-[0_22px_80px_rgba(0,0,0,0.42)]">
+              <DrawerBaseHandle className="mt-2 h-1 w-9 bg-white/16" />
+              <DrawerBaseHeader className="px-4 pb-2 pt-3 text-left">
+                <DrawerBaseTitle className="!text-left text-[0.95rem] font-semibold">
+                  Settings Profile
+                </DrawerBaseTitle>
+                <DrawerBaseDescription className="sr-only">
+                  Update your Kocteau profile.
                 </DrawerBaseDescription>
               </DrawerBaseHeader>
 
-              <div className="border-b border-border/28 px-5 py-4 md:border-border/20">
-                <div className="rounded-[1.35rem] border border-border/34 bg-card/24 p-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)] md:border-border/20 md:bg-card/18">
-                  <div className="flex items-center gap-3">
-                    <UserAvatar
-                      avatarUrl={profile.avatar_url}
-                      displayName={profile.display_name}
-                      username={profile.username}
-                      className="size-11"
-                      initialsLength={2}
-                    />
-                    <div className="min-w-0">
-                      <p className="truncate text-sm font-medium text-foreground">
-                        {profile.display_name ?? `@${profile.username}`}
-                      </p>
-                      <p className="truncate text-xs text-muted-foreground">
-                        @{profile.username}
-                      </p>
-                    </div>
-                  </div>
-                </div>
-
-                <ScrollArea className="mt-3 w-full whitespace-nowrap">
-                  <div className="flex gap-2 pb-1">
-                    {settingsNavItems.map((item) => {
-                      const Icon = item.icon;
-                      const active = activeSection === item.id;
-
-                      return (
-                        <button
-                          key={item.id}
-                          type="button"
-                          onClick={() => setSection(item.id)}
-                          className={cn(
-                            "inline-flex items-center gap-2 rounded-full border px-3 py-2 text-sm transition-colors",
-                            active
-                              ? "border-border/36 bg-card/30 text-foreground md:border-border/30 md:bg-card/26"
-                              : "border-border/26 bg-card/18 text-muted-foreground hover:text-foreground md:border-border/15 md:bg-card/10",
-                          )}
-                        >
-                          <Icon className="size-4" />
-                          {item.label}
-                        </button>
-                      );
-                    })}
-                  </div>
-                </ScrollArea>
-              </div>
-
-              <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4">
-                <ProfileEditorForm
-                  mode="settings"
-                  initialProfile={profile}
-                  settingsLayout="panel"
-                  settingsSection={activeSection}
-                  onSaved={(updatedProfile) => {
-                    onProfileUpdate?.({
-                      username: updatedProfile.username,
-                      display_name: updatedProfile.display_name,
-                      avatar_url: updatedProfile.avatar_url,
-                      bio: updatedProfile.bio,
-                      spotify_url: updatedProfile.spotify_url,
-                      apple_music_url: updatedProfile.apple_music_url,
-                      deezer_url: updatedProfile.deezer_url,
-                    });
-                    handleOpenChange(false);
-                  }}
-                />
+              <div className="min-h-0 flex-1 overflow-y-auto px-4 pb-4">
+                {form("all")}
               </div>
             </DrawerBaseContent>
           </DrawerBaseViewport>
@@ -221,30 +170,33 @@ export default function ProfileSettingsDialog({
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       {triggerElement ? <DialogTrigger asChild>{triggerElement}</DialogTrigger> : null}
-      <DialogContent className="h-[min(86vh,48rem)] max-w-[min(72rem,calc(100vw-2.5rem))] overflow-hidden border-border/44 bg-background p-0 md:border-border/40">
-        <div className="grid h-full min-h-0 grid-cols-[15.5rem_minmax(0,1fr)]">
-          <aside className="flex min-h-0 flex-col border-r border-border/32 bg-card/22 p-3 md:border-border/25 md:bg-card/14">
-            <div className="rounded-[1.35rem] border border-border/34 bg-card/26 p-3 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)] md:border-border/20 md:bg-card/18">
-              <div className="flex items-center gap-3">
+      <DialogContent
+        showCloseButton={false}
+        className="h-[min(86vh,41rem)] w-[min(calc(100vw-2rem),42rem)] max-w-none overflow-hidden rounded-[1rem] border-border/44 bg-[var(--kocteau-surface)] p-0 shadow-[0_22px_90px_rgba(0,0,0,0.42)]"
+      >
+        <div className="grid h-full min-h-0 grid-cols-[12.25rem_minmax(0,1fr)]">
+          <aside className="flex min-h-0 flex-col border-r border-border/24 bg-black/10 p-3">
+            <div className="rounded-[0.72rem] bg-black/18 p-2.5">
+              <div className="flex items-center gap-2.5">
                 <UserAvatar
                   avatarUrl={profile.avatar_url}
                   displayName={profile.display_name}
                   username={profile.username}
-                  className="size-11"
+                  className="size-9"
                   initialsLength={2}
                 />
                 <div className="min-w-0">
-                  <p className="truncate text-sm font-medium text-foreground">
+                  <p className="truncate text-[13px] font-medium text-foreground">
                     {profile.display_name ?? `@${profile.username}`}
                   </p>
-                  <p className="truncate text-xs text-muted-foreground">
+                  <p className="truncate text-[12px] text-muted-foreground/68">
                     @{profile.username}
                   </p>
                 </div>
               </div>
             </div>
 
-            <div className="mt-4 space-y-1">
+            <div className="mt-3 space-y-1">
               {settingsNavItems.map((item) => {
                 const Icon = item.icon;
                 const active = activeSection === item.id;
@@ -253,21 +205,19 @@ export default function ProfileSettingsDialog({
                   <button
                     key={item.id}
                     type="button"
-                    onClick={() => setSection(item.id)}
+                    onClick={() => setActiveSection(item.id)}
                     className={cn(
-                      "flex w-full items-center gap-3 rounded-[1rem] px-3 py-2.5 text-left transition-colors",
+                      "flex h-9 w-full items-center gap-2.5 rounded-[0.58rem] px-2.5 text-left text-[13px] font-medium transition-colors",
                       active
-                        ? "bg-background/92 text-foreground shadow-[inset_0_1px_0_rgba(255,255,255,0.02)]"
-                        : "text-muted-foreground hover:bg-card/28 hover:text-foreground md:hover:bg-card/20",
+                        ? "bg-white/[0.075] text-foreground"
+                        : "text-muted-foreground/72 hover:bg-white/[0.04] hover:text-foreground",
                     )}
                   >
-                    <Icon className="size-4 shrink-0" />
-                    <div className="min-w-0">
-                      <p className="text-sm font-medium">{item.label}</p>
-                      <p className="truncate text-[11px] text-muted-foreground">
-                        {item.description}
-                      </p>
-                    </div>
+                    <Icon
+                      className="size-4 shrink-0"
+                      weight={active ? "fill" : "regular"}
+                    />
+                    <span className="truncate">{item.label}</span>
                   </button>
                 );
               })}
@@ -275,14 +225,29 @@ export default function ProfileSettingsDialog({
           </aside>
 
           <div className="flex min-h-0 flex-col">
-            <DialogHeader className="border-b border-border/32 px-6 py-5 text-left md:border-border/25">
-              <DialogTitle>{activeItem.label}</DialogTitle>
-              <DialogDescription>
-                {activeItem.description}
-              </DialogDescription>
+            <DialogHeader className="flex-row items-center justify-between gap-3 px-4 py-3 text-left">
+              <div className="min-w-0">
+                <DialogTitle className="text-[0.95rem] font-semibold">
+                  Settings Profile
+                </DialogTitle>
+                <DialogDescription className="sr-only">
+                  Update your Kocteau profile.
+                </DialogDescription>
+              </div>
+              <DialogClose asChild>
+                <button
+                  type="button"
+                  aria-label="Close settings"
+                  className="rounded-[0.45rem] outline-none transition-opacity hover:opacity-85 focus-visible:ring-2 focus-visible:ring-ring/30"
+                >
+                  <Kbd className="h-6 rounded-[0.42rem] bg-white/[0.07] px-2 text-[11px] text-muted-foreground/78">
+                    Esc
+                  </Kbd>
+                </button>
+              </DialogClose>
             </DialogHeader>
-            <div className="min-h-0 flex-1 overflow-y-auto px-6 py-5">
-              {content}
+            <div className="min-h-0 flex-1 overflow-y-auto px-4 pb-4">
+              {form(activeSection)}
             </div>
           </div>
         </div>

--- a/apps/web/components/route-loading-skeletons.tsx
+++ b/apps/web/components/route-loading-skeletons.tsx
@@ -72,7 +72,7 @@ export function ProfileHeaderSkeleton() {
   return (
     <section
       aria-hidden="true"
-      className="border-b border-border/34 pb-4 md:border-border/30 md:pb-5"
+      className="pb-4 md:pb-5"
     >
       <div className="flex flex-col gap-4">
         <div className="flex items-start gap-4 md:gap-5">
@@ -132,7 +132,7 @@ function RecentActivityTileSkeleton({ className }: { className?: string }) {
 export function ProfileRecentActivitySkeleton() {
   return (
     <section aria-hidden="true" className="flex flex-col gap-3">
-      <div className="border-b border-border/32 pb-3 md:border-border/25">
+      <div>
         <SkeletonLine className="h-5 w-36 bg-muted-foreground/[0.15]" />
       </div>
 
@@ -143,24 +143,6 @@ export function ProfileRecentActivitySkeleton() {
             className="basis-[72%] shrink-0 sm:basis-[42%] md:basis-[31%] lg:basis-[24%] xl:basis-[20%]"
           />
         ))}
-      </div>
-    </section>
-  );
-}
-
-export function SavedReviewsSectionSkeleton() {
-  return (
-    <section
-      aria-hidden="true"
-      className="flex flex-col gap-4 border-t border-border/34 pt-8 [contain-intrinsic-size:720px] [content-visibility:auto] md:border-border/30"
-    >
-      <div className="border-b border-border/32 pb-4 md:border-border/25">
-        <SkeletonLine className="h-3 w-14 bg-muted-foreground/[0.09]" />
-      </div>
-
-      <div className="flex flex-col gap-4">
-        <ReviewCardSkeleton />
-        <ReviewCardSkeleton />
       </div>
     </section>
   );
@@ -177,7 +159,7 @@ export function ProfilePageLoadingSkeleton() {
       <div className="flex flex-col gap-5">
         <ProfileRecentActivitySkeleton />
         <section className="flex flex-col gap-4 pt-2">
-          <div className="border-b border-border/32 pb-3 md:border-border/25">
+          <div>
             <SkeletonLine className="h-5 w-20 bg-muted-foreground/[0.15]" />
           </div>
           <div className="flex flex-col gap-4">

--- a/apps/web/components/search-page-client.tsx
+++ b/apps/web/components/search-page-client.tsx
@@ -387,9 +387,8 @@ export default function SearchPageClient({
   }
 
   return (
-    <div className="mx-auto w-full max-w-5xl lg:max-w-[76rem]">
-      <div className="grid w-full gap-5 lg:grid-cols-[minmax(0,44rem)_16rem] lg:justify-center xl:gap-6">
-        <div className="min-w-0 space-y-5 sm:space-y-6">
+    <div className="mx-auto w-full max-w-5xl lg:mx-0 lg:max-w-none">
+      <div className="min-w-0 space-y-5 sm:space-y-6">
           <div className="grid gap-2.5 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-center">
             <div className="relative min-w-0">
               <Search className="pointer-events-none absolute top-1/2 left-3.5 z-10 size-4 -translate-y-1/2 text-muted-foreground/78" />
@@ -646,9 +645,6 @@ export default function SearchPageClient({
               )}
             </section>
           )}
-        </div>
-
-        <div className="hidden lg:block" aria-hidden="true" />
       </div>
     </div>
   );


### PR DESCRIPTION
## What changed

- Redesigned profile settings with a mobile drawer and a desktop dialog that keeps a scalable sidebar.
- Replaced the generic close X with an `Esc` close affordance.
- Split avatar upload and Kocteau disc preset selection in profile settings.
- Moved the secondary rail into the shared `(main)` layout for desktop routes.
- Removed the Saved section from `/u/[username]` because `/saved` already owns that surface.
- Removed profile route section separators for a quieter editorial layout.

## Why

To make profile editing feel more polished and scalable while giving main app routes a more complete editorial layout instead of leaving wide empty space.

## Testing

- [x] Ran `pnpm --filter web lint`
- [x] Ran `pnpm --filter web build`
- [x] Ran `git diff --check`
- [x] Added screenshots or a short recording for visible web UI changes
- [x] Confirmed this does not touch auth, Supabase, recommendations, analytics, CI, or release behavior

## Changelog impact

No manual `CHANGELOG.md` edit is required. Release Please generates release notes from PR titles and squash commits.

- [x] User-facing web change
- [ ] Developer experience or documentation change
- [ ] Internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI/UX Updates**
  * Updated visual styling and icon appearance throughout the application
  * Reorganized home feed and user profile page layouts
  * Enhanced profile settings with improved avatar upload controls and additional form fields
  * Redesigned profile settings dialog with keyboard shortcuts and improved navigation
  * Simplified feed loading states

* **Removed Features**
  * Removed saved reviews section from user profiles

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/francozeta/kocteau/pull/30?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->