### PR TITLE
feat(web): improve public review discoverability

### DIFF
--- a/apps/web/app/(main)/page.tsx
+++ b/apps/web/app/(main)/page.tsx
@@ -17,7 +17,8 @@ import { feedKeys, type FeedInfiniteQueryData } from "@/queries/feed";
 
 export const metadata = createPageMetadata({
   title: "Kocteau",
-  description: "Music reviews by real listeners.",
+  description:
+    "Kocteau is a social music review app for public ratings, listening notes, and taste discovery.",
   path: "/",
 });
 

--- a/apps/web/app/(main)/review/[id]/page.tsx
+++ b/apps/web/app/(main)/review/[id]/page.tsx
@@ -1,0 +1,189 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import JsonLd from "@/components/json-ld";
+import ReviewPageHeaderBridge from "@/components/review-page-header-bridge";
+import { ReviewPageCard } from "@/components/review-route-cards-server";
+import { getCurrentUser } from "@/lib/auth/server";
+import { createPageMetadata, createReviewDescription } from "@/lib/metadata";
+import {
+  getPublicReviewById,
+  getReviewPageBundle,
+  type ReviewPageReview,
+} from "@/lib/queries/reviews";
+import { buildReviewPageJsonLd } from "@/lib/structured-data";
+import { reviewIdParamsSchema } from "@/lib/validation/schemas";
+
+function getAuthorLabel(review: ReviewPageReview) {
+  const author = review.author;
+
+  if (!author) {
+    return "a Kocteau listener";
+  }
+
+  return author.display_name?.trim() || `@${author.username}`;
+}
+
+function getReviewTitle(review: ReviewPageReview) {
+  const entity = review.entities;
+  const authorLabel = getAuthorLabel(review);
+
+  if (review.title?.trim() && entity) {
+    return `${review.title.trim()} — ${entity.title}`;
+  }
+
+  if (entity) {
+    const trackLabel = entity.artist_name
+      ? `${entity.title} by ${entity.artist_name}`
+      : entity.title;
+
+    return `${trackLabel} review by ${authorLabel}`;
+  }
+
+  return `Review by ${authorLabel}`;
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}): Promise<Metadata> {
+  const { id } = await params;
+  const parsedParams = reviewIdParamsSchema.safeParse({ reviewId: id });
+
+  if (!parsedParams.success) {
+    return createPageMetadata({
+      title: "Review",
+      description: "A public music review on Kocteau.",
+      path: `/review/${id}`,
+      noIndex: true,
+    });
+  }
+
+  const review = await getPublicReviewById(parsedParams.data.reviewId);
+
+  if (!review?.entities) {
+    return createPageMetadata({
+      title: "Review",
+      description: "A public music review on Kocteau.",
+      path: `/review/${id}`,
+    });
+  }
+
+  const authorLabel = getAuthorLabel(review);
+
+  return createPageMetadata({
+    title: getReviewTitle(review),
+    description: createReviewDescription({
+      title: review.title,
+      body: review.body,
+      entityTitle: review.entities.title,
+      artistName: review.entities.artist_name,
+      authorLabel,
+    }),
+    path: `/review/${review.id}`,
+    image: `/api/og/track/${review.entities.id}`,
+  });
+}
+
+export default async function ReviewPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const parsedParams = reviewIdParamsSchema.safeParse({ reviewId: id });
+
+  if (!parsedParams.success) {
+    notFound();
+  }
+
+  const user = await getCurrentUser();
+  const bundle = await getReviewPageBundle(parsedParams.data.reviewId, user?.id);
+
+  if (!bundle) {
+    notFound();
+  }
+
+  const review = {
+    ...bundle.review,
+    viewer_has_liked: bundle.liked,
+    viewer_has_bookmarked: bundle.bookmarked,
+  };
+  const entity = review.entities;
+  const author = review.author;
+  const canManage = Boolean(user?.id && author?.id === user.id);
+  const authorLabel = getAuthorLabel(review);
+  const headerTitle = review.title?.trim() || (entity ? `${entity.title} review` : "Review");
+
+  return (
+    <section className="mx-auto w-full max-w-3xl space-y-4 pb-4 sm:space-y-5">
+      <JsonLd data={buildReviewPageJsonLd(review)} id="review-structured-data" />
+      <ReviewPageHeaderBridge
+        reviewId={review.id}
+        title={headerTitle}
+        entityTitle={entity?.title}
+        artistName={entity?.artist_name}
+      />
+
+      <nav
+        aria-label="Breadcrumb"
+        className="flex flex-wrap items-center gap-2 text-[12px] text-muted-foreground"
+      >
+        <Link href="/reviews" className="transition-colors hover:text-foreground">
+          Reviews
+        </Link>
+        {entity ? (
+          <>
+            <span aria-hidden="true">/</span>
+            <Link
+              href={`/track/${entity.id}`}
+              className="line-clamp-1 transition-colors hover:text-foreground"
+            >
+              {entity.title}
+            </Link>
+          </>
+        ) : null}
+        {author?.username ? (
+          <>
+            <span aria-hidden="true">/</span>
+            <Link
+              href={`/u/${author.username}`}
+              className="line-clamp-1 transition-colors hover:text-foreground"
+            >
+              {authorLabel}
+            </Link>
+          </>
+        ) : null}
+      </nav>
+
+      <ReviewPageCard
+        review={review}
+        entity={entity}
+        author={author}
+        isAuthenticated={Boolean(user)}
+        canManage={canManage}
+      />
+
+      {entity ? (
+        <div className="flex flex-wrap items-center gap-2 text-[12px] text-muted-foreground">
+          <span>More context</span>
+          <Link
+            href={`/track/${entity.id}`}
+            className="rounded-[0.5rem] border border-border/28 px-2.5 py-1 text-foreground/86 transition-colors hover:border-border/45 hover:text-foreground"
+          >
+            {entity.title}
+          </Link>
+          {author?.username ? (
+            <Link
+              href={`/u/${author.username}`}
+              className="rounded-[0.5rem] border border-border/28 px-2.5 py-1 text-foreground/86 transition-colors hover:border-border/45 hover:text-foreground"
+            >
+              @{author.username}
+            </Link>
+          ) : null}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/app/(main)/reviews/page.tsx
+++ b/apps/web/app/(main)/reviews/page.tsx
@@ -1,0 +1,100 @@
+import { FeedReviewCard } from "@/components/review-route-cards-server";
+import JsonLd from "@/components/json-ld";
+import { getCurrentUser } from "@/lib/auth/server";
+import { createPageMetadata } from "@/lib/metadata";
+import { getFeedPage, getFeedViewerState } from "@/lib/queries/feed";
+import { buildReviewsPageJsonLd } from "@/lib/structured-data";
+
+export const metadata = createPageMetadata({
+  title: "Music Reviews",
+  description:
+    "Read recent public music reviews, ratings, and listening notes from Kocteau.",
+  path: "/reviews",
+});
+
+export default async function ReviewsPage() {
+  const user = await getCurrentUser();
+  const publicBundle = await getFeedPage({
+    view: "latest",
+    viewerId: user?.id,
+    includeActiveUsers: false,
+    limit: 14,
+  });
+  const viewerState =
+    user?.id && publicBundle.feed.length > 0
+      ? await getFeedViewerState(
+          user.id,
+          publicBundle.feed.map((review) => review.id),
+        )
+      : {
+          likedReviewIds: new Set<string>(),
+          bookmarkedReviewIds: new Set<string>(),
+        };
+  const reviews = publicBundle.feed.map((review) => ({
+    ...review,
+    viewer_has_liked: viewerState.likedReviewIds.has(review.id),
+    viewer_has_bookmarked: viewerState.bookmarkedReviewIds.has(review.id),
+  }));
+  const structuredEntries = reviews.flatMap((review) => {
+    const entity = review.entities;
+    const author = review.author;
+
+    if (!entity?.id || !author?.username) {
+      return [];
+    }
+
+    return [
+      {
+        reviewId: review.id,
+        reviewTitle: review.title,
+        reviewBody: review.body,
+        rating: review.rating,
+        entity: {
+          id: entity.id,
+          title: entity.title,
+          artistName: entity.artist_name,
+          coverUrl: entity.cover_url,
+        },
+        author: {
+          username: author.username,
+          displayName: author.display_name,
+        },
+      },
+    ];
+  });
+
+  return (
+    <section className="mx-auto w-full max-w-3xl space-y-5 pb-4 sm:space-y-6">
+      <JsonLd data={buildReviewsPageJsonLd(structuredEntries)} id="reviews-structured-data" />
+
+      <header className="space-y-2">
+        <h1 className="font-serif text-[2rem] font-semibold leading-[1.05] tracking-normal text-foreground sm:text-[2.45rem]">
+          Music reviews
+        </h1>
+        <p className="max-w-xl text-sm leading-6 text-muted-foreground text-pretty">
+          Recent ratings and listening notes from Kocteau.
+        </p>
+      </header>
+
+      <div className="space-y-4">
+        {reviews.map((review, index) => {
+          const entity = review.entities;
+          const author = review.author;
+
+          return (
+            <FeedReviewCard
+              key={review.id}
+              review={review}
+              entity={entity}
+              author={author}
+              isAuthenticated={Boolean(user)}
+              canManage={Boolean(user?.id && author?.id === user.id)}
+              featured={index === 0}
+              showInteractionBar
+            />
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/app/(main)/search/page.tsx
+++ b/apps/web/app/(main)/search/page.tsx
@@ -17,7 +17,6 @@ export async function generateMetadata({
       title: "Explore",
       description: "Search tracks and browse active songs on Kocteau.",
       path: "/search",
-      noIndex: true,
     });
   }
 

--- a/apps/web/app/(main)/track/[id]/page.tsx
+++ b/apps/web/app/(main)/track/[id]/page.tsx
@@ -105,6 +105,19 @@ export default async function TrackPage({
           entity,
           reviewCount: trackReviews.length,
           averageRating,
+          reviews: trackReviews.slice(0, 12).map((review) => ({
+            id: review.id,
+            title: review.title,
+            body: review.body,
+            rating: review.rating,
+            created_at: review.created_at,
+            author: review.author
+              ? {
+                  username: review.author.username,
+                  display_name: review.author.display_name,
+                }
+              : null,
+          })),
         })}
         id="track-structured-data"
       />

--- a/apps/web/app/llms.txt/route.ts
+++ b/apps/web/app/llms.txt/route.ts
@@ -1,0 +1,40 @@
+import { getMetadataBase } from "@/lib/metadata";
+
+export const dynamic = "force-static";
+
+export function GET() {
+  const siteUrl = getMetadataBase().origin;
+  const body = [
+    "# Kocteau",
+    "",
+    "Kocteau is a public music review and taste discovery app. It centers on listener-written reviews, ratings, music profiles, and track pages.",
+    "",
+    "Public, crawlable content:",
+    `- ${siteUrl}/ — recent public music reviews and the main Kocteau feed`,
+    `- ${siteUrl}/reviews — recent public review index`,
+    `- ${siteUrl}/review/{id} — canonical page for a single public music review`,
+    `- ${siteUrl}/track — recently discussed tracks`,
+    `- ${siteUrl}/track/{id} — public track page with reviews and aggregate rating context`,
+    `- ${siteUrl}/u/{username} — public listener profile with reviews and taste links`,
+    `- ${siteUrl}/search — public exploration entry point for tracks and active songs`,
+    "",
+    "Private or write-only actions:",
+    "- Publishing, editing, liking, bookmarking, commenting, following, notifications, and saved reviews require login.",
+    "- Auth, onboarding, and application API routes are not intended as citation targets.",
+    "",
+    "Preferred citation targets:",
+    "- Cite individual opinions with /review/{id}.",
+    "- Cite track-level public discussion with /track/{id}.",
+    "- Cite a listener's public body of work with /u/{username}.",
+    "",
+    `Sitemap: ${siteUrl}/sitemap.xml`,
+    `Robots: ${siteUrl}/robots.txt`,
+  ].join("\n");
+
+  return new Response(body, {
+    headers: {
+      "content-type": "text/plain; charset=utf-8",
+      "cache-control": "public, max-age=3600, s-maxage=86400",
+    },
+  });
+}

--- a/apps/web/app/robots.ts
+++ b/apps/web/app/robots.ts
@@ -3,21 +3,30 @@ import { getMetadataBase } from "@/lib/metadata";
 
 export default function robots(): MetadataRoute.Robots {
   const metadataBase = getMetadataBase();
+  const publicAllow = ["/", "/api/og/"];
+  const privateDisallow = [
+    "/login",
+    "/signup",
+    "/onboarding",
+    "/notifications",
+    "/saved",
+    "/api/",
+    "/track/deezer/",
+  ];
 
   return {
-    rules: {
-      userAgent: "*",
-      allow: "/",
-      disallow: [
-        "/login",
-        "/signup",
-        "/onboarding",
-        "/notifications",
-        "/saved",
-        "/api/",
-        "/track/deezer/",
-      ],
-    },
+    rules: [
+      {
+        userAgent: "*",
+        allow: publicAllow,
+        disallow: privateDisallow,
+      },
+      {
+        userAgent: ["Googlebot", "OAI-SearchBot", "GPTBot", "ChatGPT-User"],
+        allow: publicAllow,
+        disallow: privateDisallow,
+      },
+    ],
     sitemap: new URL("/sitemap.xml", metadataBase).toString(),
     host: metadataBase.origin,
   };

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -6,29 +6,81 @@ import { supabasePublic } from "@/lib/supabase/public";
 type SitemapProfile = {
   username: string;
   created_at: string;
+  updated_at: string;
 };
 
-type SitemapTrack = {
+type SitemapReview = {
   id: string;
+  entity_id: string;
+  created_at: string;
+  updated_at: string;
+  entities:
+    | {
+        id: string;
+        created_at: string;
+        updated_at: string;
+        type: string;
+      }
+    | Array<{
+        id: string;
+        created_at: string;
+        updated_at: string;
+        type: string;
+      }>
+    | null;
 };
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const metadataBase = getMetadataBase();
   const supabase = supabasePublic();
   const now = new Date();
-  const [profilesResult, tracksResult] = await Promise.all([
+  const [profilesResult, reviewsResult] = await Promise.all([
     supabase
       .from("profiles")
-      .select("username, created_at")
-      .order("created_at", { ascending: false }),
+      .select("username, created_at, updated_at")
+      .eq("onboarded", true)
+      .not("username", "is", null)
+      .order("updated_at", { ascending: false }),
     supabase
-      .from("entities")
-      .select("id")
-      .eq("type", "track"),
+      .from("reviews")
+      .select(`
+        id,
+        entity_id,
+        created_at,
+        updated_at,
+        entities (
+          id,
+          created_at,
+          updated_at,
+          type
+        )
+      `)
+      .order("updated_at", { ascending: false })
+      .limit(5000),
   ]);
 
   const profiles = (profilesResult.data ?? []) as SitemapProfile[];
-  const tracks = (tracksResult.data ?? []) as SitemapTrack[];
+  const reviews = (reviewsResult.data ?? []) as SitemapReview[];
+  const reviewedTracks = new Map<string, Date>();
+
+  for (const review of reviews) {
+    const entity = Array.isArray(review.entities)
+      ? review.entities[0] ?? null
+      : review.entities;
+
+    if (!entity?.id || entity.type !== "track") {
+      continue;
+    }
+
+    const currentDate = reviewedTracks.get(entity.id);
+    const reviewDate = new Date(review.updated_at ?? review.created_at);
+    const entityDate = new Date(entity.updated_at ?? entity.created_at);
+    const latestDate = reviewDate > entityDate ? reviewDate : entityDate;
+
+    if (!currentDate || latestDate > currentDate) {
+      reviewedTracks.set(entity.id, latestDate);
+    }
+  }
 
   const staticRoutes: MetadataRoute.Sitemap = [
     {
@@ -38,10 +90,22 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 1,
     },
     {
+      url: new URL("/reviews", metadataBase).toString(),
+      lastModified: now,
+      changeFrequency: "hourly",
+      priority: 0.9,
+    },
+    {
       url: new URL("/track", metadataBase).toString(),
       lastModified: now,
       changeFrequency: "daily",
       priority: 0.7,
+    },
+    {
+      url: new URL("/search", metadataBase).toString(),
+      lastModified: now,
+      changeFrequency: "daily",
+      priority: 0.65,
     },
     ...helpRoutes.map((route) => ({
       url: new URL(route.href, metadataBase).toString(),
@@ -55,17 +119,24 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     .filter((profile) => Boolean(profile.username))
     .map((profile) => ({
       url: new URL(`/u/${profile.username}`, metadataBase).toString(),
-      lastModified: new Date(profile.created_at),
+      lastModified: new Date(profile.updated_at ?? profile.created_at),
       changeFrequency: "weekly",
       priority: 0.6,
     }));
 
-  const trackRoutes: MetadataRoute.Sitemap = tracks.map((track) => ({
-    url: new URL(`/track/${track.id}`, metadataBase).toString(),
-    lastModified: now,
+  const reviewRoutes: MetadataRoute.Sitemap = reviews.map((review) => ({
+    url: new URL(`/review/${review.id}`, metadataBase).toString(),
+    lastModified: new Date(review.updated_at ?? review.created_at),
+    changeFrequency: "weekly",
+    priority: 0.78,
+  }));
+
+  const trackRoutes: MetadataRoute.Sitemap = Array.from(reviewedTracks, ([trackId, lastModified]) => ({
+    url: new URL(`/track/${trackId}`, metadataBase).toString(),
+    lastModified,
     changeFrequency: "daily",
     priority: 0.8,
   }));
 
-  return [...staticRoutes, ...trackRoutes, ...profileRoutes];
+  return [...staticRoutes, ...reviewRoutes, ...trackRoutes, ...profileRoutes];
 }

--- a/apps/web/components/header.tsx
+++ b/apps/web/components/header.tsx
@@ -60,7 +60,7 @@ export default function Header({
   const isMobileReviewRoute = /^\/review\/[^/]+$/.test(pathname);
   const isTrackDetailRoute = /^\/track\/[^/]+$/.test(pathname);
   const isProfileDetailRoute = /^\/u\/[^/]+$/.test(pathname);
-  const shouldUseContextualHeader = isTrackDetailRoute || isProfileDetailRoute;
+  const shouldUseContextualHeader = isTrackDetailRoute || isProfileDetailRoute || isMobileReviewRoute;
   const isSearchRoute = pathname.startsWith("/search");
 
   const standardHeaderTitle = (() => {
@@ -70,6 +70,10 @@ export default function Header({
 
     if (isProfileDetailRoute) {
       return detailHeader?.shareLabel ?? "Profile";
+    }
+
+    if (isMobileReviewRoute) {
+      return detailHeader?.shareLabel ?? "Review";
     }
 
     if (pathname === "/") {
@@ -128,27 +132,27 @@ export default function Header({
       return;
     }
 
-    router.push(isProfileDetailRoute ? "/" : "/search");
-  }, [isProfileDetailRoute, router]);
+    router.push(isProfileDetailRoute ? "/" : isMobileReviewRoute ? "/reviews" : "/search");
+  }, [isMobileReviewRoute, isProfileDetailRoute, router]);
 
   const handleShareDetail = useCallback(async () => {
     if (typeof window === "undefined") {
       return;
     }
 
-    const detailKind = detailHeader?.kind ?? (isProfileDetailRoute ? "profile" : "track");
+    const detailKind =
+      detailHeader?.kind ?? (isProfileDetailRoute ? "profile" : isMobileReviewRoute ? "review" : "track");
     const absoluteUrl = new URL(detailHeader?.sharePath ?? pathname, window.location.origin).toString();
+    const detailLabel =
+      detailKind === "profile" ? "Profile" : detailKind === "review" ? "Review" : "Track";
 
     await shareUrl({
       title: detailHeader?.shareLabel ?? document.title,
       url: absoluteUrl,
-      successMessage: detailKind === "profile" ? "Profile link copied" : "Track link copied",
-      errorMessage:
-        detailKind === "profile"
-          ? "We couldn't share this profile right now."
-          : "We couldn't share this track right now.",
+      successMessage: `${detailLabel} link copied`,
+      errorMessage: `We couldn't share this ${detailLabel.toLowerCase()} right now.`,
     });
-  }, [detailHeader, isProfileDetailRoute, pathname]);
+  }, [detailHeader, isMobileReviewRoute, isProfileDetailRoute, pathname]);
 
   const standardHeader = (
     <header className={cn(
@@ -237,7 +241,7 @@ export default function Header({
                     variant="ghost"
                     size="icon-lg"
                     className="mobile-liquid-button size-10 rounded-full text-muted-foreground hover:text-foreground"
-                    aria-label={isProfileDetailRoute ? "Profile actions" : "Track actions"}
+                    aria-label={isProfileDetailRoute ? "Profile actions" : isMobileReviewRoute ? "Review actions" : "Track actions"}
                   >
                     <MoreHorizontal className="size-[1.1rem]" />
                   </Button>
@@ -249,7 +253,7 @@ export default function Header({
                 >
                   <DropdownMenuItem onSelect={() => void handleShareDetail()}>
                     <Share2 className="size-4" />
-                    {isProfileDetailRoute ? "Share profile" : "Share track"}
+                    {isProfileDetailRoute ? "Share profile" : isMobileReviewRoute ? "Share review" : "Share track"}
                   </DropdownMenuItem>
 
                   {(detailHeader?.externalLinks ?? []).map((link) => (

--- a/apps/web/components/nav-owned-reviews.tsx
+++ b/apps/web/components/nav-owned-reviews.tsx
@@ -54,8 +54,7 @@ function OwnedReviewRailItem({
     <SidebarMenuItem>
       <div className="kocteau-sidebar-note flex items-start gap-1 rounded-[0.95rem] px-2 py-2">
         <PrefetchLink
-          href={`/track/${item.entity.entity_id}#review-${item.id}`}
-          queryWarmup={{ kind: "track", id: item.entity.entity_id }}
+          href={`/review/${item.id}`}
           onClick={onNavigate}
           className="group min-w-0 flex-1 rounded-lg"
         >

--- a/apps/web/components/profile-recent-reviews-section.tsx
+++ b/apps/web/components/profile-recent-reviews-section.tsx
@@ -64,7 +64,7 @@ export default function ProfileRecentReviewsSection({
       ) : (
         <TrackCarousel
           ariaLabel="Recent activity"
-          controlClassName="[--kocteau-carousel-cover-size:8.6rem] lg:[--kocteau-carousel-cover-size:8.35rem]"
+          controlClassName="left-2 right-2 [--kocteau-carousel-cover-size:8.6rem] lg:[--kocteau-carousel-cover-size:8.35rem]"
           itemClassName="basis-[8.5rem] sm:basis-[9rem] lg:basis-[8.35rem] xl:basis-[8.6rem]"
         >
           {recentReviews.map((review) => (

--- a/apps/web/components/review-actions.tsx
+++ b/apps/web/components/review-actions.tsx
@@ -60,9 +60,9 @@ export function useReviewActions({
       return "";
     }
 
-    const pathname = entityId ? `/track/${entityId}#review-${reviewId}` : `/#review-${reviewId}`;
+    const pathname = `/review/${reviewId}`;
     return new URL(pathname, window.location.origin).toString();
-  }, [entityId, reviewId]);
+  }, [reviewId]);
 
   async function copyReviewLink() {
     try {

--- a/apps/web/components/review-page-header-bridge.tsx
+++ b/apps/web/components/review-page-header-bridge.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouteHeader } from "@/components/route-header-context";
+
+type ReviewPageHeaderBridgeProps = {
+  reviewId: string;
+  title: string;
+  entityTitle?: string | null;
+  artistName?: string | null;
+};
+
+export default function ReviewPageHeaderBridge({
+  reviewId,
+  title,
+  entityTitle,
+  artistName,
+}: ReviewPageHeaderBridgeProps) {
+  const { setDetailHeader } = useRouteHeader();
+
+  useEffect(() => {
+    const trackLabel = entityTitle
+      ? artistName?.trim()
+        ? `${entityTitle} — ${artistName}`
+        : entityTitle
+      : "Review";
+
+    setDetailHeader({
+      kind: "review",
+      title,
+      shareLabel: title.trim() || trackLabel,
+      sharePath: `/review/${reviewId}`,
+      externalLinks: [],
+    });
+
+    return () => {
+      setDetailHeader(null);
+    };
+  }, [artistName, entityTitle, reviewId, setDetailHeader, title]);
+
+  return null;
+}

--- a/apps/web/components/review-route-cards-server.tsx
+++ b/apps/web/components/review-route-cards-server.tsx
@@ -69,6 +69,12 @@ function buildTrackReviewCardDisplay(): ReviewCardDisplayOptions {
   };
 }
 
+function buildReviewPageCardDisplay(): ReviewCardDisplayOptions {
+  return {
+    entityMode: "cover",
+  };
+}
+
 function getAuthorLabel(author: ReviewCardAuthor | null | undefined) {
   return author?.display_name ?? (author ? `@${author.username}` : "Unknown user");
 }
@@ -200,56 +206,64 @@ async function RoutedReviewCardServer({
   const initialBookmarked = Boolean(review.viewer_has_bookmarked);
 
   const card = (
-    <ReviewCard
-      review={review}
-      entity={entity}
-      author={author}
-      display={display}
-      rootProps={rootProps}
-      slots={{
-        authorName: author ? <LinkedAuthorName author={author} /> : undefined,
-        entity: entity ? (
-          <LinkedEntitySummary
-            entity={entity}
-            mode={entityMode}
-            priority={entityPriority}
-            tone={copyTone}
-          />
-        ) : undefined,
-        entityCover:
-          entity && entityMode === "cover" ? (
-            <LinkedEntityCover entity={entity} priority={entityPriority} />
+    <div>
+      <Link
+        href={`/review/${review.id}`}
+        className="sr-only focus:not-sr-only focus:mb-2 focus:inline-flex focus:h-8 focus:items-center focus:rounded-[0.55rem] focus:border focus:border-border/35 focus:bg-muted/18 focus:px-3 focus:text-xs focus:font-medium focus:text-foreground focus:outline-none focus:ring-2 focus:ring-ring/30"
+      >
+        Open review
+      </Link>
+      <ReviewCard
+        review={review}
+        entity={entity}
+        author={author}
+        display={display}
+        rootProps={rootProps}
+        slots={{
+          authorName: author ? <LinkedAuthorName author={author} /> : undefined,
+          entity: entity ? (
+            <LinkedEntitySummary
+              entity={entity}
+              mode={entityMode}
+              priority={entityPriority}
+              tone={copyTone}
+            />
           ) : undefined,
-        headerActions: showHeaderActions ? (
-          <ReviewActionsMenu
-            reviewId={review.id}
-            reviewTitle={review.title}
-            entityTitle={entity?.title ?? null}
-            entityId={entity?.id ?? null}
-            canManage={canManage}
-            editSeed={editSeed}
-            initialBookmarked={initialBookmarked}
-            isAuthenticated={isAuthenticated}
-          />
-        ) : null,
-        footer: showInteractionBar ? (
-          <ReviewCardInteractionBar
-            review={review}
-            isAuthenticated={isAuthenticated}
-            viewer={
-              viewerProfile
-                ? {
-                    id: viewerProfile.id,
-                    username: viewerProfile.username,
-                    display_name: viewerProfile.display_name,
-                    avatar_url: viewerProfile.avatar_url,
-                  }
-                : null
-            }
-          />
-        ) : null,
-      }}
-    />
+          entityCover:
+            entity && entityMode === "cover" ? (
+              <LinkedEntityCover entity={entity} priority={entityPriority} />
+            ) : undefined,
+          headerActions: showHeaderActions ? (
+            <ReviewActionsMenu
+              reviewId={review.id}
+              reviewTitle={review.title}
+              entityTitle={entity?.title ?? null}
+              entityId={entity?.id ?? null}
+              canManage={canManage}
+              editSeed={editSeed}
+              initialBookmarked={initialBookmarked}
+              isAuthenticated={isAuthenticated}
+            />
+          ) : null,
+          footer: showInteractionBar ? (
+            <ReviewCardInteractionBar
+              review={review}
+              isAuthenticated={isAuthenticated}
+              viewer={
+                viewerProfile
+                  ? {
+                      id: viewerProfile.id,
+                      username: viewerProfile.username,
+                      display_name: viewerProfile.display_name,
+                      avatar_url: viewerProfile.avatar_url,
+                    }
+                  : null
+              }
+            />
+          ) : null,
+        }}
+      />
+    </div>
   );
 
   if (!showContextMenu) {
@@ -325,6 +339,24 @@ export async function ProfileReviewCard({
       entity={entity}
       author={author}
       display={buildFeedReviewCardDisplay(featured)}
+      permissions={{ isAuthenticated, canManage }}
+    />
+  );
+}
+
+export async function ReviewPageCard({
+  review,
+  entity,
+  author = null,
+  isAuthenticated = false,
+  canManage = false,
+}: ReviewCardRouteProps) {
+  return (
+    <RoutedReviewCardServer
+      review={review}
+      entity={entity}
+      author={author}
+      display={buildReviewPageCardDisplay()}
       permissions={{ isAuthenticated, canManage }}
     />
   );

--- a/apps/web/components/review-route-cards.tsx
+++ b/apps/web/components/review-route-cards.tsx
@@ -95,6 +95,12 @@ function buildSavedReviewCardDisplay(): ReviewCardDisplayOptions {
   };
 }
 
+function buildReviewPageCardDisplay(): ReviewCardDisplayOptions {
+  return {
+    entityMode: "cover",
+  };
+}
+
 function getAuthorLabel(author: ReviewCardAuthor | null | undefined) {
   return author?.display_name ?? (author ? `@${author.username}` : "Unknown user");
 }
@@ -221,48 +227,56 @@ function RoutedReviewCard({
   };
 
   const card = (
-    <ReviewCard
-      review={review}
-      entity={entity}
-      author={author}
-      display={display}
-      rootProps={rootProps}
-      slots={{
-        authorName: author ? <LinkedAuthorName author={author} /> : undefined,
-        entity: entity ? (
-          <LinkedEntitySummary
-            entity={entity}
-            mode={entityMode}
-            priority={entityPriority}
-            tone={copyTone}
-          />
-        ) : undefined,
-        entityCover:
-          entity && entityMode === "cover" ? (
-            <LinkedEntityCover entity={entity} priority={entityPriority} />
+    <div>
+      <PrefetchLink
+        href={`/review/${review.id}`}
+        className="sr-only focus:not-sr-only focus:mb-2 focus:inline-flex focus:h-8 focus:items-center focus:rounded-[0.55rem] focus:border focus:border-border/35 focus:bg-muted/18 focus:px-3 focus:text-xs focus:font-medium focus:text-foreground focus:outline-none focus:ring-2 focus:ring-ring/30"
+      >
+        Open review
+      </PrefetchLink>
+      <ReviewCard
+        review={review}
+        entity={entity}
+        author={author}
+        display={display}
+        rootProps={rootProps}
+        slots={{
+          authorName: author ? <LinkedAuthorName author={author} /> : undefined,
+          entity: entity ? (
+            <LinkedEntitySummary
+              entity={entity}
+              mode={entityMode}
+              priority={entityPriority}
+              tone={copyTone}
+            />
           ) : undefined,
-        headerActions: showHeaderActions ? (
-          <ReviewActionsMenu
-            reviewId={review.id}
-            reviewTitle={review.title}
-            entityTitle={entity?.title ?? null}
-            entityId={entity?.id ?? null}
-            canManage={canManage}
-            editSeed={editSeed}
-            initialBookmarked={initialBookmarked}
-            isAuthenticated={isAuthenticated}
-          />
-        ) : null,
-        footer: showInteractionBar ? (
-          <ReviewCardInteractionBar
-            review={review}
-            isAuthenticated={isAuthenticated}
-            viewer={viewer}
-            analyticsSource={analyticsSource}
-          />
-        ) : null,
-      }}
-    />
+          entityCover:
+            entity && entityMode === "cover" ? (
+              <LinkedEntityCover entity={entity} priority={entityPriority} />
+            ) : undefined,
+          headerActions: showHeaderActions ? (
+            <ReviewActionsMenu
+              reviewId={review.id}
+              reviewTitle={review.title}
+              entityTitle={entity?.title ?? null}
+              entityId={entity?.id ?? null}
+              canManage={canManage}
+              editSeed={editSeed}
+              initialBookmarked={initialBookmarked}
+              isAuthenticated={isAuthenticated}
+            />
+          ) : null,
+          footer: showInteractionBar ? (
+            <ReviewCardInteractionBar
+              review={review}
+              isAuthenticated={isAuthenticated}
+              viewer={viewer}
+              analyticsSource={analyticsSource}
+            />
+          ) : null,
+        }}
+      />
+    </div>
   );
 
   if (!showContextMenu) {
@@ -389,7 +403,7 @@ export function ReviewPageCard({
       review={review}
       entity={entity}
       author={author}
-      display={buildFeedReviewCardDisplay()}
+      display={buildReviewPageCardDisplay()}
       permissions={{ isAuthenticated, canManage }}
       viewer={viewer}
     />

--- a/apps/web/components/route-header-context.tsx
+++ b/apps/web/components/route-header-context.tsx
@@ -11,7 +11,7 @@ import {
 } from "react";
 
 export type DetailHeaderState = {
-  kind: "track" | "profile";
+  kind: "track" | "profile" | "review";
   title: string;
   shareLabel: string;
   sharePath: string;

--- a/apps/web/components/track-carousel.tsx
+++ b/apps/web/components/track-carousel.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useRef } from "react";
 import type { ReactNode } from "react";
 import { CaretLeftIcon, CaretRightIcon } from "@/components/ui/icons";
 import {
@@ -105,6 +106,95 @@ function TrackCarouselControls({
   );
 }
 
+function TrackCarouselWheelNavigation() {
+  const {
+    api,
+    canScrollNext,
+    canScrollPrev,
+    scrollNext,
+    scrollPrev,
+  } = useCarousel();
+  const canScrollNextRef = useRef(canScrollNext);
+  const canScrollPrevRef = useRef(canScrollPrev);
+  const wheelDeltaRef = useRef(0);
+  const lastScrollAtRef = useRef(0);
+
+  useEffect(() => {
+    canScrollNextRef.current = canScrollNext;
+    canScrollPrevRef.current = canScrollPrev;
+  }, [canScrollNext, canScrollPrev]);
+
+  useEffect(() => {
+    if (!api) {
+      return;
+    }
+
+    const rootNode = api.rootNode();
+
+    function handleWheel(event: WheelEvent) {
+      const hasHorizontalIntent =
+        Math.abs(event.deltaX) > Math.abs(event.deltaY) || event.shiftKey;
+
+      if (!hasHorizontalIntent) {
+        return;
+      }
+
+      const rawDelta = Math.abs(event.deltaX) > Math.abs(event.deltaY)
+        ? event.deltaX
+        : event.deltaY;
+      const normalizedDelta =
+        event.deltaMode === WheelEvent.DOM_DELTA_LINE ? rawDelta * 16 : rawDelta;
+      const direction = Math.sign(normalizedDelta);
+
+      if (direction === 0) {
+        return;
+      }
+
+      const canScroll = direction > 0
+        ? canScrollNextRef.current
+        : canScrollPrevRef.current;
+
+      if (!canScroll) {
+        wheelDeltaRef.current = 0;
+        return;
+      }
+
+      event.preventDefault();
+      wheelDeltaRef.current += normalizedDelta;
+
+      if (Math.sign(wheelDeltaRef.current) !== direction) {
+        wheelDeltaRef.current = normalizedDelta;
+      }
+
+      const now = performance.now();
+
+      if (
+        Math.abs(wheelDeltaRef.current) < 42 ||
+        now - lastScrollAtRef.current < 360
+      ) {
+        return;
+      }
+
+      if (direction > 0) {
+        scrollNext();
+      } else {
+        scrollPrev();
+      }
+
+      wheelDeltaRef.current = 0;
+      lastScrollAtRef.current = now;
+    }
+
+    rootNode.addEventListener("wheel", handleWheel, { passive: false });
+
+    return () => {
+      rootNode.removeEventListener("wheel", handleWheel);
+    };
+  }, [api, scrollNext, scrollPrev]);
+
+  return null;
+}
+
 export default function TrackCarousel({
   ariaLabel,
   children,
@@ -134,6 +224,7 @@ export default function TrackCarousel({
       >
         {children}
       </TrackCarouselContent>
+      <TrackCarouselWheelNavigation />
       <TrackCarouselControls compact={compactControls} className={controlClassName} />
     </Carousel>
   );

--- a/apps/web/lib/metadata.ts
+++ b/apps/web/lib/metadata.ts
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 
 const SITE_NAME = "Kocteau";
 const DEFAULT_DESCRIPTION =
-  "Music reviews by real listeners.";
+  "Kocteau is a music review and taste discovery app for public listening notes, ratings, and profiles.";
 const DEFAULT_OPEN_GRAPH_IMAGE = "/og/kocteau.webp";
 const DEFAULT_TWITTER_IMAGE = "/og/kocteau.webp";
 
@@ -132,6 +132,39 @@ export function createTrackDescription(title: string, artist?: string | null) {
   return artist
     ? `Reviews, ratings, and notes for ${title} by ${artist} on Kocteau.`
     : `Reviews, ratings, and notes for ${title} on Kocteau.`;
+}
+
+function truncateMetadataText(value: string, maxLength = 155) {
+  const normalized = value.replace(/\s+/g, " ").trim();
+
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+
+  return `${normalized.slice(0, maxLength - 1).trimEnd()}…`;
+}
+
+export function createReviewDescription({
+  title,
+  body,
+  entityTitle,
+  artistName,
+  authorLabel,
+}: {
+  title?: string | null;
+  body?: string | null;
+  entityTitle: string;
+  artistName?: string | null;
+  authorLabel: string;
+}) {
+  const excerpt = body?.trim() || title?.trim();
+  const trackLabel = artistName ? `${entityTitle} by ${artistName}` : entityTitle;
+
+  if (excerpt) {
+    return truncateMetadataText(`${excerpt} Review of ${trackLabel} by ${authorLabel} on Kocteau.`);
+  }
+
+  return `A Kocteau review of ${trackLabel} by ${authorLabel}.`;
 }
 
 export function createProfileDescription(

--- a/apps/web/lib/notifications.ts
+++ b/apps/web/lib/notifications.ts
@@ -114,8 +114,8 @@ export function normalizeNotification(record: NotificationRecord): NotificationI
 }
 
 export function notificationHref(notification: NotificationItem) {
-  if (notification.review?.entity_id && notification.review_id) {
-    return `/track/${notification.review.entity_id}#review-${notification.review_id}`;
+  if (notification.review_id) {
+    return `/review/${notification.review_id}`;
   }
 
   if (notification.review?.entity_id) {

--- a/apps/web/lib/structured-data.ts
+++ b/apps/web/lib/structured-data.ts
@@ -1,6 +1,7 @@
 import type { FeedReview } from "@/lib/queries/feed";
 import type { EntityPage } from "@/lib/queries/entities";
 import type { PublicProfile } from "@/lib/queries/profiles";
+import type { ReviewPageReview } from "@/lib/queries/reviews";
 import { getMetadataBase } from "@/lib/metadata";
 
 type FeedStructuredDataEntry = {
@@ -20,8 +21,79 @@ type FeedStructuredDataEntry = {
   };
 };
 
+type StructuredReviewEntry = {
+  id: string;
+  title?: string | null;
+  body?: string | null;
+  rating: number;
+  created_at?: string | null;
+  entity: {
+    id: string;
+    title: string;
+    artistName?: string | null;
+    coverUrl?: string | null;
+    deezerUrl?: string | null;
+  };
+  author: {
+    username: string;
+    displayName?: string | null;
+  };
+};
+
 function absoluteUrl(path: string) {
   return new URL(path, getMetadataBase()).toString();
+}
+
+function authorName(author: StructuredReviewEntry["author"]) {
+  return author.displayName?.trim() || `@${author.username}`;
+}
+
+function buildReviewNode(entry: StructuredReviewEntry) {
+  return {
+    "@type": "Review",
+    "@id": `${absoluteUrl(`/review/${entry.id}`)}#review`,
+    url: absoluteUrl(`/review/${entry.id}`),
+    name: entry.title?.trim() || `${entry.entity.title} review`,
+    reviewBody: entry.body?.trim() || undefined,
+    datePublished: entry.created_at || undefined,
+    reviewRating: {
+      "@type": "Rating",
+      ratingValue: entry.rating,
+      bestRating: 5,
+      worstRating: 1,
+    },
+    author: {
+      "@type": "Person",
+      name: authorName(entry.author),
+      url: absoluteUrl(`/u/${entry.author.username}`),
+    },
+    itemReviewed: {
+      "@type": "MusicRecording",
+      "@id": `${absoluteUrl(`/track/${entry.entity.id}`)}#recording`,
+      name: entry.entity.title,
+      url: absoluteUrl(`/track/${entry.entity.id}`),
+      image: entry.entity.coverUrl || undefined,
+      sameAs: entry.entity.deezerUrl || undefined,
+      byArtist: entry.entity.artistName
+        ? {
+            "@type": "MusicGroup",
+            name: entry.entity.artistName,
+          }
+        : undefined,
+    },
+  };
+}
+
+function buildBreadcrumbList(items: Array<{ name: string; path: string }>) {
+  return {
+    "@type": "BreadcrumbList",
+    itemListElement: items.map((item, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: item.name,
+      item: absoluteUrl(item.path),
+    })),
+  };
 }
 
 export function buildSiteGraphJsonLd() {
@@ -34,6 +106,7 @@ export function buildSiteGraphJsonLd() {
         "@type": "Organization",
         "@id": `${siteUrl}#organization`,
         name: "Kocteau",
+        alternateName: ["Kocteau music reviews", "Kocteau reviews"],
         url: siteUrl,
         logo: absoluteUrl("/logo.svg"),
         description:
@@ -43,6 +116,7 @@ export function buildSiteGraphJsonLd() {
         "@type": "WebSite",
         "@id": `${siteUrl}#website`,
         name: "Kocteau",
+        alternateName: ["Kocteau reviews", "Kocteau music reviews"],
         url: siteUrl,
         description:
           "Read music reviews, track listening notes, discover active songs, and explore public taste profiles on Kocteau.",
@@ -80,35 +154,54 @@ export function buildFeedPageJsonLd(entries: FeedStructuredDataEntry[]) {
       itemListElement: entries.map((entry, index) => ({
         "@type": "ListItem",
         position: index + 1,
-        url: absoluteUrl(`/track/${entry.entity.id}#review-${entry.reviewId}`),
-        item: {
-          "@type": "Review",
-          name: entry.reviewTitle?.trim() || `${entry.entity.title} review`,
-          reviewBody: entry.reviewBody?.trim() || undefined,
-          reviewRating: {
-            "@type": "Rating",
-            ratingValue: entry.rating,
-            bestRating: 5,
-            worstRating: 1,
-          },
-          author: {
-            "@type": "Person",
-            name: entry.author.displayName?.trim() || `@${entry.author.username}`,
-            url: absoluteUrl(`/u/${entry.author.username}`),
-          },
-          itemReviewed: {
-            "@type": "MusicRecording",
-            name: entry.entity.title,
-            byArtist: entry.entity.artistName
-              ? {
-                  "@type": "MusicGroup",
-                  name: entry.entity.artistName,
-                }
-              : undefined,
-            url: absoluteUrl(`/track/${entry.entity.id}`),
-            image: entry.entity.coverUrl || undefined,
-          },
-        },
+        url: absoluteUrl(`/review/${entry.reviewId}`),
+        item: buildReviewNode({
+          id: entry.reviewId,
+          title: entry.reviewTitle,
+          body: entry.reviewBody,
+          rating: entry.rating,
+          entity: entry.entity,
+          author: entry.author,
+        }),
+      })),
+    },
+  };
+}
+
+export function buildReviewsPageJsonLd(entries: FeedStructuredDataEntry[]) {
+  const url = absoluteUrl("/reviews");
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    "@id": `${url}#reviews`,
+    name: "Music reviews on Kocteau",
+    description:
+      "Recent public music reviews, ratings, and listening notes from Kocteau.",
+    url,
+    isPartOf: {
+      "@id": `${absoluteUrl("/")}#website`,
+    },
+    breadcrumb: buildBreadcrumbList([
+      { name: "Kocteau", path: "/" },
+      { name: "Reviews", path: "/reviews" },
+    ]),
+    mainEntity: {
+      "@type": "ItemList",
+      itemListOrder: "https://schema.org/ItemListOrderDescending",
+      numberOfItems: entries.length,
+      itemListElement: entries.map((entry, index) => ({
+        "@type": "ListItem",
+        position: index + 1,
+        url: absoluteUrl(`/review/${entry.reviewId}`),
+        item: buildReviewNode({
+          id: entry.reviewId,
+          title: entry.reviewTitle,
+          body: entry.reviewBody,
+          rating: entry.rating,
+          entity: entry.entity,
+          author: entry.author,
+        }),
       })),
     },
   };
@@ -118,10 +211,22 @@ export function buildTrackPageJsonLd({
   entity,
   reviewCount,
   averageRating,
+  reviews = [],
 }: {
   entity: EntityPage;
   reviewCount: number;
   averageRating?: number | null;
+  reviews?: Array<{
+    id: string;
+    title?: string | null;
+    body?: string | null;
+    rating: number;
+    created_at?: string | null;
+    author?: {
+      username: string;
+      display_name?: string | null;
+    } | null;
+  }>;
 }) {
   const url = absoluteUrl(`/track/${entity.id}`);
 
@@ -139,6 +244,11 @@ export function buildTrackPageJsonLd({
         mainEntity: {
           "@id": `${url}#recording`,
         },
+        breadcrumb: buildBreadcrumbList([
+          { name: "Kocteau", path: "/" },
+          { name: "Tracks", path: "/track" },
+          { name: entity.title, path: `/track/${entity.id}` },
+        ]),
       },
       {
         "@type": "MusicRecording",
@@ -163,7 +273,89 @@ export function buildTrackPageJsonLd({
                 worstRating: 1,
               }
             : undefined,
+        review: reviews
+          .filter((review) => review.author?.username)
+          .map((review) =>
+            buildReviewNode({
+              id: review.id,
+              title: review.title,
+              body: review.body,
+              rating: review.rating,
+              created_at: review.created_at,
+              entity: {
+                id: entity.id,
+                title: entity.title,
+                artistName: entity.artist_name,
+                coverUrl: entity.cover_url,
+                deezerUrl: entity.deezer_url,
+              },
+              author: {
+                username: review.author?.username ?? "",
+                displayName: review.author?.display_name,
+              },
+            }),
+          ),
       },
+    ],
+  };
+}
+
+export function buildReviewPageJsonLd(review: ReviewPageReview) {
+  const entity = review.entities;
+  const author = review.author;
+  const url = absoluteUrl(`/review/${review.id}`);
+
+  if (!entity || !author?.username) {
+    return {
+      "@context": "https://schema.org",
+      "@type": "WebPage",
+      "@id": `${url}#webpage`,
+      url,
+      name: review.title?.trim() || "Kocteau review",
+      isPartOf: {
+        "@id": `${absoluteUrl("/")}#website`,
+      },
+    };
+  }
+
+  return {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "WebPage",
+        "@id": `${url}#webpage`,
+        url,
+        name: review.title?.trim() || `${entity.title} review`,
+        isPartOf: {
+          "@id": `${absoluteUrl("/")}#website`,
+        },
+        mainEntity: {
+          "@id": `${url}#review`,
+        },
+        breadcrumb: buildBreadcrumbList([
+          { name: "Kocteau", path: "/" },
+          { name: "Reviews", path: "/reviews" },
+          { name: entity.title, path: `/track/${entity.id}` },
+        ]),
+      },
+      buildReviewNode({
+        id: review.id,
+        title: review.title,
+        body: review.body,
+        rating: review.rating,
+        created_at: review.created_at,
+        entity: {
+          id: entity.id,
+          title: entity.title,
+          artistName: entity.artist_name,
+          coverUrl: entity.cover_url,
+          deezerUrl: entity.deezer_url,
+        },
+        author: {
+          username: author.username,
+          displayName: author.display_name,
+        },
+      }),
     ],
   };
 }


### PR DESCRIPTION
## What changed

- Added public canonical review pages at `/review/[id]`.
- Added a public `/reviews` index for recent Kocteau music reviews.
- Updated review share links, notifications, and sidebar review links to use canonical review URLs.
- Improved metadata for Kocteau, review pages, reviews index, and public discovery surfaces.
- Expanded structured data with Review, MusicRecording, CollectionPage, ProfilePage, BreadcrumbList, and stronger site graph data.
- Updated sitemap generation to include reviews, reviewed tracks, public profiles, `/reviews`, and `/search`.
- Updated robots rules to keep private routes blocked while allowing public pages and OG images.
- Added `/llms.txt` as a crawler/AI-readable map of Kocteau’s public content.

## Why

Kocteau’s strongest SEO asset is real public music review content, not a generic landing page. This makes reviews, tracks, profiles, and discovery pages easier for Google and AI systems to crawl, understand, index, and cite.

## Testing

- [ ] Ran `pnpm check`
- [ ] Added screenshots or a short recording for visible web UI changes
- [x] Confirmed this does not touch auth, Supabase schema/RLS, recommendations, analytics, CI, or release behavior

Additional checks run:

- `pnpm --filter web exec tsc --noEmit --pretty false`
- `pnpm --filter web lint`
- `pnpm --filter web build`
- Smoke-tested `/reviews`, `/review/[id]`, `/robots.txt`, `/sitemap.xml`, and `/llms.txt`

## Changelog impact

No manual `CHANGELOG.md` edit is required. Release Please generates release notes from PR titles and squash commits.

- [x] User-facing web change
- [ ] Developer experience or documentation change
- [ ] Internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added dedicated review pages with individual URLs for easy sharing and viewing
  * Added reviews feed/listing page to browse all public reviews in one place

* **Improvements**
  * Enhanced site navigation to support review-specific routes
  * Improved SEO metadata for better search engine visibility
  * Updated header navigation to better handle review details
  * Enhanced track pages with improved review display

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/francozeta/kocteau/pull/37?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->