### PR TITLE
feat(web): add recommendation health studio

### DIFF
--- a/apps/web/app/(main)/layout.tsx
+++ b/apps/web/app/(main)/layout.tsx
@@ -7,6 +7,7 @@ import MobileBottomBar from "@/components/mobile-bottom-bar";
 import { RouteHeaderProvider } from "@/components/route-header-context";
 import WhoToFollowRail from "@/components/who-to-follow-rail";
 import { getCurrentOnboardingState, getCurrentUser, getCurrentViewerProfile } from "@/lib/auth/server";
+import { getStarterCuratorAccess } from "@/lib/queries/curation";
 import { getStarterTracks } from "@/lib/queries/starter";
 import type { SidebarOwnedReview } from "@/lib/types/sidebar";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
@@ -28,7 +29,10 @@ export default async function MainLayout({ children }: { children: React.ReactNo
     redirect("/onboarding/taste");
   }
 
-  const starterTracks = await getStarterTracks({ viewerId: user?.id, limit: 6 });
+  const [starterTracks, canAccessStudio] = await Promise.all([
+    getStarterTracks({ viewerId: user?.id, limit: 6 }),
+    user ? getStarterCuratorAccess() : Promise.resolve(false),
+  ]);
 
   return (
     <ReactQueryProvider>
@@ -46,6 +50,7 @@ export default async function MainLayout({ children }: { children: React.ReactNo
           profile={safeProfile}
           ownedReviews={ownedReviews}
           unreadCount={initialUnreadCount}
+          canAccessStudio={canAccessStudio}
         />
         <SidebarInset className="min-h-svh bg-[var(--kocteau-canvas)] lg:h-dvh lg:overflow-hidden lg:p-2.5">
           <RouteHeaderProvider>

--- a/apps/web/app/(main)/studio/health/page.tsx
+++ b/apps/web/app/(main)/studio/health/page.tsx
@@ -1,0 +1,48 @@
+import { notFound, redirect } from "next/navigation";
+import RecommendationHealthSummary from "@/components/recommendation-health-summary";
+import { getCurrentUser } from "@/lib/auth/server";
+import { createPageMetadata } from "@/lib/metadata";
+import { getStarterCuratorAccess } from "@/lib/queries/curation";
+import { getRecommendationHealthSnapshot } from "@/lib/queries/recommendation-health";
+import { getRecommendationHealthDays } from "@/lib/recommendation-health/metrics";
+
+export const metadata = createPageMetadata({
+  title: "Recommendation Health",
+  description: "Internal Kocteau recommendation health checks.",
+  path: "/studio/health",
+  noIndex: true,
+});
+
+export default async function RecommendationHealthPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ days?: string | string[] }>;
+}) {
+  const user = await getCurrentUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  const hasAccess = await getStarterCuratorAccess();
+
+  if (!hasAccess) {
+    notFound();
+  }
+
+  const resolvedSearchParams = await searchParams;
+  const daysParam = Array.isArray(resolvedSearchParams.days)
+    ? resolvedSearchParams.days[0]
+    : resolvedSearchParams.days;
+  const selectedDays = getRecommendationHealthDays(daysParam);
+  const { snapshot, unavailable } =
+    await getRecommendationHealthSnapshot(selectedDays);
+
+  return (
+    <RecommendationHealthSummary
+      snapshot={snapshot}
+      selectedDays={selectedDays}
+      unavailable={unavailable}
+    />
+  );
+}

--- a/apps/web/components/app-sidebar.tsx
+++ b/apps/web/components/app-sidebar.tsx
@@ -7,8 +7,10 @@ import {
   BellSimpleIcon,
   BookmarkSimpleIcon,
   ChatCircleTextIcon,
+  GearSixIcon,
   HouseIcon,
   MagnifyingGlassIcon,
+  Sparkles,
 } from "@/components/ui/icons";
 import BrandLogo from "@/components/brand-logo";
 import NewReviewDialog from "@/components/new-review-dialog";
@@ -49,12 +51,14 @@ type AppSidebarProps = React.ComponentProps<typeof Sidebar> & {
   profile: AppSidebarProfile | null;
   ownedReviews?: SidebarOwnedReview[];
   unreadCount?: number;
+  canAccessStudio?: boolean;
 };
 
 export default function AppSidebar({
   profile,
   ownedReviews = [],
   unreadCount: initialUnreadCount = 0,
+  canAccessStudio = false,
   ...props
 }: AppSidebarProps) {
   const pathname = usePathname();
@@ -143,6 +147,22 @@ export default function AppSidebar({
         },
       ]
     : [];
+  const studioItems = canAccessStudio
+    ? [
+        {
+          title: "Starter",
+          url: "/studio/starter",
+          icon: Sparkles,
+          isActive: pathname.startsWith("/studio/starter"),
+        },
+        {
+          title: "Health",
+          url: "/studio/health",
+          icon: GearSixIcon,
+          isActive: pathname.startsWith("/studio/health"),
+        },
+      ]
+    : [];
 
   const canShowOwnedReviews = Boolean(profile) && sidebarReviews.length > 0;
   const reviewEntryLabel = profile ? "New review" : "Find a track";
@@ -191,6 +211,13 @@ export default function AppSidebar({
         <SidebarContent className="gap-1.5 px-1 pb-2.5 group-data-[collapsible=icon]:px-0.5 group-data-[collapsible=icon]:pb-1.5">
           <NavMain items={mainItems} onNavigate={closeMobileSidebar} />
           {secondaryItems.length > 0 ? <NavSecondary items={secondaryItems} onNavigate={closeMobileSidebar} /> : null}
+          {studioItems.length > 0 ? (
+            <NavSecondary
+              items={studioItems}
+              label="Studio"
+              onNavigate={closeMobileSidebar}
+            />
+          ) : null}
           {canShowOwnedReviews ? <NavOwnedReviews items={sidebarReviews} onNavigate={closeMobileSidebar} /> : null}
         </SidebarContent>
 

--- a/apps/web/components/recommendation-health-summary.tsx
+++ b/apps/web/components/recommendation-health-summary.tsx
@@ -1,0 +1,259 @@
+import Link from "next/link";
+import {
+  formatRecommendationReason,
+  recommendationHealthWindows,
+  type EntityDestinationHealth,
+  type RecommendationHealthSnapshot,
+  type RecommendationHealthWindow,
+  type StarterTrackHealth,
+  type StarterTagCoverage,
+} from "@/lib/recommendation-health/metrics";
+import { cn } from "@/lib/utils";
+
+type RecommendationHealthSummaryProps = {
+  snapshot: RecommendationHealthSnapshot;
+  selectedDays: RecommendationHealthWindow;
+  unavailable?: boolean;
+};
+
+function formatCount(value: number) {
+  return new Intl.NumberFormat("en", { maximumFractionDigits: 0 }).format(value);
+}
+
+function formatPercent(value: number) {
+  return `${new Intl.NumberFormat("en", {
+    maximumFractionDigits: value < 0.1 ? 2 : 1,
+    minimumFractionDigits: 0,
+  }).format(value * 100)}%`;
+}
+
+function formatTrackLabel(track: StarterTrackHealth) {
+  if (track.title && track.artistName) {
+    return `${track.title} by ${track.artistName}`;
+  }
+
+  return track.title ?? track.providerId ?? track.starterTrackId;
+}
+
+function formatEntityLabel(entity: EntityDestinationHealth) {
+  if (entity.title && entity.artistName) {
+    return `${entity.title} by ${entity.artistName}`;
+  }
+
+  return entity.title ?? entity.providerId ?? entity.entityId;
+}
+
+function MetricTile({
+  label,
+  value,
+  note,
+}: {
+  label: string;
+  value: string;
+  note: string;
+}) {
+  return (
+    <div className="min-h-[6.5rem] rounded-[var(--kocteau-radius-card)] border border-border/22 bg-card/28 px-4 py-3.5">
+      <p className="text-[12px] font-medium text-muted-foreground/70">{label}</p>
+      <p className="mt-2 font-serif text-2xl font-semibold tabular-nums text-foreground">
+        {value}
+      </p>
+      <p className="mt-1 text-[12px] leading-5 text-muted-foreground/68">{note}</p>
+    </div>
+  );
+}
+
+function EmptyRow({ label }: { label: string }) {
+  return (
+    <div className="rounded-[var(--kocteau-radius-card)] border border-border/20 bg-card/20 px-4 py-5 text-sm text-muted-foreground">
+      {label}
+    </div>
+  );
+}
+
+function TagCoverageList({ items }: { items: StarterTagCoverage[] }) {
+  if (items.length === 0) {
+    return <EmptyRow label="No active starter tag coverage yet." />;
+  }
+
+  return (
+    <div className="grid gap-2 sm:grid-cols-2">
+      {items.slice(0, 8).map((item) => (
+        <div
+          key={item.kind}
+          className="rounded-[var(--kocteau-radius-card)] border border-border/20 bg-card/22 px-3.5 py-3"
+        >
+          <p className="text-sm font-medium text-foreground">
+            {formatRecommendationReason(item.kind)}
+          </p>
+          <p className="mt-1 text-[12px] text-muted-foreground/70">
+            {formatCount(item.taggedTracks)} tracks, {formatCount(item.tagCount)} tags
+          </p>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function RecommendationHealthSummary({
+  snapshot,
+  selectedDays,
+  unavailable = false,
+}: RecommendationHealthSummaryProps) {
+  const { feed, starter } = snapshot;
+  const topReasons = snapshot.reasons.slice(0, 8);
+  const topStarterTracks = snapshot.starterTracks.slice(0, 8);
+  const topEntities = snapshot.entities.slice(0, 8);
+
+  return (
+    <section className="mx-auto w-full max-w-4xl space-y-6 pb-8">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div className="min-w-0 space-y-1">
+          <p className="text-[12px] font-medium text-muted-foreground/72">Studio</p>
+          <h1 className="font-serif text-2xl font-semibold text-foreground">
+            Recommendation health
+          </h1>
+          <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
+            Aggregate signals for For You and starter picks.
+          </p>
+        </div>
+
+        <div className="inline-flex w-fit rounded-[0.68rem] border border-border/24 bg-card/26 p-1">
+          {recommendationHealthWindows.map((days) => (
+            <Link
+              key={days}
+              href={`/studio/health?days=${days}`}
+              className={cn(
+                "inline-flex h-7 min-w-10 items-center justify-center rounded-md px-2 text-[12px] font-medium tabular-nums text-muted-foreground transition-colors",
+                selectedDays === days && "bg-foreground text-background",
+              )}
+            >
+              {days}d
+            </Link>
+          ))}
+        </div>
+      </div>
+
+      {unavailable ? (
+        <div className="rounded-[var(--kocteau-radius-card)] border border-border/28 bg-card/24 px-4 py-3 text-sm leading-6 text-muted-foreground">
+          Recommendation health RPC is not available yet. Apply the local Supabase
+          migration before reading this surface in production.
+        </div>
+      ) : null}
+
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        <MetricTile
+          label="Feed loads"
+          value={formatCount(feed.loads)}
+          note={`${formatCount(feed.reviewImpressions)} review impressions`}
+        />
+        <MetricTile
+          label="Fallback rate"
+          value={formatPercent(feed.fallbackRate)}
+          note={`${formatCount(feed.fallbacks)} fallback events`}
+        />
+        <MetricTile
+          label="Review open rate"
+          value={formatPercent(feed.reviewOpenRate)}
+          note={`${formatCount(feed.reviewOpens)} review opens`}
+        />
+        <MetricTile
+          label="Starter conversion"
+          value={formatPercent(starter.reviewConversionRate)}
+          note={`${formatCount(starter.reviewsPublished)} reviews published`}
+        />
+      </div>
+
+      <section className="space-y-2.5">
+        <div className="flex items-center justify-between gap-3">
+          <h2 className="text-sm font-semibold text-foreground">Recommendation reasons</h2>
+          <span className="text-[12px] text-muted-foreground">
+            {formatCount(topReasons.length)} shown
+          </span>
+        </div>
+        {topReasons.length > 0 ? (
+          <div className="divide-y divide-border/14 rounded-[var(--kocteau-radius-card)] border border-border/20 bg-card/22">
+            {topReasons.map((reason) => (
+              <div
+                key={reason.reason}
+                className="grid grid-cols-[minmax(0,1fr)_4.5rem_4.5rem_4.75rem] items-center gap-2 px-3.5 py-3 text-[13px]"
+              >
+                <p className="truncate font-medium text-foreground">
+                  {formatRecommendationReason(reason.reason)}
+                </p>
+                <p className="text-right tabular-nums text-muted-foreground">
+                  {formatCount(reason.impressions)}
+                </p>
+                <p className="text-right tabular-nums text-muted-foreground">
+                  {formatCount(reason.opens)}
+                </p>
+                <p className="text-right tabular-nums text-foreground">
+                  {formatPercent(reason.openRate)}
+                </p>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <EmptyRow label="No recommendation reason signals yet." />
+        )}
+      </section>
+
+      <section className="space-y-2.5">
+        <h2 className="text-sm font-semibold text-foreground">Starter picks</h2>
+        {topStarterTracks.length > 0 ? (
+          <div className="divide-y divide-border/14 rounded-[var(--kocteau-radius-card)] border border-border/20 bg-card/22">
+            {topStarterTracks.map((track) => (
+              <div
+                key={track.starterTrackId}
+                className="grid grid-cols-[minmax(0,1fr)_4.5rem_4.5rem_4.75rem] items-center gap-2 px-3.5 py-3 text-[13px]"
+              >
+                <p className="truncate font-medium text-foreground">
+                  {formatTrackLabel(track)}
+                </p>
+                <p className="text-right tabular-nums text-muted-foreground">
+                  {formatCount(track.impressions)}
+                </p>
+                <p className="text-right tabular-nums text-muted-foreground">
+                  {formatCount(track.passes)}
+                </p>
+                <p className="text-right tabular-nums text-foreground">
+                  {formatPercent(track.reviewConversionRate)}
+                </p>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <EmptyRow label="No starter pick signals yet." />
+        )}
+      </section>
+
+      <section className="space-y-2.5">
+        <h2 className="text-sm font-semibold text-foreground">Starter tag coverage</h2>
+        <TagCoverageList items={snapshot.tagCoverage} />
+      </section>
+
+      <section className="space-y-2.5">
+        <h2 className="text-sm font-semibold text-foreground">Track destinations</h2>
+        {topEntities.length > 0 ? (
+          <div className="divide-y divide-border/14 rounded-[var(--kocteau-radius-card)] border border-border/20 bg-card/22">
+            {topEntities.map((entity) => (
+              <div
+                key={entity.entityId}
+                className="grid grid-cols-[minmax(0,1fr)_4.5rem] items-center gap-2 px-3.5 py-3 text-[13px]"
+              >
+                <p className="truncate font-medium text-foreground">
+                  {formatEntityLabel(entity)}
+                </p>
+                <p className="text-right tabular-nums text-foreground">
+                  {formatCount(entity.opens)}
+                </p>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <EmptyRow label="No track destination signals yet." />
+        )}
+      </section>
+    </section>
+  );
+}

--- a/apps/web/lib/queries/recommendation-health.ts
+++ b/apps/web/lib/queries/recommendation-health.ts
@@ -1,0 +1,47 @@
+import "server-only";
+
+import { measureServerTask } from "@/lib/perf";
+import {
+  normalizeRecommendationHealthSnapshot,
+  type RecommendationHealthSnapshot,
+  type RecommendationHealthWindow,
+} from "@/lib/recommendation-health/metrics";
+import { supabaseServer } from "@/lib/supabase/server";
+
+export type RecommendationHealthResult = {
+  snapshot: RecommendationHealthSnapshot;
+  unavailable: boolean;
+};
+
+export async function getRecommendationHealthSnapshot(
+  days: RecommendationHealthWindow,
+): Promise<RecommendationHealthResult> {
+  return measureServerTask(
+    "getRecommendationHealthSnapshot",
+    async () => {
+      const supabase = await supabaseServer();
+      const { data, error } = await supabase.rpc(
+        "get_recommendation_health_snapshot",
+        { p_days: days },
+      );
+
+      if (error) {
+        console.error("[recommendationHealth.getSnapshot] failed", {
+          code: error.code ?? null,
+          message: error.message ?? null,
+        });
+
+        return {
+          snapshot: normalizeRecommendationHealthSnapshot(null, days),
+          unavailable: true,
+        };
+      }
+
+      return {
+        snapshot: normalizeRecommendationHealthSnapshot(data, days),
+        unavailable: false,
+      };
+    },
+    { days },
+  );
+}

--- a/apps/web/lib/recommendation-health/metrics.test.ts
+++ b/apps/web/lib/recommendation-health/metrics.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  formatRecommendationReason,
+  getRecommendationHealthDays,
+  normalizeRecommendationHealthSnapshot,
+} from "./metrics.ts";
+
+test("normalizes aggregate recommendation health payloads for the studio UI", () => {
+  const snapshot = normalizeRecommendationHealthSnapshot({
+    window: {
+      days: 30,
+      startAt: "2026-05-01T00:00:00.000Z",
+      endAt: "2026-06-01T00:00:00.000Z",
+    },
+    feed: {
+      loads: "10",
+      fallbacks: 2,
+      fallbackRate: "0.2",
+      reviewImpressions: 40,
+      reviewOpens: 8,
+      reviewOpenRate: 0.2,
+      entityOpens: 5,
+    },
+    reasons: [
+      { reason: "taste_match", impressions: 20, opens: 6, openRate: 0.3 },
+      { reason: null, impressions: "3", opens: "1", openRate: "0.3333" },
+    ],
+    starter: {
+      impressions: 12,
+      passes: 4,
+      passRate: 0.3333,
+      reviewCtas: 3,
+      reviewsPublished: 1,
+      reviewConversionRate: 0.0833,
+    },
+    starterTracks: [
+      {
+        starterTrackId: "starter-1",
+        providerId: "deezer-1",
+        title: "Heaven or Las Vegas",
+        artistName: "Cocteau Twins",
+        impressions: 8,
+        passes: 2,
+        passRate: 0.25,
+        reviewCtas: 2,
+        reviewsPublished: 1,
+        reviewConversionRate: 0.125,
+      },
+    ],
+    tagCoverage: [
+      {
+        kind: "mood",
+        taggedTracks: 6,
+        tagCount: 8,
+      },
+    ],
+    entities: [
+      {
+        entityId: "entity-1",
+        provider: "deezer",
+        providerId: "3135556",
+        type: "track",
+        title: "Cherry-coloured Funk",
+        artistName: "Cocteau Twins",
+        opens: 7,
+      },
+    ],
+  });
+
+  assert.equal(snapshot.window.days, 30);
+  assert.equal(snapshot.feed.loads, 10);
+  assert.equal(snapshot.feed.fallbackRate, 0.2);
+  assert.equal(snapshot.reasons[0]?.reason, "taste_match");
+  assert.equal(snapshot.reasons[1]?.reason, "unknown");
+  assert.equal(snapshot.starterTracks[0]?.title, "Heaven or Las Vegas");
+  assert.equal(snapshot.tagCoverage[0]?.kind, "mood");
+  assert.equal(snapshot.tagCoverage[0]?.taggedTracks, 6);
+  assert.equal(snapshot.entities[0]?.opens, 7);
+});
+
+test("chooses only supported recommendation health windows", () => {
+  assert.equal(getRecommendationHealthDays("7"), 7);
+  assert.equal(getRecommendationHealthDays("30"), 30);
+  assert.equal(getRecommendationHealthDays("100"), 14);
+  assert.equal(getRecommendationHealthDays(null), 14);
+});
+
+test("formats recommendation reasons for quiet editorial display", () => {
+  assert.equal(formatRecommendationReason("taste_match"), "Taste match");
+  assert.equal(formatRecommendationReason("author-affinity"), "Author affinity");
+  assert.equal(formatRecommendationReason(null), "Unknown");
+});

--- a/apps/web/lib/recommendation-health/metrics.ts
+++ b/apps/web/lib/recommendation-health/metrics.ts
@@ -1,0 +1,285 @@
+export const recommendationHealthWindows = [7, 14, 30, 90] as const;
+
+export type RecommendationHealthWindow = (typeof recommendationHealthWindows)[number];
+
+export type RecommendationHealthSummary = {
+  loads: number;
+  fallbacks: number;
+  fallbackRate: number;
+  reviewImpressions: number;
+  reviewOpens: number;
+  reviewOpenRate: number;
+  entityOpens: number;
+};
+
+export type RecommendationReasonHealth = {
+  reason: string;
+  impressions: number;
+  opens: number;
+  openRate: number;
+};
+
+export type StarterHealthSummary = {
+  impressions: number;
+  passes: number;
+  passRate: number;
+  reviewCtas: number;
+  reviewsPublished: number;
+  reviewConversionRate: number;
+};
+
+export type StarterTrackHealth = StarterHealthSummary & {
+  starterTrackId: string;
+  providerId: string | null;
+  title: string | null;
+  artistName: string | null;
+};
+
+export type EntityDestinationHealth = {
+  entityId: string;
+  provider: string | null;
+  providerId: string | null;
+  type: string | null;
+  title: string | null;
+  artistName: string | null;
+  opens: number;
+};
+
+export type StarterTagCoverage = {
+  kind: string;
+  taggedTracks: number;
+  tagCount: number;
+};
+
+export type FeedDailyHealth = RecommendationHealthSummary & {
+  day: string;
+};
+
+export type RecommendationHealthSnapshot = {
+  window: {
+    days: RecommendationHealthWindow;
+    startAt: string | null;
+    endAt: string | null;
+  };
+  feed: RecommendationHealthSummary;
+  feedDaily: FeedDailyHealth[];
+  reasons: RecommendationReasonHealth[];
+  starter: StarterHealthSummary;
+  starterTracks: StarterTrackHealth[];
+  tagCoverage: StarterTagCoverage[];
+  entities: EntityDestinationHealth[];
+};
+
+const defaultFeedSummary: RecommendationHealthSummary = {
+  loads: 0,
+  fallbacks: 0,
+  fallbackRate: 0,
+  reviewImpressions: 0,
+  reviewOpens: 0,
+  reviewOpenRate: 0,
+  entityOpens: 0,
+};
+
+const defaultStarterSummary: StarterHealthSummary = {
+  impressions: 0,
+  passes: 0,
+  passRate: 0,
+  reviewCtas: 0,
+  reviewsPublished: 0,
+  reviewConversionRate: 0,
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function toFiniteNumber(value: unknown) {
+  const numberValue =
+    typeof value === "number" ? value : typeof value === "string" ? Number(value) : 0;
+
+  return Number.isFinite(numberValue) ? numberValue : 0;
+}
+
+function toStringOrNull(value: unknown) {
+  return typeof value === "string" && value.trim() ? value : null;
+}
+
+function toHealthWindow(value: unknown, fallback: RecommendationHealthWindow) {
+  const numberValue = toFiniteNumber(value);
+
+  return recommendationHealthWindows.includes(
+    numberValue as RecommendationHealthWindow,
+  )
+    ? (numberValue as RecommendationHealthWindow)
+    : fallback;
+}
+
+function normalizeFeedSummary(value: unknown): RecommendationHealthSummary {
+  if (!isRecord(value)) {
+    return { ...defaultFeedSummary };
+  }
+
+  return {
+    loads: toFiniteNumber(value.loads),
+    fallbacks: toFiniteNumber(value.fallbacks),
+    fallbackRate: toFiniteNumber(value.fallbackRate),
+    reviewImpressions: toFiniteNumber(value.reviewImpressions),
+    reviewOpens: toFiniteNumber(value.reviewOpens),
+    reviewOpenRate: toFiniteNumber(value.reviewOpenRate),
+    entityOpens: toFiniteNumber(value.entityOpens),
+  };
+}
+
+function normalizeStarterSummary(value: unknown): StarterHealthSummary {
+  if (!isRecord(value)) {
+    return { ...defaultStarterSummary };
+  }
+
+  return {
+    impressions: toFiniteNumber(value.impressions),
+    passes: toFiniteNumber(value.passes),
+    passRate: toFiniteNumber(value.passRate),
+    reviewCtas: toFiniteNumber(value.reviewCtas),
+    reviewsPublished: toFiniteNumber(value.reviewsPublished),
+    reviewConversionRate: toFiniteNumber(value.reviewConversionRate),
+  };
+}
+
+function normalizeArray<T>(value: unknown, mapper: (item: unknown) => T | null) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.map(mapper).filter((item): item is T => item !== null);
+}
+
+export function getRecommendationHealthDays(
+  value: string | null | undefined,
+): RecommendationHealthWindow {
+  const parsed = value ? Number(value) : 14;
+
+  return recommendationHealthWindows.includes(parsed as RecommendationHealthWindow)
+    ? (parsed as RecommendationHealthWindow)
+    : 14;
+}
+
+export function formatRecommendationReason(reason: string | null | undefined) {
+  const safeReason = reason?.trim();
+
+  if (!safeReason) {
+    return "Unknown";
+  }
+
+  return safeReason
+    .replaceAll("-", "_")
+    .split("_")
+    .filter(Boolean)
+    .map((part, index) =>
+      index === 0 ? `${part.charAt(0).toUpperCase()}${part.slice(1)}` : part,
+    )
+    .join(" ");
+}
+
+export function normalizeRecommendationHealthSnapshot(
+  value: unknown,
+  fallbackDays: RecommendationHealthWindow = 14,
+): RecommendationHealthSnapshot {
+  const payload = isRecord(value) ? value : {};
+  const windowValue = isRecord(payload.window) ? payload.window : {};
+  const days = toHealthWindow(windowValue.days, fallbackDays);
+
+  return {
+    window: {
+      days,
+      startAt: toStringOrNull(windowValue.startAt),
+      endAt: toStringOrNull(windowValue.endAt),
+    },
+    feed: normalizeFeedSummary(payload.feed),
+    feedDaily: normalizeArray(payload.feedDaily, (item) => {
+      if (!isRecord(item)) {
+        return null;
+      }
+
+      const day = toStringOrNull(item.day);
+
+      if (!day) {
+        return null;
+      }
+
+      return {
+        day,
+        ...normalizeFeedSummary(item),
+      };
+    }),
+    reasons: normalizeArray(payload.reasons, (item) => {
+      if (!isRecord(item)) {
+        return null;
+      }
+
+      return {
+        reason: toStringOrNull(item.reason) ?? "unknown",
+        impressions: toFiniteNumber(item.impressions),
+        opens: toFiniteNumber(item.opens),
+        openRate: toFiniteNumber(item.openRate),
+      };
+    }),
+    starter: normalizeStarterSummary(payload.starter),
+    starterTracks: normalizeArray(payload.starterTracks, (item) => {
+      if (!isRecord(item)) {
+        return null;
+      }
+
+      const starterTrackId = toStringOrNull(item.starterTrackId);
+
+      if (!starterTrackId) {
+        return null;
+      }
+
+      return {
+        starterTrackId,
+        providerId: toStringOrNull(item.providerId),
+        title: toStringOrNull(item.title),
+        artistName: toStringOrNull(item.artistName),
+        ...normalizeStarterSummary(item),
+      };
+    }),
+    tagCoverage: normalizeArray(payload.tagCoverage, (item) => {
+      if (!isRecord(item)) {
+        return null;
+      }
+
+      const kind = toStringOrNull(item.kind);
+
+      if (!kind) {
+        return null;
+      }
+
+      return {
+        kind,
+        taggedTracks: toFiniteNumber(item.taggedTracks),
+        tagCount: toFiniteNumber(item.tagCount),
+      };
+    }),
+    entities: normalizeArray(payload.entities, (item) => {
+      if (!isRecord(item)) {
+        return null;
+      }
+
+      const entityId = toStringOrNull(item.entityId);
+
+      if (!entityId) {
+        return null;
+      }
+
+      return {
+        entityId,
+        provider: toStringOrNull(item.provider),
+        providerId: toStringOrNull(item.providerId),
+        type: toStringOrNull(item.type),
+        title: toStringOrNull(item.title),
+        artistName: toStringOrNull(item.artistName),
+        opens: toFiniteNumber(item.opens),
+      };
+    }),
+  };
+}

--- a/apps/web/lib/supabase/database.types.ts
+++ b/apps/web/lib/supabase/database.types.ts
@@ -996,6 +996,10 @@ export type Database = {
           score: number
         }[]
       }
+      get_recommendation_health_snapshot: {
+        Args: { p_days?: number }
+        Returns: Json
+      }
       get_starter_tracks: {
         Args: { p_limit?: number }
         Returns: {

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -262,6 +262,13 @@ Suggested issue: `feat(web): add lightweight recommendation health checks for ma
 - Prefer simple SQL/admin notes before building a dashboard.
 - Use the signal contract in `docs/discovery-curation.md` before adding new events.
 
+Implementation path:
+
+1. Add read-only aggregate SQL checks for maintainers.
+2. Add a curator-only Studio health page backed by an aggregate Supabase RPC.
+3. Review a real 7-14 day snapshot after public traffic exists.
+4. Tune `get_recommended_review_ids` only after capturing a before snapshot.
+
 Suggested labels: `feature`, `area:recommendations`, `area:analytics`, `needs maintainer decision`
 
 Acceptance criteria:

--- a/docs/discovery-curation.md
+++ b/docs/discovery-curation.md
@@ -161,6 +161,8 @@ Outcomes:
 
 Add lightweight health checks before building a dashboard.
 
+Phase 2 starts with a read-only SQL playbook for maintainers and a curator-only Studio health surface powered by safe aggregate RPCs. Do not expose raw `analytics_events` rows to the web app.
+
 Useful checks:
 
 - fallback rate by day

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -170,6 +170,28 @@ Starter tags affect recommendations in two stages:
 
 The feed presents these picks as a lightweight taste queue. Impressions, passes, review intent, and published reviews record `starter_impression`, `starter_pass`, `starter_review_cta`, and `starter_review_published` in analytics.
 
+## Recommendation Health Checks
+
+Use `supabase/scripts/maintenance/recommendation-health-checks.sql` to inspect aggregate For You and starter health from the Supabase SQL editor.
+
+Curators can use the internal route:
+
+```text
+/studio/health
+```
+
+That route reads the same kind of aggregate signal through `get_recommendation_health_snapshot()`. Apply `supabase/migrations/20260601180027_recommendation_health_rpc.sql` before deploying the route to production.
+
+These checks are read-only and should be interpreted directionally:
+
+- `fallback_rate` above 0 means For You is falling back to latest reviews.
+- Low review open rate by reason means a reason may be surfacing weak matches.
+- High starter pass rate means a curated pick may be mistagged, too repetitive, or not editorially useful.
+- Starter impressions without review CTAs may mean the pick is visible but not inviting.
+- Entity opens show which tracks become discovery destinations.
+
+Do not export raw analytics rows. Share only aggregate counts and rates.
+
 If the full starter migration has already landed but a legacy environment needs only the starter tag/RPC patch, review `supabase/scripts/maintenance/starter-algorithm-signals-patch.sql`. It updates only the starter tag table and related RPC functions, so it takes fewer schema locks.
 
 Track pages currently keep Deezer as the canonical external music link. Spotify/Apple/ISRC resolution is intentionally not part of the app right now because the provider access model adds avoidable operational friction for the current product stage. Future playback should be designed as a separate YouTube embed layer, likely behind explicit curator/admin controls.

--- a/docs/superpowers/plans/2026-06-01-recommendation-health.md
+++ b/docs/superpowers/plans/2026-06-01-recommendation-health.md
@@ -1,0 +1,600 @@
+# Recommendation Health Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add lightweight recommendation health checks so maintainers can evaluate For You, starter picks, and discovery quality before tuning the ranking algorithm.
+
+**Architecture:** Start with read-only, aggregate SQL checks documented for maintainers. Do not add a dashboard until the team approves a Supabase read path for safe aggregate analytics. If a web surface is approved, expose only grouped metrics through a curator-only route and never expose raw user-level analytics.
+
+**Tech Stack:** Next.js App Router, TypeScript, Supabase Postgres, existing `analytics_events`, existing starter curator access model, Markdown docs, optional SQL maintenance script.
+
+---
+
+## Scope Decision
+
+Recommended first slice: **Phase 2A, operational health checks only.**
+
+This gives maintainers useful signal immediately and does not require a Supabase migration, new RLS policy, service role key, or app dashboard.
+
+Optional second slice: **Phase 2B, curator-only web health page.**
+
+This requires explicit approval before touching Supabase because `analytics_events` currently grants inserts only. The app cannot safely read aggregate analytics without a new approved read path.
+
+Execution note for `feat/recommendation-health`: the maintainer approved Phase 2A and Phase 2B. The implemented version uses a JSON aggregate RPC, a typed normalizer, `/studio/health`, and a curator-only Studio sidebar group.
+
+## Files
+
+Phase 2A:
+
+- Create: `supabase/scripts/maintenance/recommendation-health-checks.sql`
+- Modify: `docs/operations.md`
+- Modify: `docs/discovery-curation.md`
+- Modify: `docs/backlog.md`
+
+Phase 2B, only after approval:
+
+- Create: `supabase/migrations/20260601180027_recommendation_health_rpc.sql`
+- Modify: `apps/web/lib/supabase/database.types.ts`
+- Create: `apps/web/lib/queries/recommendation-health.ts`
+- Create: `apps/web/lib/recommendation-health/metrics.ts`
+- Test: `apps/web/lib/recommendation-health/metrics.test.ts`
+- Create: `apps/web/app/(main)/studio/health/page.tsx`
+- Create: `apps/web/components/recommendation-health-summary.tsx`
+- Modify: `apps/web/app/(main)/layout.tsx`
+- Modify: `apps/web/components/app-sidebar.tsx`
+
+## Phase 2A: Read-Only Operational Checks
+
+### Task 1: Add the SQL Health Playbook
+
+**Files:**
+
+- Create: `supabase/scripts/maintenance/recommendation-health-checks.sql`
+
+- [ ] **Step 1: Create read-only SQL queries**
+
+Add this script:
+
+```sql
+-- Kocteau recommendation health checks.
+-- Read-only aggregate queries for maintainers.
+-- Run in the Supabase SQL editor. Do not expose raw rows publicly.
+
+-- 1. Daily For You feed load and fallback health.
+SELECT
+  date_trunc('day', created_at) AS day,
+  count(*) FILTER (WHERE event_type = 'feed_loaded') AS feed_loads,
+  count(*) FILTER (WHERE event_type = 'recommendation_fallback') AS fallbacks,
+  round(
+    count(*) FILTER (WHERE event_type = 'recommendation_fallback')::numeric
+    / nullif(count(*) FILTER (WHERE event_type = 'feed_loaded'), 0),
+    4
+  ) AS fallback_rate
+FROM public.analytics_events
+WHERE created_at >= now() - interval '14 days'
+  AND event_type IN ('feed_loaded', 'recommendation_fallback')
+GROUP BY 1
+ORDER BY 1 DESC;
+
+-- 2. Surfaced recommendation reasons.
+SELECT
+  metadata->>'reason' AS reason,
+  count(*) AS impressions,
+  min(created_at) AS first_seen_at,
+  max(created_at) AS last_seen_at
+FROM public.analytics_events
+WHERE created_at >= now() - interval '14 days'
+  AND event_type = 'review_impression'
+GROUP BY 1
+ORDER BY impressions DESC;
+
+-- 3. Review open rate by recommendation reason.
+WITH impressions AS (
+  SELECT
+    metadata->>'review_id' AS review_id,
+    metadata->>'reason' AS reason,
+    count(*) AS impression_count
+  FROM public.analytics_events
+  WHERE created_at >= now() - interval '14 days'
+    AND event_type = 'review_impression'
+  GROUP BY 1, 2
+),
+opens AS (
+  SELECT
+    metadata->>'review_id' AS review_id,
+    count(*) AS open_count
+  FROM public.analytics_events
+  WHERE created_at >= now() - interval '14 days'
+    AND event_type = 'review_open'
+  GROUP BY 1
+)
+SELECT
+  coalesce(impressions.reason, 'unknown') AS reason,
+  sum(impressions.impression_count) AS impressions,
+  coalesce(sum(opens.open_count), 0) AS opens,
+  round(coalesce(sum(opens.open_count), 0)::numeric / nullif(sum(impressions.impression_count), 0), 4) AS open_rate
+FROM impressions
+LEFT JOIN opens ON opens.review_id = impressions.review_id
+GROUP BY 1
+ORDER BY impressions DESC;
+
+-- 4. Starter pick funnel.
+SELECT
+  date_trunc('day', created_at) AS day,
+  count(*) FILTER (WHERE event_type = 'starter_impression') AS impressions,
+  count(*) FILTER (WHERE event_type = 'starter_pass') AS passes,
+  count(*) FILTER (WHERE event_type = 'starter_review_cta') AS review_ctas,
+  count(*) FILTER (WHERE event_type = 'starter_review_published') AS reviews_published,
+  round(
+    count(*) FILTER (WHERE event_type = 'starter_review_published')::numeric
+    / nullif(count(*) FILTER (WHERE event_type = 'starter_impression'), 0),
+    4
+  ) AS review_conversion_rate
+FROM public.analytics_events
+WHERE created_at >= now() - interval '14 days'
+  AND event_type IN (
+    'starter_impression',
+    'starter_pass',
+    'starter_review_cta',
+    'starter_review_published'
+  )
+GROUP BY 1
+ORDER BY 1 DESC;
+
+-- 5. Starter pick quality by track.
+SELECT
+  metadata->>'starter_track_id' AS starter_track_id,
+  max(metadata->>'provider_id') AS provider_id,
+  count(*) FILTER (WHERE event_type = 'starter_impression') AS impressions,
+  count(*) FILTER (WHERE event_type = 'starter_pass') AS passes,
+  count(*) FILTER (WHERE event_type = 'starter_review_cta') AS review_ctas,
+  count(*) FILTER (WHERE event_type = 'starter_review_published') AS reviews_published
+FROM public.analytics_events
+WHERE created_at >= now() - interval '14 days'
+  AND event_type LIKE 'starter_%'
+GROUP BY 1
+ORDER BY impressions DESC NULLS LAST;
+
+-- 6. Entity destination health.
+SELECT
+  metadata->>'entity_id' AS entity_id,
+  max(metadata->>'provider') AS provider,
+  max(metadata->>'provider_id') AS provider_id,
+  max(metadata->>'type') AS type,
+  count(*) AS opens
+FROM public.analytics_events
+WHERE created_at >= now() - interval '14 days'
+  AND event_type = 'entity_open'
+GROUP BY 1
+ORDER BY opens DESC;
+```
+
+- [ ] **Step 2: Run a syntax-only smoke check**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: exit code 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add supabase/scripts/maintenance/recommendation-health-checks.sql
+git commit -m "docs: add recommendation health sql checks"
+```
+
+### Task 2: Document How Maintainers Should Read the Checks
+
+**Files:**
+
+- Modify: `docs/operations.md`
+- Modify: `docs/discovery-curation.md`
+
+- [ ] **Step 1: Add operations guidance**
+
+Add this section to `docs/operations.md` near the starter/analytics operations content:
+
+```md
+## Recommendation Health Checks
+
+Use `supabase/scripts/maintenance/recommendation-health-checks.sql` to inspect aggregate For You and starter health from the Supabase SQL editor.
+
+These checks are read-only and should be interpreted directionally:
+
+- `fallback_rate` above 0 means For You is falling back to latest reviews.
+- Low review open rate by reason means a reason may be surfacing weak matches.
+- High starter pass rate means a curated pick may be mistagged, too repetitive, or not editorially useful.
+- Starter impressions without review CTAs may mean the pick is visible but not inviting.
+- Entity opens show which tracks become discovery destinations.
+
+Do not export raw analytics rows. Share only aggregate counts and rates.
+```
+
+- [ ] **Step 2: Add phase status to discovery docs**
+
+Update `docs/discovery-curation.md` under Phase 2:
+
+```md
+Phase 2 starts as operational checks, not a dashboard. The first useful artifact is a read-only SQL playbook for maintainers. A curator-facing web page should wait until there is an approved aggregate read path for `analytics_events`.
+```
+
+- [ ] **Step 3: Verify docs formatting**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: exit code 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/operations.md docs/discovery-curation.md
+git commit -m "docs: explain recommendation health checks"
+```
+
+### Task 3: Update Backlog Status
+
+**Files:**
+
+- Modify: `docs/backlog.md`
+
+- [ ] **Step 1: Narrow the Recommendation Health backlog item**
+
+Update the `Recommendation Health` section:
+
+```md
+Implementation path:
+
+1. Add read-only aggregate SQL checks for maintainers.
+2. Review a real 7-14 day snapshot after public traffic exists.
+3. Decide whether a curator-only health page is worth the Supabase read-path migration.
+
+Do not tune `get_recommended_review_ids` from vibes alone. Capture a before snapshot first.
+```
+
+- [ ] **Step 2: Verify docs formatting**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: exit code 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/backlog.md
+git commit -m "docs: phase recommendation health work"
+```
+
+## Phase 2B: Curator-Only Health Page, Requires Supabase Approval
+
+Do not start this phase until the maintainer explicitly approves a Supabase migration.
+
+### Task 4: Design the Aggregate Read Path
+
+**Files:**
+
+- Create: `supabase/migrations/<generated>_recommendation_health_rpc.sql`
+
+- [ ] **Step 1: Confirm the desired access model**
+
+Decision to confirm before implementation:
+
+```text
+Only users where public.is_starter_curator() returns true can read aggregate recommendation health.
+No raw user_id values are returned.
+No raw analytics rows are returned.
+All rows are grouped by day, event type, source, reason, entity_id, or starter_track_id.
+```
+
+- [ ] **Step 2: Create the migration with Supabase CLI**
+
+Run:
+
+```bash
+supabase migration new recommendation_health_rpc
+```
+
+Expected: creates a timestamped file under `supabase/migrations`.
+
+- [ ] **Step 3: Add an aggregate RPC**
+
+Use this shape for the migration after reviewing current Supabase docs:
+
+```sql
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.get_recommendation_health_snapshot(
+  p_days integer DEFAULT 14
+)
+RETURNS TABLE (
+  metric text,
+  bucket text,
+  value numeric
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF NOT public.is_starter_curator() THEN
+    RAISE EXCEPTION 'not allowed';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    'feed_loads'::text AS metric,
+    date_trunc('day', created_at)::date::text AS bucket,
+    count(*)::numeric AS value
+  FROM public.analytics_events
+  WHERE created_at >= now() - make_interval(days => greatest(1, least(p_days, 90)))
+    AND event_type = 'feed_loaded'
+  GROUP BY 2
+
+  UNION ALL
+
+  SELECT
+    'recommendation_fallbacks'::text AS metric,
+    date_trunc('day', created_at)::date::text AS bucket,
+    count(*)::numeric AS value
+  FROM public.analytics_events
+  WHERE created_at >= now() - make_interval(days => greatest(1, least(p_days, 90)))
+    AND event_type = 'recommendation_fallback'
+  GROUP BY 2
+
+  UNION ALL
+
+  SELECT
+    'starter_reviews_published'::text AS metric,
+    date_trunc('day', created_at)::date::text AS bucket,
+    count(*)::numeric AS value
+  FROM public.analytics_events
+  WHERE created_at >= now() - make_interval(days => greatest(1, least(p_days, 90)))
+    AND event_type = 'starter_review_published'
+  GROUP BY 2;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.get_recommendation_health_snapshot(integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_recommendation_health_snapshot(integer) TO authenticated;
+
+COMMIT;
+```
+
+- [ ] **Step 4: Run security review before committing**
+
+Run:
+
+```bash
+supabase db advisors
+```
+
+Expected: no new security warnings caused by the migration.
+
+### Task 5: Add the Server Query
+
+**Files:**
+
+- Create: `apps/web/lib/queries/recommendation-health.ts`
+
+- [ ] **Step 1: Add a typed query wrapper**
+
+```ts
+import "server-only";
+
+import { measureServerTask } from "@/lib/perf";
+import { supabaseServer } from "@/lib/supabase/server";
+
+export type RecommendationHealthMetric = {
+  metric: string;
+  bucket: string;
+  value: number;
+};
+
+export async function getRecommendationHealthSnapshot(days = 14) {
+  return measureServerTask(
+    "getRecommendationHealthSnapshot",
+    async (): Promise<RecommendationHealthMetric[]> => {
+      const supabase = await supabaseServer();
+      const safeDays = Math.max(1, Math.min(days, 90));
+      const { data, error } = await supabase.rpc(
+        "get_recommendation_health_snapshot",
+        { p_days: safeDays },
+      );
+
+      if (error) {
+        console.error("[recommendationHealth.getSnapshot] failed", {
+          code: error.code ?? null,
+          message: error.message ?? null,
+        });
+
+        return [];
+      }
+
+      return (data ?? []).map((row) => ({
+        metric: row.metric,
+        bucket: row.bucket,
+        value: Number(row.value),
+      }));
+    },
+    { days },
+  );
+}
+```
+
+- [ ] **Step 2: Verify TypeScript**
+
+Run:
+
+```bash
+pnpm --filter web build
+```
+
+Expected: build passes after `database.types.ts` includes the RPC.
+
+### Task 6: Add a Quiet Studio Health Page
+
+**Files:**
+
+- Create: `apps/web/app/(main)/studio/health/page.tsx`
+- Create: `apps/web/components/recommendation-health-summary.tsx`
+
+- [ ] **Step 1: Add route protection**
+
+Use the same access model as `/studio/starter`:
+
+```tsx
+import { notFound, redirect } from "next/navigation";
+import RecommendationHealthSummary from "@/components/recommendation-health-summary";
+import { getCurrentUser } from "@/lib/auth/server";
+import { createPageMetadata } from "@/lib/metadata";
+import { getStarterCuratorAccess } from "@/lib/queries/curation";
+import { getRecommendationHealthSnapshot } from "@/lib/queries/recommendation-health";
+
+export const metadata = createPageMetadata({
+  title: "Recommendation Health",
+  description: "Internal Kocteau recommendation health checks.",
+  path: "/studio/health",
+  noIndex: true,
+});
+
+export default async function RecommendationHealthPage() {
+  const user = await getCurrentUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  const hasAccess = await getStarterCuratorAccess();
+
+  if (!hasAccess) {
+    notFound();
+  }
+
+  const metrics = await getRecommendationHealthSnapshot(14);
+
+  return <RecommendationHealthSummary metrics={metrics} />;
+}
+```
+
+- [ ] **Step 2: Keep the UI text compact**
+
+```tsx
+import type { RecommendationHealthMetric } from "@/lib/queries/recommendation-health";
+
+type RecommendationHealthSummaryProps = {
+  metrics: RecommendationHealthMetric[];
+};
+
+export default function RecommendationHealthSummary({
+  metrics,
+}: RecommendationHealthSummaryProps) {
+  const latest = metrics.slice(0, 12);
+
+  return (
+    <section className="mx-auto w-full max-w-4xl space-y-5 pb-8">
+      <div className="space-y-1">
+        <p className="text-[12px] font-medium text-muted-foreground/72">
+          Studio
+        </p>
+        <h1 className="font-serif text-2xl font-semibold text-foreground">
+          Recommendation health
+        </h1>
+        <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
+          Aggregate checks for For You and starter picks. No raw user analytics are shown.
+        </p>
+      </div>
+
+      <div className="divide-y divide-border/18 rounded-[var(--kocteau-radius-card)] border border-border/24 bg-card/30">
+        {latest.length > 0 ? (
+          latest.map((metric) => (
+            <div
+              key={`${metric.metric}:${metric.bucket}`}
+              className="grid grid-cols-[minmax(0,1fr)_7rem] gap-3 px-4 py-3 text-sm"
+            >
+              <div className="min-w-0">
+                <p className="truncate font-medium text-foreground">
+                  {metric.metric.replaceAll("_", " ")}
+                </p>
+                <p className="text-xs text-muted-foreground">{metric.bucket}</p>
+              </div>
+              <p className="text-right font-mono text-sm tabular-nums text-foreground">
+                {metric.value.toLocaleString()}
+              </p>
+            </div>
+          ))
+        ) : (
+          <p className="px-4 py-6 text-sm text-muted-foreground">
+            No aggregate health signals yet.
+          </p>
+        )}
+      </div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 3: Verify**
+
+Run:
+
+```bash
+pnpm --filter web lint
+pnpm --filter web build
+git diff --check
+```
+
+Expected: all commands pass.
+
+## Manual Verification
+
+Phase 2A:
+
+- Open `supabase/scripts/maintenance/recommendation-health-checks.sql`.
+- Confirm every query is `SELECT` only.
+- Run the script in Supabase SQL editor against a non-production dataset first.
+- Confirm results show aggregate counts only.
+
+Phase 2B:
+
+- Log in as a curator.
+- Open `/studio/health`.
+- Confirm the page loads aggregate rows.
+- Log in as a non-curator.
+- Confirm `/studio/health` returns not found.
+- Confirm no raw `user_id`, email, IP address, user agent, or raw review body is visible.
+
+## Recommended Branch Flow
+
+Start Phase 2 only after Phase 1 is merged, or branch from `feat/analytics-signal-contract` and rebase after merge.
+
+Suggested branch:
+
+```bash
+git switch main
+git pull --ff-only origin main
+git switch -c feat/recommendation-health
+```
+
+If Phase 1 is not merged yet:
+
+```bash
+git switch feat/analytics-signal-contract
+git switch -c feat/recommendation-health
+```
+
+## Self-Review
+
+- Spec coverage: covers fallback rate, action/open rates, starter usage, entity destinations, and safe aggregate handling. Read-depth metrics are intentionally not included in Phase 2A because `review_read_50` and `review_read_90` are documented but not yet instrumented.
+- Placeholder scan: no open placeholder text is required for execution; the generated migration filename must come from `supabase migration new`.
+- Type consistency: event names match `docs/discovery-curation.md` and the phase 1 analytics contract.

--- a/supabase/migrations/20260601180027_recommendation_health_rpc.sql
+++ b/supabase/migrations/20260601180027_recommendation_health_rpc.sql
@@ -1,0 +1,257 @@
+-- Kocteau recommendation health aggregate RPC.
+-- Apply after analytics signal contract events are deployed.
+-- This function intentionally returns grouped health metrics only.
+
+BEGIN;
+
+DROP FUNCTION IF EXISTS public.get_recommendation_health_snapshot(integer);
+
+CREATE OR REPLACE FUNCTION public.get_recommendation_health_snapshot(
+  p_days integer DEFAULT 14
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_days integer := greatest(1, least(coalesce(p_days, 14), 90));
+  v_start_at timestamptz := now() - make_interval(days => greatest(1, least(coalesce(p_days, 14), 90)));
+  v_end_at timestamptz := now();
+BEGIN
+  IF NOT public.is_starter_curator() THEN
+    RAISE EXCEPTION 'not allowed'
+      USING ERRCODE = '42501';
+  END IF;
+
+  RETURN (
+    WITH events AS (
+      SELECT
+        event_type,
+        source,
+        metadata,
+        created_at
+      FROM public.analytics_events
+      WHERE created_at >= v_start_at
+        AND created_at <= v_end_at
+    ),
+    feed_counts AS (
+      SELECT
+        count(*) FILTER (WHERE event_type = 'feed_loaded') AS loads,
+        count(*) FILTER (WHERE event_type = 'recommendation_fallback') AS fallbacks,
+        count(*) FILTER (WHERE event_type = 'review_impression') AS review_impressions,
+        count(*) FILTER (WHERE event_type = 'review_open') AS review_opens,
+        count(*) FILTER (WHERE event_type = 'entity_open') AS entity_opens
+      FROM events
+    ),
+    feed_daily AS (
+      SELECT
+        date_trunc('day', created_at)::date AS day,
+        count(*) FILTER (WHERE event_type = 'feed_loaded') AS loads,
+        count(*) FILTER (WHERE event_type = 'recommendation_fallback') AS fallbacks,
+        count(*) FILTER (WHERE event_type = 'review_impression') AS review_impressions,
+        count(*) FILTER (WHERE event_type = 'review_open') AS review_opens
+      FROM events
+      WHERE event_type IN (
+        'feed_loaded',
+        'recommendation_fallback',
+        'review_impression',
+        'review_open'
+      )
+      GROUP BY 1
+    ),
+    reason_impressions AS (
+      SELECT
+        metadata->>'review_id' AS review_id,
+        coalesce(metadata->>'reason', 'unknown') AS reason,
+        count(*) AS impressions
+      FROM events
+      WHERE event_type = 'review_impression'
+      GROUP BY 1, 2
+    ),
+    review_opens AS (
+      SELECT
+        metadata->>'review_id' AS review_id,
+        count(*) AS opens
+      FROM events
+      WHERE event_type = 'review_open'
+      GROUP BY 1
+    ),
+    reason_health AS (
+      SELECT
+        reason_impressions.reason,
+        sum(reason_impressions.impressions) AS impressions,
+        coalesce(sum(review_opens.opens), 0) AS opens
+      FROM reason_impressions
+      LEFT JOIN review_opens
+        ON review_opens.review_id = reason_impressions.review_id
+      GROUP BY 1
+    ),
+    starter_counts AS (
+      SELECT
+        count(*) FILTER (WHERE event_type = 'starter_impression') AS impressions,
+        count(*) FILTER (WHERE event_type = 'starter_pass') AS passes,
+        count(*) FILTER (WHERE event_type = 'starter_review_cta') AS review_ctas,
+        count(*) FILTER (WHERE event_type = 'starter_review_published') AS reviews_published
+      FROM events
+      WHERE event_type IN (
+        'starter_impression',
+        'starter_pass',
+        'starter_review_cta',
+        'starter_review_published'
+      )
+    ),
+    starter_track_health AS (
+      SELECT
+        metadata->>'starter_track_id' AS starter_track_id,
+        max(metadata->>'provider_id') AS provider_id,
+        count(*) FILTER (WHERE event_type = 'starter_impression') AS impressions,
+        count(*) FILTER (WHERE event_type = 'starter_pass') AS passes,
+        count(*) FILTER (WHERE event_type = 'starter_review_cta') AS review_ctas,
+        count(*) FILTER (WHERE event_type = 'starter_review_published') AS reviews_published
+      FROM events
+      WHERE event_type LIKE 'starter_%'
+        AND metadata ? 'starter_track_id'
+      GROUP BY 1
+    ),
+    entity_health AS (
+      SELECT
+        metadata->>'entity_id' AS entity_id,
+        max(metadata->>'provider') AS provider,
+        max(metadata->>'provider_id') AS provider_id,
+        max(metadata->>'type') AS type,
+        count(*) AS opens
+      FROM events
+      WHERE event_type = 'entity_open'
+        AND metadata ? 'entity_id'
+      GROUP BY 1
+    ),
+    tag_coverage AS (
+      SELECT
+        preference_tags.kind::text AS kind,
+        count(DISTINCT starter_track_tags.starter_track_id) AS tagged_tracks,
+        count(DISTINCT starter_track_tags.tag_id) AS tag_count
+      FROM public.starter_track_tags AS starter_track_tags
+      JOIN public.preference_tags AS preference_tags
+        ON preference_tags.id = starter_track_tags.tag_id
+      JOIN public.starter_tracks AS starter_tracks
+        ON starter_tracks.id = starter_track_tags.starter_track_id
+      WHERE starter_tracks.is_active = true
+      GROUP BY 1
+    )
+    SELECT jsonb_build_object(
+      'window', jsonb_build_object(
+        'days', v_days,
+        'startAt', v_start_at,
+        'endAt', v_end_at
+      ),
+      'feed', (
+        SELECT jsonb_build_object(
+          'loads', loads,
+          'fallbacks', fallbacks,
+          'fallbackRate', coalesce(round(fallbacks::numeric / nullif(loads, 0), 4), 0),
+          'reviewImpressions', review_impressions,
+          'reviewOpens', review_opens,
+          'reviewOpenRate', coalesce(round(review_opens::numeric / nullif(review_impressions, 0), 4), 0),
+          'entityOpens', entity_opens
+        )
+        FROM feed_counts
+      ),
+      'feedDaily', coalesce((
+        SELECT jsonb_agg(
+          jsonb_build_object(
+            'day', day,
+            'loads', loads,
+            'fallbacks', fallbacks,
+            'fallbackRate', coalesce(round(fallbacks::numeric / nullif(loads, 0), 4), 0),
+            'reviewImpressions', review_impressions,
+            'reviewOpens', review_opens,
+            'reviewOpenRate', coalesce(round(review_opens::numeric / nullif(review_impressions, 0), 4), 0)
+          )
+          ORDER BY day DESC
+        )
+        FROM feed_daily
+      ), '[]'::jsonb),
+      'reasons', coalesce((
+        SELECT jsonb_agg(
+          jsonb_build_object(
+            'reason', reason,
+            'impressions', impressions,
+            'opens', opens,
+            'openRate', coalesce(round(opens::numeric / nullif(impressions, 0), 4), 0)
+          )
+          ORDER BY impressions DESC, reason ASC
+        )
+        FROM reason_health
+      ), '[]'::jsonb),
+      'starter', (
+        SELECT jsonb_build_object(
+          'impressions', impressions,
+          'passes', passes,
+          'passRate', coalesce(round(passes::numeric / nullif(impressions, 0), 4), 0),
+          'reviewCtas', review_ctas,
+          'reviewsPublished', reviews_published,
+          'reviewConversionRate', coalesce(round(reviews_published::numeric / nullif(impressions, 0), 4), 0)
+        )
+        FROM starter_counts
+      ),
+      'starterTracks', coalesce((
+        SELECT jsonb_agg(
+          jsonb_build_object(
+            'starterTrackId', starter_track_health.starter_track_id,
+            'providerId', starter_track_health.provider_id,
+            'title', starter_tracks.title,
+            'artistName', starter_tracks.artist_name,
+            'impressions', starter_track_health.impressions,
+            'passes', starter_track_health.passes,
+            'passRate', coalesce(round(starter_track_health.passes::numeric / nullif(starter_track_health.impressions, 0), 4), 0),
+            'reviewCtas', starter_track_health.review_ctas,
+            'reviewsPublished', starter_track_health.reviews_published,
+            'reviewConversionRate', coalesce(round(starter_track_health.reviews_published::numeric / nullif(starter_track_health.impressions, 0), 4), 0)
+          )
+          ORDER BY starter_track_health.impressions DESC, starter_track_health.passes DESC
+        )
+        FROM starter_track_health
+        LEFT JOIN public.starter_tracks AS starter_tracks
+          ON starter_tracks.id::text = starter_track_health.starter_track_id
+      ), '[]'::jsonb),
+      'tagCoverage', coalesce((
+        SELECT jsonb_agg(
+          jsonb_build_object(
+            'kind', kind,
+            'taggedTracks', tagged_tracks,
+            'tagCount', tag_count
+          )
+          ORDER BY tagged_tracks DESC, kind ASC
+        )
+        FROM tag_coverage
+      ), '[]'::jsonb),
+      'entities', coalesce((
+        SELECT jsonb_agg(
+          jsonb_build_object(
+            'entityId', entity_health.entity_id,
+            'provider', coalesce(entities.provider, entity_health.provider),
+            'providerId', coalesce(entities.provider_id, entity_health.provider_id),
+            'type', coalesce(entities.type::text, entity_health.type),
+            'title', entities.title,
+            'artistName', entities.artist_name,
+            'opens', entity_health.opens
+          )
+          ORDER BY entity_health.opens DESC
+        )
+        FROM entity_health
+        LEFT JOIN public.entities AS entities
+          ON entities.id::text = entity_health.entity_id
+      ), '[]'::jsonb)
+    )
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.get_recommendation_health_snapshot(integer)
+  FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_recommendation_health_snapshot(integer)
+  TO authenticated;
+
+COMMIT;

--- a/supabase/scripts/maintenance/recommendation-health-checks.sql
+++ b/supabase/scripts/maintenance/recommendation-health-checks.sql
@@ -1,0 +1,129 @@
+-- Kocteau recommendation health checks.
+-- Read-only aggregate queries for maintainers.
+-- Run in the Supabase SQL editor. Do not expose raw rows publicly.
+
+-- 1. Daily For You feed load and fallback health.
+SELECT
+  date_trunc('day', created_at) AS day,
+  count(*) FILTER (WHERE event_type = 'feed_loaded') AS feed_loads,
+  count(*) FILTER (WHERE event_type = 'recommendation_fallback') AS fallbacks,
+  round(
+    count(*) FILTER (WHERE event_type = 'recommendation_fallback')::numeric
+    / nullif(count(*) FILTER (WHERE event_type = 'feed_loaded'), 0),
+    4
+  ) AS fallback_rate
+FROM public.analytics_events
+WHERE created_at >= now() - interval '14 days'
+  AND event_type IN ('feed_loaded', 'recommendation_fallback')
+GROUP BY 1
+ORDER BY 1 DESC;
+
+-- 2. Surfaced recommendation reasons.
+SELECT
+  coalesce(metadata->>'reason', 'unknown') AS reason,
+  count(*) AS impressions,
+  min(created_at) AS first_seen_at,
+  max(created_at) AS last_seen_at
+FROM public.analytics_events
+WHERE created_at >= now() - interval '14 days'
+  AND event_type = 'review_impression'
+GROUP BY 1
+ORDER BY impressions DESC;
+
+-- 3. Review open rate by recommendation reason.
+WITH impressions AS (
+  SELECT
+    metadata->>'review_id' AS review_id,
+    coalesce(metadata->>'reason', 'unknown') AS reason,
+    count(*) AS impression_count
+  FROM public.analytics_events
+  WHERE created_at >= now() - interval '14 days'
+    AND event_type = 'review_impression'
+  GROUP BY 1, 2
+),
+opens AS (
+  SELECT
+    metadata->>'review_id' AS review_id,
+    count(*) AS open_count
+  FROM public.analytics_events
+  WHERE created_at >= now() - interval '14 days'
+    AND event_type = 'review_open'
+  GROUP BY 1
+)
+SELECT
+  impressions.reason,
+  sum(impressions.impression_count) AS impressions,
+  coalesce(sum(opens.open_count), 0) AS opens,
+  round(
+    coalesce(sum(opens.open_count), 0)::numeric
+    / nullif(sum(impressions.impression_count), 0),
+    4
+  ) AS open_rate
+FROM impressions
+LEFT JOIN opens ON opens.review_id = impressions.review_id
+GROUP BY 1
+ORDER BY impressions DESC;
+
+-- 4. Starter pick funnel.
+SELECT
+  date_trunc('day', created_at) AS day,
+  count(*) FILTER (WHERE event_type = 'starter_impression') AS impressions,
+  count(*) FILTER (WHERE event_type = 'starter_pass') AS passes,
+  count(*) FILTER (WHERE event_type = 'starter_review_cta') AS review_ctas,
+  count(*) FILTER (WHERE event_type = 'starter_review_published') AS reviews_published,
+  round(
+    count(*) FILTER (WHERE event_type = 'starter_review_published')::numeric
+    / nullif(count(*) FILTER (WHERE event_type = 'starter_impression'), 0),
+    4
+  ) AS review_conversion_rate
+FROM public.analytics_events
+WHERE created_at >= now() - interval '14 days'
+  AND event_type IN (
+    'starter_impression',
+    'starter_pass',
+    'starter_review_cta',
+    'starter_review_published'
+  )
+GROUP BY 1
+ORDER BY 1 DESC;
+
+-- 5. Starter pick quality by track.
+SELECT
+  metadata->>'starter_track_id' AS starter_track_id,
+  max(metadata->>'provider_id') AS provider_id,
+  count(*) FILTER (WHERE event_type = 'starter_impression') AS impressions,
+  count(*) FILTER (WHERE event_type = 'starter_pass') AS passes,
+  count(*) FILTER (WHERE event_type = 'starter_review_cta') AS review_ctas,
+  count(*) FILTER (WHERE event_type = 'starter_review_published') AS reviews_published
+FROM public.analytics_events
+WHERE created_at >= now() - interval '14 days'
+  AND event_type LIKE 'starter_%'
+GROUP BY 1
+ORDER BY impressions DESC NULLS LAST;
+
+-- 6. Entity destination health.
+SELECT
+  metadata->>'entity_id' AS entity_id,
+  max(metadata->>'provider') AS provider,
+  max(metadata->>'provider_id') AS provider_id,
+  max(metadata->>'type') AS type,
+  count(*) AS opens
+FROM public.analytics_events
+WHERE created_at >= now() - interval '14 days'
+  AND event_type = 'entity_open'
+GROUP BY 1
+ORDER BY opens DESC;
+
+-- 7. Starter tag coverage by tag kind.
+SELECT
+  preference_tags.kind,
+  count(DISTINCT starter_track_tags.starter_track_id) AS tagged_tracks,
+  count(DISTINCT starter_track_tags.tag_id) AS tag_count
+FROM public.starter_track_tags
+JOIN public.preference_tags
+  ON preference_tags.id = starter_track_tags.tag_id
+JOIN public.starter_tracks
+  ON starter_tracks.id = starter_track_tags.starter_track_id
+WHERE starter_tracks.is_active = true
+GROUP BY 1
+ORDER BY tagged_tracks DESC, preference_tags.kind ASC;


### PR DESCRIPTION
## What changed

- Added `/studio/health`, a curator-only recommendation health surface.
- Added a Studio sidebar group with `Starter` and `Health`, visible only to curator/admin users.
- Added `get_recommendation_health_snapshot(p_days)` as a Supabase aggregate RPC for safe analytics reads.
- Added read-only SQL maintenance checks for recommendation health.
- Added typed normalization/tests for recommendation health payloads.
- Updated operations, discovery, backlog, and implementation plan docs.

## Why

This gives Kocteau an internal way to inspect For You and starter-pick health before tuning ranking logic. It keeps analytics aggregated and curator-gated instead of exposing raw `analytics_events` rows.

## Testing

- [ ] Ran `pnpm check`
- [ ] Added screenshots or a short recording for visible web UI changes
- [ ] Confirmed this does not touch auth, Supabase, recommendations, analytics, CI, or release behavior

Targeted verification run:

- `node --test apps/web/lib/recommendation-health/metrics.test.ts`
- focused ESLint on touched web files
- `pnpm --dir apps/web build`
- `pnpm --filter web lint`
- `git diff --check`
- Manual `/studio/health` check after applying SQL

Notes:

- This intentionally touches Supabase, recommendations, analytics, and internal Studio UI.
- Supabase SQL was applied manually in the Supabase SQL Editor.
- No raw analytics rows are exposed to the web app; the route reads aggregate RPC output only.
- `pnpm --filter web lint` still prints the existing `jsx-ast-utils` AwaitExpression warning, but exits 0.

## Changelog impact

No manual `CHANGELOG.md` edit is required. Release Please generates release notes from PR titles and squash commits.

- [ ] User-facing web change
- [x] Developer experience or documentation change
- [x] Internal-only change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a Studio section to the sidebar for starter curators with access to recommendation health monitoring.
  * Added a new Recommendation Health page displaying key performance metrics including fallback rates, review patterns, starter pick performance, and tag coverage across configurable time periods (7, 14, 30, or 90 days).

* **Documentation**
  * Added operational guidance for recommendation health monitoring and interpretation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->