### PR TITLE
fix(web): support signup OTP codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,10 +135,10 @@ Run SQL scripts manually from the Supabase SQL Editor after reviewing them.
 Kocteau is OTP-first:
 
 - `signInWithOtp` sends codes for login/signup.
-- `verifyOtp({ type: "email" })` verifies the 6-digit code in-app.
+- The app verifies the 6-digit code in-app as an email OTP, then falls back to signup confirmation OTPs for newly-created users.
 - `Confirm email` should stay enabled in Supabase.
-- The Supabase `Magic Link` template must be code-only and use `{{ .Token }}`.
-- Do not include `{{ .ConfirmationURL }}` or `{{ .TokenHash }}` in the OTP template unless intentionally re-enabling magic links.
+- The Supabase `Magic Link or OTP` and `Confirm Signup` templates must both be code-only and use `{{ .Token }}`.
+- Do not include `{{ .ConfirmationURL }}` or `{{ .TokenHash }}` in either OTP template unless intentionally re-enabling magic links.
 
 See [apps/web/emails/README.md](./apps/web/emails/README.md).
 

--- a/apps/web/components/auth/otp-auth-page-client.tsx
+++ b/apps/web/components/auth/otp-auth-page-client.tsx
@@ -8,6 +8,7 @@ import { Field, FieldError, FieldGroup, FieldLabel } from "@/components/ui/field
 import { Input } from "@/components/ui/input";
 import { InputOTP, InputOTPGroup, InputOTPSlot } from "@/components/ui/input-otp";
 import { appendInternalNext, safeInternalPath } from "@/lib/internal-path";
+import { verifyKocteauEmailOtp } from "@/lib/auth/otp";
 import { isProfileOnboarded } from "@/lib/profile";
 import { supabaseBrowser } from "@/lib/supabase/client";
 import { getFirstFieldError } from "@/lib/validation/errors";
