### PR TITLE
feat(web): implement analytics signal contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Recommendation inputs currently include:
 - rating, likes, comments, and recency
 - light diversity penalties to reduce repetition
 
-If the recommendation RPC fails, the app logs `for_you_fallback` and falls back to latest reviews instead of breaking the feed.
+If the recommendation RPC fails, the app logs `recommendation_fallback` and falls back to latest reviews instead of breaking the feed.
 
 When a signed-in user's For You feed is empty or sparse, Kocteau can show editorial starter picks. These are not fake reviews; they are curated track prompts stored in `starter_tracks` and ranked against the user's onboarding tags through `get_starter_tracks`.
 
@@ -180,10 +180,16 @@ Official identity and internal permissions are separate:
 Kocteau uses a small first-party analytics table in Supabase. Events currently tracked:
 
 - `taste_onboarding_completed`
-- `for_you_reviews_loaded`
+- `feed_loaded`
+- `recommendation_fallback`
+- `review_impression`
+- `review_open`
+- `entity_open`
 - `for_you_review_action`
-- `for_you_recommendation_action`
-- `for_you_fallback`
+- `starter_impression`
+- `starter_pass`
+- `starter_review_cta`
+- `starter_review_published`
 
 The goal is product feedback, not surveillance. Events avoid emails, IPs, user agents, and long free-form payloads.
 

