### PR TITLE
feat(web): polish auth backdrop and editorial rail

### DIFF
--- a/apps/web/app/(main)/layout.tsx
+++ b/apps/web/app/(main)/layout.tsx
@@ -7,6 +7,7 @@ import MobileBottomBar from "@/components/mobile-bottom-bar";
 import { RouteHeaderProvider } from "@/components/route-header-context";
 import WhoToFollowRail from "@/components/who-to-follow-rail";
 import { getCurrentOnboardingState, getCurrentUser, getCurrentViewerProfile } from "@/lib/auth/server";
+import { getStarterTracks } from "@/lib/queries/starter";
 import type { SidebarOwnedReview } from "@/lib/types/sidebar";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 
@@ -26,6 +27,8 @@ export default async function MainLayout({ children }: { children: React.ReactNo
   if (user && onboardingState && !onboardingState.tasteOnboarded) {
     redirect("/onboarding/taste");
   }
+
+  const starterTracks = await getStarterTracks({ viewerId: user?.id, limit: 6 });
 
   return (
     <ReactQueryProvider>
@@ -49,14 +52,17 @@ export default async function MainLayout({ children }: { children: React.ReactNo
             <GlobalShortcuts isAuthenticated={Boolean(safeProfile)} />
             <div className="kocteau-app-frame flex min-h-svh flex-1 flex-col lg:min-h-0 lg:h-full lg:overflow-hidden lg:rounded-[0.8rem]">
               <Header profile={safeProfile} />
-              <main className="mx-auto flex min-h-0 w-full max-w-[82rem] flex-1 flex-col px-3.5 pt-[calc(env(safe-area-inset-top)+4rem)] pb-[calc(env(safe-area-inset-bottom)+6.5rem)] sm:px-6 sm:pt-[calc(env(safe-area-inset-top)+4.75rem)] sm:pb-28 lg:max-w-none lg:overflow-y-auto lg:px-7 lg:pt-3 lg:pb-6 xl:px-8">
-                <div className="mx-auto grid min-h-0 w-full max-w-[76rem] flex-1 gap-5 lg:grid-cols-[minmax(0,44rem)_16rem] lg:items-start lg:justify-center xl:gap-6">
-                  <div className="min-w-0">
+              <div className="mx-auto flex min-h-0 w-full max-w-[82rem] flex-1 flex-col px-3.5 pt-[calc(env(safe-area-inset-top)+4rem)] pb-[calc(env(safe-area-inset-bottom)+6.5rem)] sm:px-6 sm:pt-[calc(env(safe-area-inset-top)+4.75rem)] sm:pb-28 lg:max-w-none lg:overflow-hidden lg:px-0 lg:py-0">
+                <div className="mx-auto grid min-h-0 w-full max-w-[76rem] flex-1 gap-5 lg:h-full lg:grid-cols-[minmax(0,44rem)_16rem] lg:items-stretch lg:justify-center lg:px-7 xl:gap-6 xl:px-8">
+                  <main className="no-scrollbar min-w-0 lg:min-h-0 lg:overflow-x-hidden lg:overflow-y-auto lg:pr-1">
                     {children}
-                  </div>
-                  <WhoToFollowRail isAuthenticated={Boolean(safeProfile)} />
+                  </main>
+                  <WhoToFollowRail
+                    isAuthenticated={Boolean(safeProfile)}
+                    starterTracks={starterTracks}
+                  />
                 </div>
-              </main>
+              </div>
             </div>
             <MobileBottomBar profile={safeProfile} />
           </RouteHeaderProvider>

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -4,6 +4,176 @@
 
 @custom-variant dark (&:is(.dark *));
 
+@property --scroll-mask-t-from {
+  syntax: "<length-percentage>";
+  inherits: false;
+  initial-value: 100%;
+}
+
+@property --scroll-mask-b-from {
+  syntax: "<length-percentage>";
+  inherits: false;
+  initial-value: 100%;
+}
+
+@property --scroll-mask-l-from {
+  syntax: "<length-percentage>";
+  inherits: false;
+  initial-value: 100%;
+}
+
+@property --scroll-mask-r-from {
+  syntax: "<length-percentage>";
+  inherits: false;
+  initial-value: 100%;
+}
+
+@keyframes scroll-mask-y-scroll {
+  0% {
+    --scroll-mask-t-from: 100%;
+  }
+
+  10%,
+  100% {
+    --scroll-mask-t-from: var(--scroll-mask-fade-from-t, 100%);
+  }
+
+  0%,
+  90% {
+    --scroll-mask-b-from: var(--scroll-mask-fade-from-b, 100%);
+  }
+
+  100% {
+    --scroll-mask-b-from: 100%;
+  }
+}
+
+@keyframes scroll-mask-x-scroll {
+  0% {
+    --scroll-mask-l-from: 100%;
+  }
+
+  10%,
+  100% {
+    --scroll-mask-l-from: var(--scroll-mask-fade-from-l, 100%);
+  }
+
+  0%,
+  90% {
+    --scroll-mask-r-from: var(--scroll-mask-fade-from-r, 100%);
+  }
+
+  100% {
+    --scroll-mask-r-from: 100%;
+  }
+}
+
+@supports (animation-timeline: scroll()) {
+  :where([class^="scroll-mask-"], [class*=" scroll-mask-"]) {
+    --scroll-mask-t: linear-gradient(
+      to top,
+      black,
+      black var(--scroll-mask-t-from),
+      transparent
+    );
+    --scroll-mask-b: linear-gradient(
+      to bottom,
+      black,
+      black var(--scroll-mask-b-from),
+      transparent
+    );
+    --scroll-mask-l: linear-gradient(
+      to left,
+      black,
+      black var(--scroll-mask-l-from),
+      transparent
+    );
+    --scroll-mask-r: linear-gradient(
+      to right,
+      black,
+      black var(--scroll-mask-r-from),
+      transparent
+    );
+    mask-image:
+      var(--scroll-mask-t), var(--scroll-mask-b), var(--scroll-mask-l),
+      var(--scroll-mask-r);
+    mask-composite: intersect;
+    -webkit-mask-composite: source-in;
+    animation:
+      scroll-mask-y-scroll linear,
+      scroll-mask-x-scroll linear;
+    animation-timeline: scroll(self block), scroll(self inline);
+  }
+}
+
+@utility scroll-mask-t {
+  --scroll-mask-fade-from-t: 80%;
+}
+
+@utility scroll-mask-t-from-* {
+  --scroll-mask-fade-from-t: --spacing(--value(integer));
+  --scroll-mask-fade-from-t: --value(percentage);
+  --scroll-mask-fade-from-t: --value([length], [percentage]);
+}
+
+@utility scroll-mask-b {
+  --scroll-mask-fade-from-b: 80%;
+}
+
+@utility scroll-mask-b-from-* {
+  --scroll-mask-fade-from-b: --spacing(--value(integer));
+  --scroll-mask-fade-from-b: --value(percentage);
+  --scroll-mask-fade-from-b: --value([length], [percentage]);
+}
+
+@utility scroll-mask-y {
+  --scroll-mask-fade-from-t: 80%;
+  --scroll-mask-fade-from-b: 80%;
+}
+
+@utility scroll-mask-y-from-* {
+  --scroll-mask-fade-from-t: --spacing(--value(integer));
+  --scroll-mask-fade-from-t: --value(percentage);
+  --scroll-mask-fade-from-t: --value([length], [percentage]);
+  --scroll-mask-fade-from-b: --spacing(--value(integer));
+  --scroll-mask-fade-from-b: --value(percentage);
+  --scroll-mask-fade-from-b: --value([length], [percentage]);
+}
+
+@utility scroll-mask-l {
+  --scroll-mask-fade-from-l: 80%;
+}
+
+@utility scroll-mask-l-from-* {
+  --scroll-mask-fade-from-l: --spacing(--value(integer));
+  --scroll-mask-fade-from-l: --value(percentage);
+  --scroll-mask-fade-from-l: --value([length], [percentage]);
+}
+
+@utility scroll-mask-r {
+  --scroll-mask-fade-from-r: 80%;
+}
+
+@utility scroll-mask-r-from-* {
+  --scroll-mask-fade-from-r: --spacing(--value(integer));
+  --scroll-mask-fade-from-r: --value(percentage);
+  --scroll-mask-fade-from-r: --value([length], [percentage]);
+}
+
+@utility scroll-mask-x {
+  --scroll-mask-fade-from-l: 80%;
+  --scroll-mask-fade-from-r: 80%;
+}
+
+@utility scroll-mask-x-from-* {
+  --scroll-mask-fade-from-l: --spacing(--value(integer));
+  --scroll-mask-fade-from-l: --value(percentage);
+  --scroll-mask-fade-from-l: --value([length], [percentage]);
+  --scroll-mask-fade-from-r: --spacing(--value(integer));
+  --scroll-mask-fade-from-r: --value(percentage);
+  --scroll-mask-fade-from-r: --value([length], [percentage]);
+}
+
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
@@ -225,6 +395,14 @@
 }
 
 @layer components {
+  .no-scrollbar {
+    scrollbar-width: none;
+  }
+
+  .no-scrollbar::-webkit-scrollbar {
+    display: none;
+  }
+
   .kocteau-app-frame {
     border: 1px solid transparent;
     background: transparent;
@@ -593,10 +771,7 @@
   height: 100dvh;
   min-height: 100vh;
   min-height: 100dvh;
-  background:
-    radial-gradient(circle at 48% 50%, rgba(255, 255, 255, 0.055), transparent 30rem),
-    linear-gradient(180deg, rgba(0, 0, 0, 0.16), rgba(0, 0, 0, 0.52)),
-    var(--background);
+  background: #050505;
 }
 
 .kocteau-auth-background::before {
@@ -606,8 +781,9 @@
   z-index: 1;
   pointer-events: none;
   background:
-    linear-gradient(90deg, rgba(0, 0, 0, 0.58), transparent 42%, rgba(0, 0, 0, 0.24)),
-    radial-gradient(circle at 50% 52%, transparent 0 13rem, rgba(0, 0, 0, 0.22) 31rem);
+    radial-gradient(circle at 50% 47%, rgba(255, 255, 255, 0.075), transparent 18rem),
+    radial-gradient(circle at 50% 52%, transparent 0 12rem, rgba(0, 0, 0, 0.22) 31rem),
+    linear-gradient(90deg, rgba(0, 0, 0, 0.62), rgba(0, 0, 0, 0.12) 48%, rgba(0, 0, 0, 0.48));
 }
 
 .kocteau-auth-background::after {
@@ -616,10 +792,9 @@
   inset: 0;
   z-index: 2;
   pointer-events: none;
-  opacity: 0.2;
-  mix-blend-mode: screen;
-  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 140 140' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)' opacity='0.55'/%3E%3C/svg%3E");
-  background-size: 140px 140px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.035), transparent 24%, rgba(0, 0, 0, 0.34)),
+    radial-gradient(circle at 50% 50%, transparent 0 18rem, rgba(0, 0, 0, 0.36) 42rem);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/apps/web/components/auth/auth-form-shell.tsx
+++ b/apps/web/components/auth/auth-form-shell.tsx
@@ -1,12 +1,19 @@
 "use client";
 
 import Link from "next/link";
-import Image from "next/image";
-import type { ReactNode } from "react";
+import dynamic from "next/dynamic";
+import { useEffect, useState, type ReactNode } from "react";
 import { ChevronLeft } from "lucide-react";
 import BrandLogo from "@/components/brand-logo";
 import { FieldDescription, FieldGroup } from "@/components/ui/field";
 import { cn } from "@/lib/utils";
+
+const DitheringShader = dynamic(
+  () => import("@paper-design/shaders-react").then((mod) => mod.Dithering),
+  {
+    ssr: false,
+  },
+);
 
 type AuthFormShellProps = {
   title: string;
@@ -19,6 +26,44 @@ type AuthFormShellProps = {
   className?: string;
   widthClassName?: string;
 };
+
+function AuthDitheringBackground() {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+  useEffect(() => {
+    const query = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const sync = () => setPrefersReducedMotion(query.matches);
+
+    sync();
+    query.addEventListener("change", sync);
+
+    return () => {
+      query.removeEventListener("change", sync);
+    };
+  }, []);
+
+  return (
+    <div className="pointer-events-none absolute inset-0 z-0 overflow-hidden bg-[#050505]">
+      <DitheringShader
+        aria-hidden="true"
+        colorBack="#050505"
+        colorFront="#2b2b2b"
+        fit="cover"
+        height="100%"
+        maxPixelCount={1_600_000}
+        minPixelRatio={1}
+        rotation={0}
+        scale={0.82}
+        shape="warp"
+        size={2}
+        speed={prefersReducedMotion ? 0 : 0.14}
+        style={{ height: "100%", width: "100%" }}
+        type="4x4"
+        width="100%"
+      />
+    </div>
+  );
+}
 
 export default function AuthFormShell({
   title,
@@ -33,15 +78,7 @@ export default function AuthFormShell({
 }: AuthFormShellProps) {
   return (
     <main className="kocteau-auth-background relative isolate flex overflow-hidden bg-background text-foreground">
-      <Image
-        src="/background-auth.webp"
-        alt=""
-        fill
-        priority
-        sizes="100vw"
-        aria-hidden="true"
-        className="pointer-events-none absolute inset-0 z-0 object-cover"
-      />
+      <AuthDitheringBackground />
 
       <Link
         href="/"

--- a/apps/web/components/auth/otp-auth-page-client.tsx
+++ b/apps/web/components/auth/otp-auth-page-client.tsx
@@ -383,7 +383,7 @@ export default function OtpAuthPageClient({ mode }: OtpAuthPageClientProps) {
                   setFieldErrors((current) => ({ ...current, email: undefined }));
                   setMessage(null);
                 }}
-                className="h-11 rounded-[0.52rem] border-white/10 bg-white/[0.055] px-4 text-sm shadow-[0_0_0_1px_rgba(0,0,0,0.24)] placeholder:text-muted-foreground/58 focus-visible:border-white/24 focus-visible:bg-white/[0.075] focus-visible:ring-white/18"
+                className="h-11 rounded-[0.52rem] border-white/12 bg-[var(--kocteau-surface)] px-4 text-sm shadow-[0_0_0_1px_rgba(0,0,0,0.36),inset_0_1px_0_rgba(255,255,255,0.035)] placeholder:text-muted-foreground/52 focus-visible:border-white/26 focus-visible:bg-[var(--kocteau-surface-raised)] focus-visible:ring-white/16"
                 aria-invalid={Boolean(fieldErrors.email)}
                 autoComplete="email"
                 autoFocus
@@ -438,7 +438,7 @@ export default function OtpAuthPageClient({ mode }: OtpAuthPageClientProps) {
                     <InputOTPSlot
                       key={index}
                       index={index}
-                      className="h-11 min-w-0 flex-1 !rounded-[0.48rem] !border border-white/10 bg-white/[0.035] text-lg font-medium shadow-[0_0_0_1px_rgba(0,0,0,0.2)] first:!rounded-[0.48rem] last:!rounded-[0.48rem] data-[active=true]:border-white/55 data-[active=true]:bg-white/[0.06] data-[active=true]:ring-2 data-[active=true]:ring-white/16 sm:h-12"
+                      className="h-11 min-w-0 flex-1 !rounded-[0.48rem] !border border-white/12 bg-[var(--kocteau-surface)] text-lg font-medium shadow-[0_0_0_1px_rgba(0,0,0,0.32),inset_0_1px_0_rgba(255,255,255,0.03)] first:!rounded-[0.48rem] last:!rounded-[0.48rem] data-[active=true]:border-white/50 data-[active=true]:bg-[var(--kocteau-surface-raised)] data-[active=true]:ring-2 data-[active=true]:ring-white/16 sm:h-12"
                     />
                   ))}
                 </InputOTPGroup>

--- a/apps/web/components/feed-loading-skeletons.tsx
+++ b/apps/web/components/feed-loading-skeletons.tsx
@@ -198,8 +198,8 @@ export function WhoToFollowRailSkeleton({
       {showHeading ? (
         <SkeletonLine className="h-3 w-28 bg-muted-foreground/[0.09]" />
       ) : null}
-      <div className="border-t border-border/32">
-        {Array.from({ length: 4 }).map((_, index) => (
+      <div>
+        {Array.from({ length: 3 }).map((_, index) => (
           <RailProfileSkeleton key={`rail-profile-${index}`} index={index} />
         ))}
       </div>

--- a/apps/web/components/feed-review-list.tsx
+++ b/apps/web/components/feed-review-list.tsx
@@ -311,13 +311,13 @@ export default function FeedReviewList({
           ) : null}
         </div>
       ) : (
-        <p className="py-3 text-center text-xs text-muted-foreground">
+        <p className="py-3 text-center text-xs text-muted-foreground/46">
           created by{" "}
           <Link
             href="https://francozeta.vercel.app/"
             target="_blank"
             rel="noreferrer"
-            className="font-medium text-foreground underline underline-offset-4"
+            className="font-medium text-muted-foreground/62 underline underline-offset-4 transition-colors hover:text-muted-foreground/82"
           >
             francozeta
           </Link>

--- a/apps/web/components/notifications-button.tsx
+++ b/apps/web/components/notifications-button.tsx
@@ -149,15 +149,15 @@ export default function NotificationsButton({
           </div>
         </PopoverHeader>
 
-        <ScrollArea className="max-h-[24rem]">
+        <ScrollArea className="min-h-40 max-h-[24rem]">
           <div>
             {isLoadingNotifications ? (
-              <div className="flex justify-center px-3 py-7">
-                <Spinner className="size-4 text-muted-foreground/70" />
+              <div className="flex min-h-40 items-center justify-center px-3 py-7">
+                <Spinner className="size-5 text-muted-foreground/70" />
               </div>
             ) : isFetchingNotifications && notifications.length === 0 ? (
-              <div className="flex justify-center px-3 py-7">
-                <Spinner className="size-4 text-muted-foreground/70" />
+              <div className="flex min-h-40 items-center justify-center px-3 py-7">
+                <Spinner className="size-5 text-muted-foreground/70" />
               </div>
             ) : isNotificationsError ? (
               <Alert className="rounded-[0.64rem] border-border/46 bg-card p-3 shadow-none md:border-border/40 md:bg-card">

--- a/apps/web/components/profile-hero-avatar.tsx
+++ b/apps/web/components/profile-hero-avatar.tsx
@@ -125,7 +125,7 @@ export default function ProfileHeroAvatar({
           priority={priority}
           unoptimized={isSvgAsset(resolvedAvatarUrl)}
           sizes="(max-width: 640px) 96px, 112px"
-          className={cn("relative z-[1] object-cover", imageClassName)}
+          className={cn("z-[1] object-cover", imageClassName)}
         />
       ) : null}
 

--- a/apps/web/components/profile-recent-reviews-section.tsx
+++ b/apps/web/components/profile-recent-reviews-section.tsx
@@ -1,16 +1,8 @@
 "use client";
 
 import { Star } from "lucide-react";
-import EntityCoverImage from "@/components/entity-cover-image";
-import PrefetchLink from "@/components/prefetch-link";
+import TrackTile from "@/components/track-tile";
 import type { ReviewCardData, ReviewCardEntity } from "@/components/review-card";
-import {
-  Carousel,
-  CarouselContent,
-  CarouselItem,
-  CarouselNext,
-  CarouselPrevious,
-} from "@/components/ui/carousel";
 
 type ProfileRecentReview = ReviewCardData & {
   entities: ReviewCardEntity | null;
@@ -21,61 +13,25 @@ type ProfileRecentReviewsSectionProps = {
   variant?: "auto" | "carousel" | "cards";
 };
 
-function RecentReviewTile({
-  review,
-  compact = false,
-}: {
-  review: ProfileRecentReview;
-  compact?: boolean;
-}) {
+function RecentReviewTile({ review }: { review: ProfileRecentReview }) {
   const entity = review.entities;
   const entityId = entity?.id ?? null;
 
-  const tile = (
-    <article className="group min-w-0">
-      <div className="relative aspect-square overflow-hidden rounded-lg border border-border/34 bg-card/32 shadow-[inset_0_1px_0_rgba(255,255,255,0.035)] transition-colors group-hover:border-border/52 group-hover:bg-card/46 md:border-border/24 md:bg-card/24 md:group-hover:border-border/40 md:group-hover:bg-card/34">
-        <EntityCoverImage
-          src={entity?.cover_url}
-          alt={entity?.title ?? "Reviewed track"}
-          sizes={compact ? "45vw" : "(min-width: 1280px) 210px, (min-width: 768px) 28vw, 72vw"}
-          quality={84}
-          variant="card"
-          className="absolute inset-0 bg-muted"
-          imageClassName="transition-transform duration-500 group-hover:scale-[1.04]"
-          iconClassName="size-7"
-        />
-        <div className="absolute inset-0 bg-gradient-to-t from-black/78 via-black/18 to-black/6" />
-        <div className="absolute top-2 right-2 inline-flex items-center gap-1.5 rounded-lg border border-white/12 bg-black/48 px-2 py-1 text-xs font-semibold text-white backdrop-blur-md">
+  return (
+    <TrackTile
+      href={entityId ? `/track/${entityId}` : undefined}
+      queryWarmup={entityId ? { kind: "track", id: entityId } : undefined}
+      title={entity?.title ?? "Untitled track"}
+      artistName={entity?.artist_name}
+      coverUrl={entity?.cover_url}
+      sizes="(min-width: 1280px) 148px, (min-width: 768px) 22vw, 45vw"
+      badge={
+        <>
           <Star className="size-3 fill-amber-400 text-amber-400" />
           {review.rating.toFixed(1)}
-        </div>
-      </div>
-
-      <div className="mt-2 min-w-0 space-y-0.5 px-0.5">
-        <p className="line-clamp-1 text-sm font-semibold text-foreground">
-          {entity?.title ?? "Untitled track"}
-        </p>
-        <p className="line-clamp-1 text-xs text-muted-foreground">
-          {entity?.artist_name ?? "Unknown artist"}
-        </p>
-      </div>
-    </article>
-  );
-
-  if (!entityId) {
-    return tile;
-  }
-
-  const href = `/track/${entityId}`;
-
-  return (
-    <PrefetchLink
-      href={href}
-      queryWarmup={{ kind: "track", id: entityId }}
-      className="block outline-none focus-visible:ring-2 focus-visible:ring-ring/70 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-    >
-      {tile}
-    </PrefetchLink>
+        </>
+      }
+    />
   );
 }
 
@@ -101,31 +57,22 @@ export default function ProfileRecentReviewsSection({
       {shouldUseCards ? (
         <div className="grid gap-3 sm:grid-cols-2">
           {recentReviews.map((review) => (
-            <RecentReviewTile key={review.id} review={review} compact />
+            <RecentReviewTile key={review.id} review={review} />
           ))}
         </div>
       ) : (
-        <Carousel
-          opts={{
-            align: "start",
-            dragFree: true,
-            containScroll: "trimSnaps",
-          }}
-          className="group/profile-reviews"
-        >
-          <CarouselContent className="-ml-3 md:-ml-4">
+        <div className="-mx-1 overflow-hidden">
+          <div className="scroll-mask-r scroll-mask-r-from-[calc(100%-3rem)] no-scrollbar flex gap-4 overflow-x-auto overscroll-x-contain px-1 pb-1">
             {recentReviews.map((review) => (
-              <CarouselItem
+              <div
                 key={review.id}
-                className="basis-[72%] pl-3 sm:basis-[42%] md:basis-[31%] lg:basis-[24%] xl:basis-[20%] md:pl-4"
+                className="w-[8.5rem] shrink-0 sm:w-[9rem] lg:w-[8.35rem] xl:w-[8.6rem]"
               >
                 <RecentReviewTile review={review} />
-              </CarouselItem>
+              </div>
             ))}
-          </CarouselContent>
-          <CarouselPrevious className="hidden border-border/34 bg-background/88 text-foreground shadow-none backdrop-blur-md hover:bg-muted/40 disabled:opacity-0 md:inline-flex md:-left-4" />
-          <CarouselNext className="hidden border-border/34 bg-background/88 text-foreground shadow-none backdrop-blur-md hover:bg-muted/40 disabled:opacity-0 md:inline-flex md:-right-4" />
-        </Carousel>
+          </div>
+        </div>
       )}
     </section>
   );

--- a/apps/web/components/track-tile.tsx
+++ b/apps/web/components/track-tile.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import type { ReactNode } from "react";
+import EntityCoverImage from "@/components/entity-cover-image";
+import PrefetchLink, { type QueryWarmupDescriptor } from "@/components/prefetch-link";
+import { cn } from "@/lib/utils";
+
+type TrackTileProps = {
+  title: string;
+  artistName?: string | null;
+  coverUrl?: string | null;
+  href?: string;
+  queryWarmup?: QueryWarmupDescriptor | QueryWarmupDescriptor[];
+  badge?: ReactNode;
+  className?: string;
+  coverClassName?: string;
+  titleClassName?: string;
+  artistClassName?: string;
+  sizes?: string;
+  quality?: number;
+};
+
+function TrackTileContent({
+  title,
+  artistName,
+  coverUrl,
+  badge,
+  className,
+  coverClassName,
+  titleClassName,
+  artistClassName,
+  sizes = "(min-width: 1024px) 128px, 42vw",
+  quality = 84,
+}: Omit<TrackTileProps, "href" | "queryWarmup">) {
+  return (
+    <div className={cn("group min-w-0", className)}>
+      <div
+        className={cn(
+          "relative aspect-square overflow-hidden rounded-[0.68rem] bg-card/28 shadow-[0_0_0_1px_rgba(255,255,255,0.075)]",
+          coverClassName,
+        )}
+      >
+        <EntityCoverImage
+          src={coverUrl}
+          alt={title}
+          sizes={sizes}
+          quality={quality}
+          variant="card"
+          className="absolute inset-0 bg-muted/20"
+          iconClassName="size-6"
+        />
+        {badge ? (
+          <div className="absolute right-1.5 top-1.5 inline-flex h-7 items-center gap-1.5 rounded-[0.48rem] bg-black/48 px-2 text-xs font-semibold tabular-nums text-white ring-1 ring-white/10">
+            {badge}
+          </div>
+        ) : null}
+      </div>
+
+      <div className="mt-2 min-w-0 space-y-0.5 px-0.5">
+        <p className={cn("line-clamp-1 text-sm font-semibold text-foreground", titleClassName)}>
+          {title}
+        </p>
+        <p className={cn("line-clamp-1 text-xs text-muted-foreground", artistClassName)}>
+          {artistName ?? "Unknown artist"}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default function TrackTile({
+  href,
+  queryWarmup,
+  ...props
+}: TrackTileProps) {
+  const tile = <TrackTileContent {...props} />;
+
+  if (!href) {
+    return tile;
+  }
+
+  return (
+    <PrefetchLink
+      href={href}
+      queryWarmup={queryWarmup}
+      className="block rounded-[0.72rem] outline-none focus-visible:ring-2 focus-visible:ring-ring/70 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+    >
+      {tile}
+    </PrefetchLink>
+  );
+}

--- a/apps/web/components/ui/spinner.tsx
+++ b/apps/web/components/ui/spinner.tsx
@@ -1,10 +1,51 @@
-import { cn } from "@/lib/utils"
-import { IconLoader } from "@tabler/icons-react"
+import type { ComponentProps } from "react"
 
-function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
+import { cn } from "@/lib/utils"
+
+type ClassicProps = Omit<ComponentProps<"span">, "children">
+
+function Classic({ className, ...props }: ClassicProps) {
   return (
-    <IconLoader role="status" aria-label="Loading" className={cn("size-4 animate-spin", className)} {...props} />
+    <>
+      <style>{`
+        @keyframes loading-ui-classic-fade {
+          0% {
+            opacity: 1;
+          }
+
+          100% {
+            opacity: 0.15;
+          }
+        }
+      `}</style>
+      <span
+        role="status"
+        className={cn("box-border inline-block size-5", className)}
+        {...props}
+      >
+        <span
+          aria-hidden="true"
+          className="relative left-1/2 top-1/2 block size-full"
+        >
+          {Array.from({ length: 12 }, (_, index) => (
+            <span
+              key={index}
+              className="absolute left-[-10%] top-[-3.9%] block h-[8%] w-[24%] rounded-[var(--radius)] bg-current"
+              style={{
+                transform: `rotate(${index * 30}deg) translate(146%)`,
+                animation:
+                  "loading-ui-classic-fade var(--duration, 1.2s) linear infinite",
+                animationDelay: `calc(var(--duration, 1.2s) / 12 * ${index - 12})`,
+              }}
+            />
+          ))}
+        </span>
+        <span className="sr-only">Loading</span>
+      </span>
+    </>
   )
 }
 
-export { Spinner }
+const Spinner = Classic
+
+export { Classic, Spinner }

--- a/apps/web/components/user-avatar.tsx
+++ b/apps/web/components/user-avatar.tsx
@@ -193,7 +193,7 @@ export default function UserAvatar({
           fetchPriority={fetchPriority}
           unoptimized={shouldBypassOptimization(resolvedAvatarUrl)}
           className={cn(
-            "relative z-[1] object-cover",
+            "z-[1] object-cover",
             shapeClasses.image,
             imageClassName,
           )}

--- a/apps/web/components/who-to-follow-rail.tsx
+++ b/apps/web/components/who-to-follow-rail.tsx
@@ -4,13 +4,17 @@ import { useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import FollowProfileButton from "@/components/follow-profile-button";
 import { WhoToFollowRailSkeleton } from "@/components/feed-loading-skeletons";
+import NewReviewDialog from "@/components/new-review-dialog";
 import PrefetchLink from "@/components/prefetch-link";
+import TrackTile from "@/components/track-tile";
 import UserAvatar from "@/components/user-avatar";
 import { helpFooterLinks } from "@/lib/help";
+import type { StarterTrack } from "@/lib/starter";
 import { activeProfilesQueryOptions } from "@/queries/profiles";
 
 type WhoToFollowRailProps = {
   isAuthenticated: boolean;
+  starterTracks?: StarterTrack[];
 };
 
 function useDesktopRail() {
@@ -31,82 +35,150 @@ function useDesktopRail() {
   return isDesktop;
 }
 
+function StarterPickReviewTrigger({
+  track,
+  isAuthenticated,
+}: {
+  track: StarterTrack;
+  isAuthenticated: boolean;
+}) {
+  return (
+    <NewReviewDialog
+      isAuthenticated={isAuthenticated}
+      initialSelection={{
+        provider: "deezer",
+        provider_id: track.provider_id,
+        type: "track",
+        title: track.title,
+        artist_name: track.artist_name,
+        cover_url: track.cover_url,
+        deezer_url: track.deezer_url,
+        entity_id: null,
+      }}
+      trigger={
+        <button
+          type="button"
+          className="block w-full rounded-[0.72rem] text-left outline-none transition-[opacity,transform] hover:opacity-[0.88] focus-visible:ring-2 focus-visible:ring-ring/70 focus-visible:ring-offset-2 focus-visible:ring-offset-background active:scale-[0.98]"
+          aria-label={`Review ${track.title}`}
+        >
+          <TrackTile
+            title={track.title}
+            artistName={track.artist_name}
+            coverUrl={track.cover_url}
+            sizes="104px"
+            coverClassName="rounded-[0.58rem]"
+            titleClassName="text-[12px] leading-4"
+            artistClassName="text-[11px] leading-4"
+          />
+        </button>
+      }
+    />
+  );
+}
+
 export default function WhoToFollowRail({
   isAuthenticated,
+  starterTracks = [],
 }: WhoToFollowRailProps) {
   const isDesktop = useDesktopRail();
   const { data, isLoading } = useQuery({
-    ...activeProfilesQueryOptions(4),
+    ...activeProfilesQueryOptions(3),
     enabled: isDesktop,
   });
   const profiles = data?.profiles ?? [];
+  const visibleStarterTracks = starterTracks.slice(0, 6);
 
   return (
-    <aside className="hidden lg:block" aria-label="Writers to notice">
-      <div className="sticky top-1 space-y-3 pt-1">
-        <p className="px-1 text-[12px] font-medium leading-none text-muted-foreground/70">
-          Writers to notice
-        </p>
+    <aside
+      className="hidden lg:block lg:min-h-0 lg:pt-3 lg:pb-6"
+      aria-label="Editorial rail"
+    >
+      <div className="flex h-full min-h-0 flex-col">
+        <section className="min-h-[11.25rem] space-y-3 overflow-hidden" aria-label="Writers to notice">
+          <p className="px-1 text-[12px] font-medium leading-none text-muted-foreground/70">
+            Writers to notice
+          </p>
 
-        {isLoading ? (
-          <WhoToFollowRailSkeleton showHeading={false} />
-        ) : profiles.length > 0 ? (
-          <div>
-            {profiles.map((profile) => {
-              const primaryLabel = profile.display_name ?? `@${profile.username}`;
+          {isLoading ? (
+            <WhoToFollowRailSkeleton showHeading={false} />
+          ) : profiles.length > 0 ? (
+            <div>
+              {profiles.map((profile) => {
+                const primaryLabel = profile.display_name ?? `@${profile.username}`;
 
-              return (
-                <div
-                  key={profile.id}
-                  className="kocteau-rail-row rounded-[0.62rem] px-1 py-3"
-                >
-                  <div className="flex items-start gap-2.5">
-                    <PrefetchLink
-                      href={`/u/${profile.username}`}
-                      className="group min-w-0 flex-1 rounded-[0.7rem] transition-colors hover:text-foreground"
-                    >
-                      <div className="flex items-start gap-2.5">
-                        <UserAvatar
-                          avatarUrl={profile.avatar_url}
-                          displayName={profile.display_name}
-                          username={profile.username}
-                          className="size-8 shrink-0 ring-1 ring-white/[0.05]"
-                          sizes="32px"
-                          initialsLength={2}
-                        />
+                return (
+                  <div
+                    key={profile.id}
+                    className="kocteau-rail-row rounded-[0.62rem] px-1 py-3"
+                  >
+                    <div className="flex items-start gap-2.5">
+                      <PrefetchLink
+                        href={`/u/${profile.username}`}
+                        className="group min-w-0 flex-1 rounded-[0.7rem] transition-colors hover:text-foreground"
+                      >
+                        <div className="flex items-start gap-2.5">
+                          <UserAvatar
+                            avatarUrl={profile.avatar_url}
+                            displayName={profile.display_name}
+                            username={profile.username}
+                            className="size-8 shrink-0 ring-1 ring-white/[0.05]"
+                            sizes="32px"
+                            initialsLength={2}
+                          />
 
-                        <div className="min-w-0 flex-1 space-y-0.5">
-                          <p className="truncate text-[13px] font-medium text-foreground">
-                            {primaryLabel}
-                          </p>
-                          <p className="truncate text-[12px] text-muted-foreground/78">
-                            Reviewing lately
-                          </p>
+                          <div className="min-w-0 flex-1 space-y-0.5">
+                            <p className="truncate text-[13px] font-medium text-foreground">
+                              {primaryLabel}
+                            </p>
+                            <p className="truncate text-[12px] text-muted-foreground/78">
+                              Reviewing lately
+                            </p>
+                          </div>
                         </div>
-                      </div>
-                    </PrefetchLink>
+                      </PrefetchLink>
 
-                    {isAuthenticated ? (
-                      <FollowProfileButton
-                        profileId={profile.id}
-                        initialFollowing={profile.viewer_is_following}
-                        isAuthenticated
-                        size="xs"
-                        className="h-7 shrink-0 rounded-md px-2 text-[10px] !border-transparent !bg-transparent !text-foreground/88 hover:!bg-foreground/[0.055] hover:!text-foreground"
-                      />
-                    ) : null}
+                      {isAuthenticated ? (
+                        <FollowProfileButton
+                          profileId={profile.id}
+                          initialFollowing={profile.viewer_is_following}
+                          isAuthenticated
+                          size="xs"
+                          className="h-7 shrink-0 rounded-md px-2 text-[10px] !border-transparent !bg-transparent !text-foreground/88 hover:!bg-foreground/[0.055] hover:!text-foreground"
+                        />
+                      ) : null}
+                    </div>
                   </div>
-                </div>
-              );
-            })}
-          </div>
-        ) : (
-          <div className="px-1 py-3 text-[13px] text-muted-foreground/78">
-            No writers to notice yet.
-          </div>
-        )}
+                );
+              })}
+            </div>
+          ) : (
+            <div className="px-1 py-3 text-[13px] text-muted-foreground/78">
+              No writers to notice yet.
+            </div>
+          )}
+        </section>
 
-        <footer className="px-1 pt-2 text-[11px] leading-5 text-muted-foreground/52">
+        {visibleStarterTracks.length > 0 ? (
+          <section className="mt-6 min-h-[12.25rem] space-y-3 overflow-hidden" aria-label="Starter picks">
+            <p className="px-1 text-[12px] font-medium leading-none text-muted-foreground/70">
+              Starter picks
+            </p>
+            <div className="-mx-1 overflow-hidden">
+              <div className="scroll-mask-r scroll-mask-r-from-[calc(100%-1.25rem)] no-scrollbar flex gap-3 overflow-x-auto overscroll-x-contain px-1 pb-1">
+                {visibleStarterTracks.map((track) => (
+                  <div key={track.id} className="w-[6.35rem] shrink-0">
+                    <StarterPickReviewTrigger
+                      track={track}
+                      isAuthenticated={isAuthenticated}
+                    />
+                  </div>
+                ))}
+              </div>
+            </div>
+          </section>
+        ) : null}
+
+        <footer className="mt-5 px-1 pb-8 pt-1 text-[11px] leading-5 text-muted-foreground/52">
           <div className="flex flex-wrap gap-x-2 gap-y-0.5">
             {helpFooterLinks.map((link) => (
               <PrefetchLink

--- a/apps/web/lib/queries/starter.ts
+++ b/apps/web/lib/queries/starter.ts
@@ -30,10 +30,6 @@ export async function getStarterTracks({
   viewerId: string | null | undefined;
   limit?: number;
 }): Promise<StarterTrack[]> {
-  if (!viewerId) {
-    return [];
-  }
-
   return measureServerTask(
     "getStarterTracks",
     async () => {
@@ -58,6 +54,10 @@ export async function getStarterTracks({
       );
 
       if (providerIds.length === 0) {
+        return tracks.slice(0, requestedLimit);
+      }
+
+      if (!viewerId) {
         return tracks.slice(0, requestedLimit);
       }
 


### PR DESCRIPTION
## What changed

- Added the dithering auth background treatment for login and signup.
- Kept auth inputs visually solid, including OTP fields.
- Added the Classic inline spinner component and stabilized notification loading height.
- Reworked the main layout so the feed column owns scrolling while the secondary rail stays fixed and editorial.
- Added Starter picks to the right rail with right-edge scroll fading and review-dialog launch from selected tracks.
- Reduced Writers to notice skeletons to 3 rows and improved rail/footer spacing.
- Reworked profile recent activity into a native horizontal scroller using reusable track tiles.
- Fixed profile/avatar image containment during scroll.

## Why

To make Kocteau feel more polished, editorial, and stable across the main feed, profile, auth, and secondary rail surfaces without adding visual noise.

## Testing

- [ ] Ran `pnpm check`
- [x] Added screenshots or a short recording for visible web UI changes
- [ ] Confirmed this does not touch auth, Supabase, recommendations, analytics, CI, or release behavior

Notes:
- Ran `pnpm --filter web exec tsc --noEmit`
- Ran `pnpm --filter web lint`
- Ran `git diff --check`
- Verified `/` and `/u/kocteau` with Playwright screenshots.
- Verified Starter picks open the review dialog with the selected track.
- `pnpm --filter web build` timed out after a long run, so `pnpm check` was not completed.
- This touches auth UI files only; it does not change OTP/auth logic.

## Changelog impact

No manual `CHANGELOG.md` edit is required. Release Please generates release notes from PR titles and squash commits.

- [x] User-facing web change
- [ ] Developer experience or documentation change
- [ ] Internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Starter picks" rail featuring recommended tracks

* **UI/Style Improvements**
  * Redesigned spinner animation
  * Added dithering effect to authentication pages
  * Introduced scroll fade effects for refined scrolling appearance
  * Updated OTP authentication input styling
  * Improved profile avatar and recent reviews display
  * Enhanced notification dropdown interface layout

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/francozeta/kocteau/pull/32?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->