@@ -299,10 +300,10 @@ export default function OtpAuthPageClient({ mode }: OtpAuthPageClientProps) {
     setMessage(null);
     setFieldErrors({});
 
-    const { error } = await supabase.auth.verifyOtp({
+    const { error } = await verifyKocteauEmailOtp({
       email: parsedEmail.data.email,
       token: parsedCode.data.code,
-      type: "email",
+      verifyOtp: (params) => supabase.auth.verifyOtp(params),
     });
 
     if (error) {

--- a/apps/web/emails/README.md
+++ b/apps/web/emails/README.md
@@ -14,44 +14,36 @@ React Email runs on port `3001` so it does not collide with the Next.js app.
 
 ## OTP Email
 
-- Subject: `Your Kocteau sign-in code`
-- Preheader: `Use {{otpCode}} to continue to Kocteau.`
+- Subject: `Your Kocteau code`
 - Primary text: a short code-only login message.
 - CTA: none. The OTP email should only expose the code.
-- Variables:
-  - `userName`
-  - `otpCode`
-  - `logoUrl`
-  - `expiresInMinutes`
 
 For Supabase Auth SMTP, use `supabase-otp-template.html` and keep the code
 placeholder as `{{ .Token }}`. Since Kocteau verifies the code inside the app,
 do not include a button back to `/login`; it creates a confusing loop.
 
-Paste `supabase-otp-template.html` into:
+Paste the same `supabase-otp-template.html` into both dashboard templates:
 
 ```text
-Supabase Dashboard -> Authentication -> Email Templates -> Magic Link
+Supabase Dashboard -> Authentication -> Emails -> Magic Link or OTP
+Supabase Dashboard -> Authentication -> Emails -> Confirm Signup
 ```
 
-Set the subject to:
+Set both subjects to:
 
 ```text
-Your Kocteau sign-in code
+Your Kocteau code
 ```
 
-Important: the Magic Link template decides whether Supabase sends a clickable
-login link or a code. For Kocteau's OTP-first flow, keep this template code-only
-and do not add the Supabase confirmation URL variable.
-
-You may also keep `Confirm Signup` code-only for consistency. The current app
-primarily depends on the `Magic Link` template because `/login` and `/signup`
-use Supabase `signInWithOtp`.
+Important: existing users usually receive the `Magic Link or OTP` template,
+while newly-created emails can receive `Confirm Signup`. For Kocteau's OTP-first
+flow, both templates must be code-only and must not include the Supabase
+confirmation URL variables.
 
 Short version:
 
 ```text
-Your Kocteau code is {{otpCode}}. It expires soon.
+Your Kocteau code is {{ .Token }}. It expires soon.
 ```
 
 ## Welcome Email

--- a/apps/web/emails/supabase-otp-template.html
+++ b/apps/web/emails/supabase-otp-template.html
@@ -1,164 +1,17 @@
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="color-scheme" content="dark" />
-    <meta name="supported-color-schemes" content="dark" />
-    <title>Your Kocteau sign-in code</title>
-  </head>
-  <body
-    style="
-      margin: 0;
-      padding: 0;
-      background: #070707;
-      color: #f4f1ea;
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica,
-        Arial, sans-serif;
-    "
-  >
-    <div
-      style="
-        display: none;
-        max-height: 0;
-        max-width: 0;
-        opacity: 0;
-        overflow: hidden;
-      "
-    >
-      Use {{ .Token }} to continue to Kocteau.
-    </div>
+<p>Hello,</p>
 
-    <table
-      role="presentation"
-      width="100%"
-      cellspacing="0"
-      cellpadding="0"
-      style="width: 100%; background: #070707"
-    >
-      <tr>
-        <td align="center" style="padding: 32px 16px">
-          <table
-            role="presentation"
-            width="100%"
-            cellspacing="0"
-            cellpadding="0"
-            style="width: 100%; max-width: 560px; margin: 0 auto"
-          >
-            <tr>
-              <td
-                style="
-                  border: 1px solid #262626;
-                  border-radius: 24px;
-                  background: #0d0d0d;
-                  padding: 34px 28px;
-                "
-              >
-                <div style="padding-bottom: 28px; text-align: center">
-                  <img
-                    src="https://kocteau.com/logo-k.png"
-                    width="42"
-                    height="42"
-                    alt="Kocteau"
-                    style="
-                      display: inline-block;
-                      width: 42px;
-                      height: 42px;
-                      border: 0;
-                      outline: none;
-                      text-decoration: none;
-                    "
-                  />
-                </div>
+<p>
+  Use the following code to sign in to Kocteau:
+</p>
 
-                <p
-                  style="
-                    margin: 0 0 12px;
-                    color: #9b9b9b;
-                    font-size: 12px;
-                    line-height: 18px;
-                    font-weight: 600;
-                    letter-spacing: 0.02em;
-                    text-transform: uppercase;
-                  "
-                >
-                  Kocteau access
-                </p>
+<p>
+  <code>{{ .Token }}</code>
+</p>
 
-                <h1
-                  style="
-                    margin: 0;
-                    color: #f7f4ee;
-                    font-size: 28px;
-                    line-height: 34px;
-                    font-weight: 700;
-                    letter-spacing: 0;
-                  "
-                >
-                  Your code is ready.
-                </h1>
+<p>
+  If you did not request this email, you can safely ignore it.
+</p>
 
-                <p
-                  style="
-                    margin: 18px 0 0;
-                    color: #b8b4ad;
-                    font-size: 15px;
-                    line-height: 24px;
-                    font-weight: 400;
-                  "
-                >
-                  Enter this one-time code to continue. It expires soon.
-                </p>
-
-                <div
-                  style="
-                    margin: 28px 0 0;
-                    border: 1px solid #2b2b2b;
-                    border-radius: 18px;
-                    background: #141414;
-                    color: #fff7ef;
-                    font-family: 'SFMono-Regular', Consolas, 'Liberation Mono',
-                      Menlo, monospace;
-                    font-size: 34px;
-                    line-height: 42px;
-                    font-weight: 700;
-                    letter-spacing: 8px;
-                    padding: 20px 18px;
-                    text-align: center;
-                  "
-                >
-                  {{ .Token }}
-                </div>
-
-                <p
-                  style="
-                    margin: 18px 0 0;
-                    color: #7d7d7d;
-                    font-size: 12px;
-                    line-height: 19px;
-                  "
-                >
-                  Sent to {{ .Email }}. Never share this code. Kocteau will
-                  never ask for it outside the sign-in screen.
-                </p>
-              </td>
-            </tr>
-            <tr>
-              <td
-                style="
-                  padding: 20px 8px 0;
-                  color: #686868;
-                  font-size: 12px;
-                  line-height: 18px;
-                  text-align: center;
-                "
-              >
-                If this was not you, you can ignore this message.
-              </td>
-            </tr>
-          </table>
-        </td>
-      </tr>
-    </table>
-  </body>
-</html>
+<p>
+  &mdash; Kocteau
+</p>

--- a/apps/web/lib/auth/otp.test.ts
+++ b/apps/web/lib/auth/otp.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  kocteauEmailOtpVerificationTypes,
+  verifyKocteauEmailOtp,
+  type EmailOtpVerificationType,
+} from "./otp";
+
+function authError(code: string, status = 400) {
+  return { code, message: code, status };
+}
+
+test("email OTP verification falls back to signup tokens for newly created users", async () => {
+  const attempts: EmailOtpVerificationType[] = [];
+
+  const result = await verifyKocteauEmailOtp({
+    email: "new@example.com",
+    token: "123456",
+    verifyOtp: async ({ type }) => {
+      attempts.push(type);
+
+      return type === "signup"
+        ? { error: null }
+        : { error: authError("otp_expired") };
+    },
+  });
+
+  assert.equal(result.error, null);
+  assert.equal(result.type, "signup");
+  assert.deepEqual(attempts, ["email", "signup"]);
+});
+
+test("email OTP verification does not retry non-token errors", async () => {
+  const attempts: EmailOtpVerificationType[] = [];
+
+  const result = await verifyKocteauEmailOtp({
+    email: "new@example.com",
+    token: "123456",
+    verifyOtp: async ({ type }) => {
+      attempts.push(type);
+
+      return { error: authError("over_request_rate_limit", 429) };
+    },
+  });
+
+  assert.deepEqual(attempts, ["email"]);
+  assert.equal(result.type, null);
+  assert.equal(result.error?.code, "over_request_rate_limit");
+});
+
+test("Kocteau verifies normal email OTPs before signup confirmation OTPs", () => {
+  assert.deepEqual(kocteauEmailOtpVerificationTypes, ["email", "signup"]);
+});

--- a/apps/web/lib/auth/otp.ts
+++ b/apps/web/lib/auth/otp.ts
@@ -1,0 +1,115 @@
+export const kocteauEmailOtpVerificationTypes = ["email", "signup"] as const;
+
+export type EmailOtpVerificationType =
+  (typeof kocteauEmailOtpVerificationTypes)[number];
+
+type EmailOtpAuthError = {
+  code?: string;
+  message?: string;
+  status?: number | string;
+};
+
+type VerifyOtp = (params: {
+  email: string;
+  token: string;
+  type: EmailOtpVerificationType;
+}) => Promise<{ error: EmailOtpAuthError | null }>;
+
+type VerifyKocteauEmailOtpParams = {
+  email: string;
+  token: string;
+  verifyOtp: VerifyOtp;
+};
+
+type VerifyKocteauEmailOtpResult =
+  | {
+      error: null;
+      type: EmailOtpVerificationType;
+    }
+  | {
+      error: EmailOtpAuthError;
+      type: null;
+    };
+
+const retryableOtpErrorCodes = new Set([
+  "invalid_credentials",
+  "otp_expired",
+  "validation_failed",
+]);
+
+const nonRetryableOtpErrorCodes = new Set([
+  "captcha_failed",
+  "email_not_confirmed",
+  "email_provider_disabled",
+  "over_email_send_rate_limit",
+  "over_request_rate_limit",
+  "over_sms_send_rate_limit",
+  "phone_not_confirmed",
+  "signup_disabled",
+  "user_banned",
+]);
+
+function getStatus(error: EmailOtpAuthError) {
+  if (typeof error.status === "number") {
+    return error.status;
+  }
+
+  if (typeof error.status === "string") {
+    const parsed = Number.parseInt(error.status, 10);
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+
+  return null;
+}
+
+function isTokenVerificationError(error: EmailOtpAuthError) {
+  const code = error.code?.toLowerCase();
+
+  if (code && nonRetryableOtpErrorCodes.has(code)) {
+    return false;
+  }
+
+  if (code && retryableOtpErrorCodes.has(code)) {
+    return true;
+  }
+
+  const status = getStatus(error);
+
+  if (status !== 400 && status !== 401 && status !== 403) {
+    return false;
+  }
+
+  const message = error.message?.toLowerCase() ?? "";
+  const mentionsOtp = /\b(code|otp|token)\b/.test(message);
+  const mentionsVerificationIssue =
+    /expired|invalid|missing|not found|verification|verify/.test(message);
+
+  return mentionsOtp && mentionsVerificationIssue;
+}
+
+export async function verifyKocteauEmailOtp({
+  email,
+  token,
+  verifyOtp,
+}: VerifyKocteauEmailOtpParams): Promise<VerifyKocteauEmailOtpResult> {
+  let lastError: EmailOtpAuthError | null = null;
+
+  for (const type of kocteauEmailOtpVerificationTypes) {
+    const { error } = await verifyOtp({ email, token, type });
+
+    if (!error) {
+      return { error: null, type };
+    }
+
+    lastError = error;
+
+    if (!isTokenVerificationError(error)) {
+      return { error, type: null };
+    }
+  }
+
+  return {
+    error: lastError ?? { message: "OTP verification failed." },
+    type: null,
+  };
+}

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -197,6 +197,22 @@ Acceptance criteria:
 - Notifications feel more meaningful and less noisy.
 - Existing notification APIs remain compatible unless intentionally changed.
 
+### Unified Auth Entry Point
+
+Suggested issue: `feat(web): unify email auth into one entry point`
+
+- Decide whether `/login` should become the primary email auth surface and `/signup` should redirect or render the same flow.
+- Keep the OTP-first behavior and Supabase email confirmation intact.
+- Preserve existing `next` redirects, onboarding routing, and signup confirmation handling.
+
+Suggested labels: `feature`, `area:web`, `area:auth`, `needs maintainer decision`
+
+Acceptance criteria:
+
+- New and returning users can continue with email from the same UI.
+- `/login` and `/signup` do not present conflicting copy or behavior.
+- Existing OTP, signup confirmation, and onboarding tests still cover both new and returning users.
+
 ## Sensitive System Work
 
 These can be public issues, but they should require maintainer review and careful acceptance criteria.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -17,7 +17,7 @@ Current app behavior:
 
 - `/login` and `/signup` both use `signInWithOtp`.
 - New emails are allowed through `shouldCreateUser: true`.
-- The app verifies codes with `verifyOtp({ type: "email" })`.
+- The app verifies codes as a normal email OTP first, then falls back to a signup confirmation OTP for newly-created users.
 - After verification, users are routed through profile onboarding, taste onboarding, or `/`.
 
 ## Supabase Email Templates
@@ -31,7 +31,8 @@ Template file:
 Supabase dashboard location:
 
 ```text
-Authentication -> Email Templates -> Magic Link
+Authentication -> Emails -> Magic Link or OTP
+Authentication -> Emails -> Confirm Signup
 ```
 
 Use:
@@ -49,7 +50,7 @@ Avoid:
 
 Those URL variables reintroduce magic-link behavior and can confuse users because Kocteau expects the code to be entered in-app.
 
-The `Confirm Signup` template may also be kept code-only for consistency, but the current app flow primarily depends on the Magic Link template because it uses `signInWithOtp`.
+Existing users usually receive `Magic Link or OTP`. New emails can receive `Confirm Signup`, so both templates must use the same code-only body and a consistent subject such as `Your Kocteau code`.
 
 ## Resend SMTP
 
@@ -104,14 +105,17 @@ Editorial starter content is product configuration, not demo user data. Keep it 
 After deploying auth or recommendation changes:
 
 1. Log out.
-2. Request OTP on `/login`.
+2. Request OTP on `/login` with an existing email.
 3. Confirm the email contains only a 6-digit code.
 4. Verify the code.
-5. Complete profile onboarding if needed.
-6. Complete taste onboarding if needed.
-7. Confirm `/` loads For You.
-8. Like, bookmark, and open comments from For You.
-9. Check Supabase for analytics events.
+5. Request OTP on `/signup` with a new email.
+6. Confirm the `Confirm Signup` email contains only a 6-digit code.
+7. Verify the code.
+8. Complete profile onboarding if needed.
+9. Complete taste onboarding if needed.
+10. Confirm `/` loads For You.
+11. Like, bookmark, and open comments from For You.
+12. Check Supabase for analytics events.
 
 Useful analytics check:
 


### PR DESCRIPTION
## What changed

- Added OTP verification fallback for newly-created users: the app now tries `email` OTP first, then `signup` OTP.
- Replaced the Supabase OTP template with a simple code-only `{{ .Token }}` email.
- Updated auth/email docs to require the same template in both `Magic Link or OTP` and `Confirm Signup`.
- Added the unified auth entry point idea to the backlog without implementing it.

## Why

New users can receive Supabase's `Confirm Signup` email instead of the `Magic Link or OTP` email. If that template is stale or missing `{{ .Token }}`, the email arrives without a visible code. Supporting both OTP verification types and documenting both templates fixes the signup-code path.

## Testing

- [x] Ran `pnpm check`
- [ ] Added screenshots or a short recording for visible web UI changes
- [ ] Confirmed this does not touch auth, Supabase, recommendations, analytics, CI, or release behavior

Additional checks:
- `node --import jiti/register --test lib/auth/otp.test.ts` passed, 3/3 tests.
- `git diff --cached --check` passed.

Note: the third checkbox is intentionally unchecked because this PR touches auth/Supabase email behavior.

## Changelog impact

No manual `CHANGELOG.md` edit is required. Release Please generates release notes from PR titles and squash commits.

- [x] User-facing web change
- [x] Developer experience or documentation change
- [ ] Internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented OTP verification fallback for newly created users, attempting email OTP verification first with automatic fallback to signup confirmation OTP when needed.

* **Documentation**
  * Updated authentication guidance and email template instructions for consistency across Supabase configurations.

* **Bug Fixes**
  * Simplified and standardized email template to ensure reliable OTP delivery.

* **Tests**
  * Added comprehensive test coverage for OTP verification behavior and error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/francozeta/kocteau/pull/39?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->