--- a/apps/web/app/(main)/review/[id]/page.tsx
+++ b/apps/web/app/(main)/review/[id]/page.tsx
@@ -121,6 +121,8 @@ export default async function ReviewPage({
       <JsonLd data={buildReviewPageJsonLd(review)} id="review-structured-data" />
       <ReviewPageHeaderBridge
         reviewId={review.id}
+        entityId={entity?.id}
+        isAuthenticated={Boolean(user)}
         title={headerTitle}
         entityTitle={entity?.title}
         artistName={entity?.artist_name}

--- a/apps/web/app/(main)/track/[id]/page.tsx
+++ b/apps/web/app/(main)/track/[id]/page.tsx
@@ -124,6 +124,10 @@ export default async function TrackPage({
       <section className="mx-auto w-full max-w-6xl space-y-4 sm:space-y-5">
         <TrackPageHeaderBridge
           entityId={entity.id}
+          provider={entity.provider}
+          providerId={entity.provider_id}
+          type={entity.type}
+          isAuthenticated={Boolean(user)}
           title={entity.title}
           artistName={entity.artist_name}
           deezerUrl={entity.deezer_url}

--- a/apps/web/components/feed-review-list.tsx
+++ b/apps/web/components/feed-review-list.tsx
@@ -196,8 +196,12 @@ export default function FeedReviewList({
       return;
     }
 
+    let reviewPositionOffset = 0;
+
     (data?.pages ?? []).forEach((page, pageIndex) => {
       const reviewIds = page.feed.map((review) => review.id);
+      const pageStartPosition = reviewPositionOffset;
+      reviewPositionOffset += page.feed.length;
 
       if (reviewIds.length === 0) {
         return;
@@ -211,17 +215,34 @@ export default function FeedReviewList({
 
       trackedPageKeysRef.current.add(pageKey);
       trackAnalyticsEvent({
-        eventType: "for_you_reviews_loaded",
+        eventType: "feed_loaded",
         source: "feed:for-you",
         metadata: {
+          view,
           page_index: pageIndex,
           review_count: reviewIds.length,
+          starter_count: visibleStarterTracks.length,
           review_ids: reviewIds,
+          has_cursor: Boolean(page.nextCursor),
           has_next_page: Boolean(page.nextCursor),
         },
       });
+
+      page.feed.forEach((review, reviewIndex) => {
+        trackAnalyticsEvent({
+          eventType: "review_impression",
+          source: "feed:for-you",
+          metadata: {
+            review_id: review.id,
+            entity_id: review.entities?.id ?? null,
+            reason: review.recommendation_reason ?? null,
+            page_index: pageIndex,
+            position: pageStartPosition + reviewIndex,
+          },
+        });
+      });
     });
-  }, [data?.pages, isAuthenticated, view]);
+  }, [data?.pages, isAuthenticated, view, visibleStarterTracks.length]);
 
   useEffect(() => {
     const node = sentinelRef.current;

--- a/apps/web/components/feed-starter-layer.tsx
+++ b/apps/web/components/feed-starter-layer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { motion, useReducedMotion } from "motion/react";
 import { ArrowRight, Sparkles, X } from "@/components/ui/icons";
 import EntityCoverImage from "@/components/entity-cover-image";
@@ -33,6 +33,7 @@ export default function FeedStarterLayer({
 }: FeedStarterLayerProps) {
   const [passedTrackIds, setPassedTrackIds] = useState<Set<string>>(() => new Set());
   const [reviewedTrackIds, setReviewedTrackIds] = useState<Set<string>>(() => new Set());
+  const trackedImpressionIdsRef = useRef(new Set<string>());
   const prefersReducedMotion = useReducedMotion();
   const visibleTracks = useMemo(
     () =>
@@ -44,6 +45,28 @@ export default function FeedStarterLayer({
   const activeTrack = visibleTracks[0] ?? null;
   const upcomingTracks = visibleTracks.slice(1, 4);
   const completedCount = tracks.length - visibleTracks.length;
+
+  useEffect(() => {
+    if (!isAuthenticated || !activeTrack) {
+      return;
+    }
+
+    if (trackedImpressionIdsRef.current.has(activeTrack.id)) {
+      return;
+    }
+
+    trackedImpressionIdsRef.current.add(activeTrack.id);
+    trackAnalyticsEvent({
+      eventType: "starter_impression",
+      source: "feed:starter",
+      metadata: {
+        starter_track_id: activeTrack.id,
+        provider_id: activeTrack.provider_id,
+        matched_tag_count: activeTrack.matched_tag_count,
+        position: completedCount,
+      },
+    });
+  }, [activeTrack, completedCount, isAuthenticated]);
 
   if (tracks.length === 0) {
     return null;
@@ -57,7 +80,7 @@ export default function FeedStarterLayer({
     }
 
     trackAnalyticsEvent({
-      eventType: "for_you_recommendation_action",
+      eventType: "starter_pass",
       source: "feed:starter",
       metadata: {
         action: "starter_pass",
@@ -76,7 +99,7 @@ export default function FeedStarterLayer({
     }
 
     trackAnalyticsEvent({
-      eventType: "for_you_recommendation_action",
+      eventType: "starter_review_published",
       source: "feed:starter",
       metadata: {
         action: "starter_review_published",
@@ -220,8 +243,12 @@ export default function FeedStarterLayer({
                       size="sm"
                       className="h-8 gap-1.5 rounded-md border-border/28 bg-[var(--kocteau-surface-control)] px-3 text-xs text-foreground hover:bg-[var(--kocteau-surface-control-hover)]"
                       onClick={() => {
+                        if (!isAuthenticated) {
+                          return;
+                        }
+
                         trackAnalyticsEvent({
-                          eventType: "for_you_review_action",
+                          eventType: "starter_review_cta",
                           source: "feed:starter",
                           metadata: {
                             action: "starter_review_cta",

--- a/apps/web/components/review-page-header-bridge.tsx
+++ b/apps/web/components/review-page-header-bridge.tsx
@@ -2,9 +2,12 @@
 
 import { useEffect } from "react";
 import { useRouteHeader } from "@/components/route-header-context";
+import { trackAnalyticsEvent } from "@/lib/analytics/client";
 
 type ReviewPageHeaderBridgeProps = {
   reviewId: string;
+  entityId?: string | null;
+  isAuthenticated?: boolean;
   title: string;
   entityTitle?: string | null;
   artistName?: string | null;
@@ -12,6 +15,8 @@ type ReviewPageHeaderBridgeProps = {
 
 export default function ReviewPageHeaderBridge({
   reviewId,
+  entityId,
+  isAuthenticated = false,
   title,
   entityTitle,
   artistName,
@@ -37,6 +42,21 @@ export default function ReviewPageHeaderBridge({
       setDetailHeader(null);
     };
   }, [artistName, entityTitle, reviewId, setDetailHeader, title]);
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      return;
+    }
+
+    trackAnalyticsEvent({
+      eventType: "review_open",
+      source: "review:page",
+      metadata: {
+        review_id: reviewId,
+        entity_id: entityId ?? null,
+      },
+    });
+  }, [entityId, isAuthenticated, reviewId]);
 
   return null;
 }

--- a/apps/web/components/track-page-header-bridge.tsx
+++ b/apps/web/components/track-page-header-bridge.tsx
@@ -2,9 +2,14 @@
 
 import { useEffect, useMemo } from "react";
 import { useRouteHeader } from "@/components/route-header-context";
+import { trackAnalyticsEvent } from "@/lib/analytics/client";
 
 type TrackPageHeaderBridgeProps = {
   entityId?: string | null;
+  provider?: string | null;
+  providerId?: string | null;
+  type?: string | null;
+  isAuthenticated?: boolean;
   sharePath?: string;
   title: string;
   artistName: string | null;
@@ -13,6 +18,10 @@ type TrackPageHeaderBridgeProps = {
 
 export default function TrackPageHeaderBridge({
   entityId,
+  provider,
+  providerId,
+  type,
+  isAuthenticated = false,
   sharePath,
   title,
   artistName,
@@ -50,6 +59,23 @@ export default function TrackPageHeaderBridge({
       setDetailHeader(null);
     };
   }, [artistName, externalLinks, resolvedSharePath, setDetailHeader, title]);
+
+  useEffect(() => {
+    if (!isAuthenticated || !entityId) {
+      return;
+    }
+
+    trackAnalyticsEvent({
+      eventType: "entity_open",
+      source: "track:page",
+      metadata: {
+        entity_id: entityId,
+        provider: provider ?? null,
+        provider_id: providerId ?? null,
+        type: type ?? null,
+      },
+    });
+  }, [entityId, isAuthenticated, provider, providerId, type]);
 
   return null;
 }

--- a/apps/web/lib/analytics/events.test.ts
+++ b/apps/web/lib/analytics/events.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  analyticsEventTypes,
+  getCanonicalAnalyticsEventType,
+  isAllowedAnalyticsMetadataKey,
+} from "./events.ts";
+
+test("analytics event contract includes documented discovery events", () => {
+  assert.ok(analyticsEventTypes.includes("feed_loaded"));
+  assert.ok(analyticsEventTypes.includes("review_impression"));
+  assert.ok(analyticsEventTypes.includes("review_open"));
+  assert.ok(analyticsEventTypes.includes("review_read_50"));
+  assert.ok(analyticsEventTypes.includes("review_read_90"));
+  assert.ok(analyticsEventTypes.includes("entity_open"));
+  assert.ok(analyticsEventTypes.includes("starter_impression"));
+  assert.ok(analyticsEventTypes.includes("starter_review_published"));
+});
+
+test("legacy analytics event names normalize to the signal contract", () => {
+  assert.equal(
+    getCanonicalAnalyticsEventType("for_you_reviews_loaded"),
+    "feed_loaded",
+  );
+  assert.equal(
+    getCanonicalAnalyticsEventType("for_you_fallback"),
+    "recommendation_fallback",
+  );
+  assert.equal(
+    getCanonicalAnalyticsEventType("for_you_recommendation_action"),
+    "starter_pass",
+  );
+  assert.equal(
+    getCanonicalAnalyticsEventType("for_you_review_action"),
+    "for_you_review_action",
+  );
+});
+
+test("analytics metadata keys reject sensitive fields", () => {
+  assert.equal(isAllowedAnalyticsMetadataKey("review_id"), true);
+  assert.equal(isAllowedAnalyticsMetadataKey("matched_tag_count"), true);
+  assert.equal(isAllowedAnalyticsMetadataKey("email"), false);
+  assert.equal(isAllowedAnalyticsMetadataKey("ip_address"), false);
+  assert.equal(isAllowedAnalyticsMetadataKey("ipaddress"), false);
+  assert.equal(isAllowedAnalyticsMetadataKey("user-agent"), false);
+  assert.equal(isAllowedAnalyticsMetadataKey("user_agent"), false);
+  assert.equal(isAllowedAnalyticsMetadataKey("ReviewID"), false);
+  assert.equal(isAllowedAnalyticsMetadataKey("raw_review_text"), false);
+});

--- a/apps/web/lib/analytics/events.ts
+++ b/apps/web/lib/analytics/events.ts
@@ -1,0 +1,70 @@
+export const analyticsEventTypes = [
+  "taste_onboarding_completed",
+  "feed_loaded",
+  "recommendation_fallback",
+  "review_impression",
+  "review_open",
+  "review_read_50",
+  "review_read_90",
+  "entity_open",
+  "for_you_review_action",
+  "starter_impression",
+  "starter_open",
+  "starter_pass",
+  "starter_review_cta",
+  "starter_review_published",
+] as const;
+
+export type AnalyticsEventType = (typeof analyticsEventTypes)[number];
+
+const legacyAnalyticsEventAliases = {
+  for_you_reviews_loaded: "feed_loaded",
+  for_you_fallback: "recommendation_fallback",
+  for_you_recommendation_action: "starter_pass",
+} as const satisfies Record<string, AnalyticsEventType>;
+
+export const analyticsAcceptedEventTypes = [
+  ...analyticsEventTypes,
+  ...Object.keys(legacyAnalyticsEventAliases),
+] as const;
+
+const analyticsEventTypeSet = new Set<string>(analyticsEventTypes);
+
+const sensitiveAnalyticsMetadataKeys = new Set([
+  "email",
+  "email_address",
+  "ip",
+  "ip_address",
+  "ipaddress",
+  "raw_review_text",
+  "review_body",
+  "review_text",
+  "text_body",
+  "ua",
+  "user_agent",
+  "useragent",
+]);
+
+export function getCanonicalAnalyticsEventType(
+  eventType: string,
+): AnalyticsEventType | null {
+  if (analyticsEventTypeSet.has(eventType)) {
+    return eventType as AnalyticsEventType;
+  }
+
+  return legacyAnalyticsEventAliases[
+    eventType as keyof typeof legacyAnalyticsEventAliases
+  ] ?? null;
+}
+
+export function isAllowedAnalyticsMetadataKey(key: string) {
+  const trimmedKey = key.trim();
+  const normalizedKey = trimmedKey.toLowerCase().replaceAll("-", "_");
+
+  return (
+    trimmedKey === key &&
+    trimmedKey === normalizedKey &&
+    /^[a-z0-9_]{1,64}$/.test(trimmedKey) &&
+    !sensitiveAnalyticsMetadataKeys.has(normalizedKey)
+  );
+}

--- a/apps/web/lib/queries/feed.ts
+++ b/apps/web/lib/queries/feed.ts
@@ -310,7 +310,7 @@ async function queryRecommendedFeedPage({
 
     await trackServerAnalyticsEvent(supabase, {
       userId: viewerId,
-      eventType: "for_you_fallback",
+      eventType: "recommendation_fallback",
       source: "feed:server",
       metadata: {
         code: recommendationsResult.error.code ?? null,

--- a/apps/web/lib/validation/schemas.ts
+++ b/apps/web/lib/validation/schemas.ts
@@ -1,4 +1,9 @@
 import { z } from "zod";
+import {
+  analyticsAcceptedEventTypes,
+  getCanonicalAnalyticsEventType,
+  isAllowedAnalyticsMetadataKey,
+} from "@/lib/analytics/events";
 import { searchableEntityTypes } from "@/lib/search-types";
 import { tasteOnboardingMaxTags, tasteOnboardingMinTags } from "@/lib/taste";
 
@@ -255,20 +260,21 @@ const analyticsMetadataValueSchema: z.ZodType<
 ]);
 
 export const analyticsEventSchema = z.object({
-  eventType: z.enum([
-    "taste_onboarding_completed",
-    "for_you_reviews_loaded",
-    "for_you_review_action",
-    "for_you_recommendation_action",
-    "for_you_fallback",
-  ]),
+  eventType: z
+    .enum(analyticsAcceptedEventTypes)
+    .transform((eventType) => getCanonicalAnalyticsEventType(eventType) ?? eventType),
   source: z
     .string()
     .trim()
     .regex(/^[a-z0-9_:-]{2,80}$/, "Invalid analytics source.")
     .default("web"),
   metadata: z
-    .record(z.string().regex(/^[a-z0-9_:-]{1,64}$/), analyticsMetadataValueSchema)
+    .record(
+      z.string().refine(isAllowedAnalyticsMetadataKey, {
+        message: "Analytics metadata contains a sensitive or invalid key.",
+      }),
+      analyticsMetadataValueSchema,
+    )
     .default({}),
 });
 

--- a/docs/discovery-curation.md
+++ b/docs/discovery-curation.md
@@ -100,7 +100,6 @@ entity_open
 feed_loaded
 recommendation_fallback
 for_you_review_action
-for_you_recommendation_action
 starter_impression
 starter_open
 starter_pass
@@ -128,10 +127,11 @@ Use only fields that help answer a product question:
 | `review_open` | `review_id`, `entity_id`, `reason`, `position` | Which surfaced reviews earn deeper reading? |
 | `review_read_50` | `review_id`, `entity_id`, `reason` | Which reviews hold attention? |
 | `review_read_90` | `review_id`, `entity_id`, `reason` | Which reviews are genuinely read? |
-| `entity_open` | `entity_id`, `provider`, `provider_id`, `source` | Which tracks become discovery destinations? |
+| `entity_open` | `entity_id`, `provider`, `provider_id`, `type` | Which tracks become discovery destinations? |
 | `for_you_review_action` | `action`, `review_id`, `entity_id`, `reason` | Which feed actions should tune ranking? |
-| `for_you_recommendation_action` | `action`, `starter_track_id`, `provider_id`, `matched_tag_count` | Are starter picks useful or being skipped? |
 | `starter_impression` | `starter_track_id`, `provider_id`, `matched_tag_count`, `position` | Which editorial picks are shown? |
+| `starter_pass` | `starter_track_id`, `provider_id`, `matched_tag_count` | Which editorial picks should be downranked or replaced? |
+| `starter_open` | `starter_track_id`, `provider_id`, `matched_tag_count` | Which editorial picks become discovery destinations? |
 | `starter_review_cta` | `starter_track_id`, `provider_id` | Which starter picks invite reviews? |
 | `starter_review_published` | `starter_track_id`, `provider_id` | Which starter picks convert into reviews? |
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -168,7 +168,7 @@ Starter tags affect recommendations in two stages:
 1. `get_starter_tracks()` ranks starter picks against the viewer's onboarding taste.
 2. `sync_entity_tags_from_starter_track()` copies starter tags to `entity_preference_tags` when a user reviews that track. If a curator edits the starter tags later, stale `system` tags are removed while manual tags are preserved.
 
-The feed presents these picks as a lightweight taste queue. A pass records `for_you_recommendation_action` in analytics; a review click still records `for_you_review_action`.
+The feed presents these picks as a lightweight taste queue. Impressions, passes, review intent, and published reviews record `starter_impression`, `starter_pass`, `starter_review_cta`, and `starter_review_published` in analytics.
 
 If the full starter migration has already landed but a legacy environment needs only the starter tag/RPC patch, review `supabase/scripts/maintenance/starter-algorithm-signals-patch.sql`. It updates only the starter tag table and related RPC functions, so it takes fewer schema locks.
 


### PR DESCRIPTION
## What changed

- Added a central analytics signal contract with canonical event names, legacy aliases, and metadata key validation.
- Instrumented the first discovery signals: `feed_loaded`, `review_impression`, `review_open`, `entity_open`, `recommendation_fallback`, and starter pick events.
- Updated README and discovery/operations docs so the documented analytics contract matches the implementation.

## Why

This gives Kocteau a cleaner base for Recommendation Health without letting analytics grow chaotically. The first pass keeps signals product-specific, first-party, and free of sensitive metadata.

## Testing

- [ ] Ran `pnpm check`
- [ ] Added screenshots or a short recording for visible web UI changes
- [ ] Confirmed this does not touch auth, Supabase, recommendations, analytics, CI, or release behavior

Targeted verification run:

- `node --test apps/web/lib/analytics/events.test.ts`
- `pnpm --filter web lint`
- `pnpm --dir apps/web build`
- `git diff --check`

Notes:

- No visible UI change, so no screenshots added.
- This intentionally touches analytics and recommendation-adjacent signal instrumentation.
- No Supabase DB migrations, RLS changes, or RPC/schema changes.

## Changelog impact

No manual `CHANGELOG.md` edit is required. Release Please generates release notes from PR titles and squash commits.

- [ ] User-facing web change
- [x] Developer experience or documentation change
- [x] Internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced analytics tracking for review and entity page opens
  * Added impression, action, and published event tracking for starter picks
  * Expanded feed analytics with page-load and per-review impression tracking

* **Bug Fixes**
  * Corrected recommendation fallback event naming for consistency

* **Documentation**
  * Updated analytics event documentation and metadata validation requirements
  * Clarified tracking behavior for starter picks and feed interactions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->