### PR TITLE
fix(web): satisfy stricter hooks lint

### DIFF
--- a/apps/web/app/(main)/search/page.tsx
+++ b/apps/web/app/(main)/search/page.tsx
@@ -40,6 +40,7 @@ export default async function SearchPage({
 
   return (
     <SearchPageClient
+      key={`${initialType}:${initialQuery}`}
       initialQuery={initialQuery}
       initialType={initialType}
       highlights={highlights}

--- a/apps/web/components/avatar-crop-dialog.tsx
+++ b/apps/web/components/avatar-crop-dialog.tsx
@@ -49,19 +49,77 @@ export default function AvatarCropDialog({
   onOpenChange,
 }: AvatarCropDialogProps) {
   const isMobile = useIsMobile();
+  const sourceFile = initialFile;
+  const cropSessionKey = sourceFile
+    ? `${open ? "open" : "closed"}:${sourceFile.name}:${sourceFile.size}:${sourceFile.lastModified}`
+    : `${open ? "open" : "closed"}:empty`;
+
+  const cropperContent = (
+    <AvatarCropDialogContent
+      key={cropSessionKey}
+      isMobile={isMobile}
+      sourceFile={sourceFile}
+      onConfirm={onConfirm}
+      onOpenChange={onOpenChange}
+    />
+  );
+
+  if (isMobile) {
+    return (
+      <DrawerBase open={open} onOpenChange={onOpenChange} swipeDirection="down">
+        <DrawerBasePortal>
+          <DrawerBaseBackdrop className="bg-black/78" />
+          <DrawerBaseViewport>
+            <DrawerBaseContent className="max-h-[calc(100dvh-0.25rem)] border-white/10 bg-[#060606] text-white">
+              <DrawerBaseHandle className="bg-white/18" />
+              <DrawerBaseHeader className="sr-only">
+                <DrawerBaseTitle>Crop profile photo</DrawerBaseTitle>
+                <DrawerBaseDescription>
+                  Adjust the framing and save.
+                </DrawerBaseDescription>
+              </DrawerBaseHeader>
+
+              {cropperContent}
+            </DrawerBaseContent>
+          </DrawerBaseViewport>
+        </DrawerBasePortal>
+      </DrawerBase>
+    );
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        showCloseButton={false}
+        className="w-[min(100vw-1rem,34rem)] overflow-hidden rounded-[1.1rem] border border-white/10 bg-[#060606] p-0 text-white shadow-2xl"
+      >
+        <DialogHeader className="sr-only">
+          <DialogTitle>Crop profile photo</DialogTitle>
+          <DialogDescription>
+            Adjust the framing and save.
+          </DialogDescription>
+        </DialogHeader>
+
+        {cropperContent}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function AvatarCropDialogContent({
+  isMobile,
+  sourceFile,
+  onConfirm,
+  onOpenChange,
+}: {
+  isMobile: boolean;
+  sourceFile: File | null;
+  onConfirm: (result: PreparedAvatarUpload) => void;
+  onOpenChange: (open: boolean) => void;
+}) {
   const [cropArea, setCropArea] = useState<PixelCropArea | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isConfirming, setIsConfirming] = useState(false);
-  const sourceFile = initialFile;
-
-  useEffect(() => {
-    if (!open) {
-      return;
-    }
-
-    setCropArea(null);
-    setError(null);
-  }, [open, initialFile]);
 
   const previewUrl = useMemo(() => {
     if (!sourceFile) {
@@ -199,44 +257,5 @@ export default function AvatarCropDialog({
     </div>
   );
 
-  if (isMobile) {
-    return (
-      <DrawerBase open={open} onOpenChange={onOpenChange} swipeDirection="down">
-        <DrawerBasePortal>
-          <DrawerBaseBackdrop className="bg-black/78" />
-          <DrawerBaseViewport>
-            <DrawerBaseContent className="max-h-[calc(100dvh-0.25rem)] border-white/10 bg-[#060606] text-white">
-              <DrawerBaseHandle className="bg-white/18" />
-              <DrawerBaseHeader className="sr-only">
-                <DrawerBaseTitle>Crop profile photo</DrawerBaseTitle>
-                <DrawerBaseDescription>
-                  Adjust the framing and save.
-                </DrawerBaseDescription>
-              </DrawerBaseHeader>
-
-              {cropperContent}
-            </DrawerBaseContent>
-          </DrawerBaseViewport>
-        </DrawerBasePortal>
-      </DrawerBase>
-    );
-  }
-
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent
-        showCloseButton={false}
-        className="w-[min(100vw-1rem,34rem)] overflow-hidden rounded-[1.1rem] border border-white/10 bg-[#060606] p-0 text-white shadow-2xl"
-      >
-        <DialogHeader className="sr-only">
-          <DialogTitle>Crop profile photo</DialogTitle>
-          <DialogDescription>
-            Adjust the framing and save.
-          </DialogDescription>
-        </DialogHeader>
-
-        {cropperContent}
-      </DialogContent>
-    </Dialog>
-  );
+  return cropperContent;
 }

--- a/apps/web/components/new-review-form.tsx
+++ b/apps/web/components/new-review-form.tsx
@@ -78,7 +78,44 @@ export type NewReviewFormProps = {
 
 export type NewReviewFormStep = "search" | "compose";
 
-export default function NewReviewForm({
+type ActiveResultState = {
+  key: string;
+  index: number;
+};
+
+function getSelectionKey(selection: DeezerResult | null | undefined) {
+  if (!selection) {
+    return "none";
+  }
+
+  return [
+    selection.provider,
+    selection.provider_id,
+    selection.entity_id ?? "",
+    selection.title,
+    selection.artist_name ?? "",
+  ].join(":");
+}
+
+function getNewReviewFormStateKey(props: NewReviewFormProps) {
+  return [
+    props.mode ?? "create",
+    props.intent ?? "review",
+    props.reviewId ?? "",
+    props.initialQuery ?? "",
+    getSelectionKey(props.initialSelection),
+    props.initialRating ?? "",
+    props.initialTitle ?? "",
+    props.initialBody ?? "",
+    props.initialPinned ? "pinned" : "unpinned",
+  ].join("|");
+}
+
+export default function NewReviewForm(props: NewReviewFormProps) {
+  return <NewReviewFormState key={getNewReviewFormStateKey(props)} {...props} />;
+}
+
+function NewReviewFormState({
   mode = "create",
   intent = "review",
   isAuthenticated = true,
@@ -108,7 +145,10 @@ export default function NewReviewForm({
   );
   const [query, setQuery] = useState(initialQuery);
   const [selected, setSelected] = useState<DeezerResult | null>(initialSelection);
-  const [activeResultIndex, setActiveResultIndex] = useState(-1);
+  const [activeResultState, setActiveResultState] = useState<ActiveResultState>({
+    key: "",
+    index: -1,
+  });
 
   const [rating, setRating] = useState<number | null>(initialRating);
   const [title, setTitle] = useState(initialTitle);
@@ -132,44 +172,34 @@ export default function NewReviewForm({
     enabled: searchEnabled,
   });
   const results = useMemo(() => (searchEnabled ? ((data ?? []) as DeezerResult[]) : []), [data, searchEnabled]);
+  const activeResultKey = useMemo(
+    () =>
+      [
+        step,
+        normalizedQuery,
+        ...results.map((result) => `${result.provider}:${result.provider_id}`),
+      ].join("|"),
+    [normalizedQuery, results, step],
+  );
+  const defaultActiveResultIndex =
+    step === "search" && normalizedQuery.length >= 2 && results.length > 0 ? 0 : -1;
+  const activeResultIndex =
+    activeResultState.key === activeResultKey
+      ? activeResultState.index
+      : defaultActiveResultIndex;
 
-  useEffect(() => {
-    setQuery(initialQuery);
-  }, [initialQuery]);
+  function setActiveResultIndex(nextIndex: number | ((current: number) => number)) {
+    setActiveResultState((current) => {
+      const currentIndex =
+        current.key === activeResultKey ? current.index : defaultActiveResultIndex;
 
-  useEffect(() => {
-    if (isSearchIntent) {
-      setStep("search");
-      setSelected(null);
-      setErrorMsg(null);
-      return;
-    }
-
-    if (initialSelection) {
-      setSelected(initialSelection);
-      setStep("compose");
-      setErrorMsg(null);
-      return;
-    }
-
-    setSelected(null);
-    setStep("search");
-  }, [initialSelection, isSearchIntent]);
-
-  useEffect(() => {
-    setRating(initialRating);
-    setTitle(initialTitle);
-    setBody(initialBody);
-  }, [initialBody, initialRating, initialTitle, reviewId]);
-
-  useEffect(() => {
-    if (step !== "search" || normalizedQuery.length < 2 || results.length === 0) {
-      setActiveResultIndex(-1);
-      return;
-    }
-
-    setActiveResultIndex(0);
-  }, [normalizedQuery, results.length, step]);
+      return {
+        key: activeResultKey,
+        index:
+          typeof nextIndex === "function" ? nextIndex(currentIndex) : nextIndex,
+      };
+    });
+  }
 
   useEffect(() => {
     if (activeResultIndex < 0) {

--- a/apps/web/components/profile-page-header.tsx
+++ b/apps/web/components/profile-page-header.tsx
@@ -38,7 +38,31 @@ type ProfilePageHeaderProps = {
   } | null;
 };
 
-export default function ProfilePageHeader({
+function getProfilePageHeaderStateKey(profile: ProfilePageHeaderProfile) {
+  return [
+    profile.id,
+    profile.username,
+    profile.display_name ?? "",
+    profile.avatar_url ?? "",
+    profile.bio ?? "",
+    profile.spotify_url ?? "",
+    profile.apple_music_url ?? "",
+    profile.deezer_url ?? "",
+    profile.is_official ? "official" : "",
+    profile.official_label ?? "",
+  ].join("|");
+}
+
+export default function ProfilePageHeader(props: ProfilePageHeaderProps) {
+  return (
+    <ProfilePageHeaderState
+      key={getProfilePageHeaderStateKey(props.profile)}
+      {...props}
+    />
+  );
+}
+
+function ProfilePageHeaderState({
   profile,
   totalReviews,
   memberSince,
@@ -83,10 +107,6 @@ export default function ProfilePageHeader({
       ].filter((link): link is { label: string; url: string } => Boolean(link)),
     [localProfile.apple_music_url, localProfile.deezer_url, localProfile.spotify_url],
   );
-
-  useEffect(() => {
-    setLocalProfile(profile);
-  }, [profile]);
 
   useEffect(() => {
     setDetailHeader({

--- a/apps/web/components/search-page-client.tsx
+++ b/apps/web/components/search-page-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { Disc3, LoaderCircle, Music2, Search } from "@/components/ui/icons";
 import EntityCoverImage from "@/components/entity-cover-image";
@@ -25,6 +25,11 @@ type SearchPageClientProps = {
 type RecentSearch = {
   label: string;
   query: string;
+};
+
+type ActiveSearchResultState = {
+  key: string;
+  index: number;
 };
 
 const suggestedSearches = [
@@ -59,6 +64,50 @@ const searchEntityTabs: Array<{
 ];
 
 const recentSearchesStorageKey = "kocteau:recent-searches";
+const recentSearchesChangedEvent = "kocteau:recent-searches-changed";
+const emptyRecentSearchesSnapshot = "[]";
+
+function parseRecentSearchesSnapshot(snapshot: string): RecentSearch[] {
+  try {
+    const parsed = JSON.parse(snapshot) as RecentSearch[];
+
+    if (Array.isArray(parsed)) {
+      return parsed.slice(0, 6);
+    }
+  } catch {
+    // Ignore broken local storage payloads and fall back to empty recent searches.
+  }
+
+  return [];
+}
+
+function getRecentSearchesSnapshot() {
+  return window.localStorage.getItem(recentSearchesStorageKey) ?? emptyRecentSearchesSnapshot;
+}
+
+function getRecentSearchesServerSnapshot() {
+  return emptyRecentSearchesSnapshot;
+}
+
+function subscribeRecentSearches(onStoreChange: () => void) {
+  function handleStorage(event: StorageEvent) {
+    if (event.key === recentSearchesStorageKey) {
+      onStoreChange();
+    }
+  }
+
+  window.addEventListener("storage", handleStorage);
+  window.addEventListener(recentSearchesChangedEvent, onStoreChange);
+
+  return () => {
+    window.removeEventListener("storage", handleStorage);
+    window.removeEventListener(recentSearchesChangedEvent, onStoreChange);
+  };
+}
+
+function notifyRecentSearchesChanged() {
+  window.dispatchEvent(new Event(recentSearchesChangedEvent));
+}
 
 function formatDate(value: string) {
   return new Date(value).toLocaleDateString("en-US", {
@@ -229,52 +278,52 @@ export default function SearchPageClient({
   const pathname = usePathname();
 
   const [query, setQuery] = useState(initialQuery);
-  const [activeIndex, setActiveIndex] = useState(-1);
-  const [recentSearches, setRecentSearches] = useState<RecentSearch[]>([]);
+  const [activeIndexState, setActiveIndexState] = useState<ActiveSearchResultState>({
+    key: "",
+    index: -1,
+  });
   const resultRefs = useRef<Array<HTMLAnchorElement | null>>([]);
   const searchType = initialType;
   const normalizedQuery = query.trim();
+  const recentSearchesSnapshot = useSyncExternalStore(
+    subscribeRecentSearches,
+    getRecentSearchesSnapshot,
+    getRecentSearchesServerSnapshot,
+  );
+  const recentSearches = useMemo(
+    () => parseRecentSearchesSnapshot(recentSearchesSnapshot),
+    [recentSearchesSnapshot],
+  );
   const { data = [], isFetching, error } = useDeezerSearch({
     query,
     type: searchType,
     enabled: searchType === "track",
   });
   const results = data as DeezerSearchResult[];
+  const activeResultKey = useMemo(
+    () =>
+      [
+        normalizedQuery,
+        ...results.map((result) => `${result.provider}:${result.provider_id}`),
+      ].join("|"),
+    [normalizedQuery, results],
+  );
+  const defaultActiveIndex = normalizedQuery.length >= 2 && results.length > 0 ? 0 : -1;
+  const activeIndex =
+    activeIndexState.key === activeResultKey ? activeIndexState.index : defaultActiveIndex;
 
-  useEffect(() => {
-    setQuery(initialQuery);
-  }, [initialQuery]);
+  function setActiveIndex(nextIndex: number | ((current: number) => number)) {
+    setActiveIndexState((current) => {
+      const currentIndex =
+        current.key === activeResultKey ? current.index : defaultActiveIndex;
 
-  useEffect(() => {
-    if (typeof window === "undefined") {
-      return;
-    }
-
-    try {
-      const stored = window.localStorage.getItem(recentSearchesStorageKey);
-
-      if (!stored) {
-        return;
-      }
-
-      const parsed = JSON.parse(stored) as RecentSearch[];
-
-      if (Array.isArray(parsed)) {
-        setRecentSearches(parsed.slice(0, 6));
-      }
-    } catch {
-      // Ignore broken local storage payloads and fall back to empty recent searches.
-    }
-  }, []);
-
-  useEffect(() => {
-    if (normalizedQuery.length < 2 || results.length === 0) {
-      setActiveIndex(-1);
-      return;
-    }
-
-    setActiveIndex(0);
-  }, [normalizedQuery, results.length]);
+      return {
+        key: activeResultKey,
+        index:
+          typeof nextIndex === "function" ? nextIndex(currentIndex) : nextIndex,
+      };
+    });
+  }
 
   useEffect(() => {
     if (activeIndex < 0) {
@@ -341,18 +390,19 @@ export default function SearchPageClient({
       query: label,
     } satisfies RecentSearch;
 
-    setRecentSearches((current) => {
-      const next = [nextItem, ...current.filter((item) => item.query.toLowerCase() !== label.toLowerCase())].slice(0, 6);
-      window.localStorage.setItem(recentSearchesStorageKey, JSON.stringify(next));
-      return next;
-    });
+    const next = [
+      nextItem,
+      ...recentSearches.filter((item) => item.query.toLowerCase() !== label.toLowerCase()),
+    ].slice(0, 6);
+
+    window.localStorage.setItem(recentSearchesStorageKey, JSON.stringify(next));
+    notifyRecentSearchesChanged();
   }
 
   function clearRecentSearches() {
-    setRecentSearches([]);
-
     if (typeof window !== "undefined") {
       window.localStorage.removeItem(recentSearchesStorageKey);
+      notifyRecentSearchesChanged();
     }
   }
 

--- a/apps/web/hooks/use-mobile.ts
+++ b/apps/web/hooks/use-mobile.ts
@@ -2,18 +2,22 @@ import * as React from "react"
 
 const MOBILE_BREAKPOINT = 768
 
+function subscribe(onStoreChange: () => void) {
+  const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
+
+  mql.addEventListener("change", onStoreChange)
+
+  return () => mql.removeEventListener("change", onStoreChange)
+}
+
+function getSnapshot() {
+  return window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`).matches
+}
+
+function getServerSnapshot() {
+  return false
+}
+
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
-
-  React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    }
-    mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    return () => mql.removeEventListener("change", onChange)
-  }, [])
-
-  return !!isMobile
+  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
 }


### PR DESCRIPTION
## What changed

- Refactored web components flagged by the updated React Hooks lint rule.
- Replaced prop-sync `useEffect` resets with controlled remount keys where the component state should restart from new initial props.
- Derived active search result indexes from query/result keys instead of resetting them through effects.
- Switched mobile breakpoint and recent-search subscriptions to `useSyncExternalStore`.

## Why

The dependency/tooling update introduced a stricter `react-hooks/set-state-in-effect` rule through `eslint-plugin-react-hooks`.

CI was failing in `web#lint`, so this fixes the underlying component patterns without disabling the rule.

## Testing

- [x] Ran `pnpm check`
- [ ] Added screenshots or a short recording for visible web UI changes
- [ ] Confirmed this does not touch auth, Supabase, recommendations, analytics, CI, or release behavior

Additional checks:

- [x] `pnpm --filter web lint`
- [x] `git diff --check`

## Changelog impact

No manual `CHANGELOG.md` edit is required. Release Please generates release notes from PR titles and squash commits.

- [ ] User-facing web change
- [x] Developer experience or documentation change
- [x] Internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved state management and component remounting behavior across search, review form, and profile components for better performance and consistency.
  * Enhanced mobile detection responsiveness through optimized external store subscriptions.
  * Recent search persistence now uses local storage for more reliable data retention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->