### PR TITLE
feat(web): contextualize starter rail picks

### DIFF
--- a/apps/web/app/(main)/layout.tsx
+++ b/apps/web/app/(main)/layout.tsx
@@ -8,7 +8,6 @@ import { RouteHeaderProvider } from "@/components/route-header-context";
 import WhoToFollowRail from "@/components/who-to-follow-rail";
 import { getCurrentOnboardingState, getCurrentUser, getCurrentViewerProfile } from "@/lib/auth/server";
 import { getStarterCuratorAccess } from "@/lib/queries/curation";
-import { getStarterTracks } from "@/lib/queries/starter";
 import type { SidebarOwnedReview } from "@/lib/types/sidebar";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 
@@ -29,10 +28,7 @@ export default async function MainLayout({ children }: { children: React.ReactNo
     redirect("/onboarding/taste");
   }
 
-  const [starterTracks, canAccessStudio] = await Promise.all([
-    getStarterTracks({ viewerId: user?.id, limit: 6 }),
-    user ? getStarterCuratorAccess() : Promise.resolve(false),
-  ]);
+  const canAccessStudio = user ? await getStarterCuratorAccess() : false;
 
   return (
     <ReactQueryProvider>
@@ -62,10 +58,7 @@ export default async function MainLayout({ children }: { children: React.ReactNo
                   <main className="no-scrollbar min-w-0 lg:min-h-0 lg:overflow-x-hidden lg:overflow-y-auto lg:pr-1">
                     {children}
                   </main>
-                  <WhoToFollowRail
-                    isAuthenticated={Boolean(safeProfile)}
-                    starterTracks={starterTracks}
-                  />
+                  <WhoToFollowRail isAuthenticated={Boolean(safeProfile)} />
                 </div>
               </div>
             </div>

--- a/apps/web/app/(main)/page.tsx
+++ b/apps/web/app/(main)/page.tsx
@@ -10,7 +10,7 @@ import {
   getFeedPage,
   getFeedViewerState,
 } from "@/lib/queries/feed";
-import { getStarterTracks } from "@/lib/queries/starter";
+import { getStarterTracksForSurface } from "@/lib/queries/starter";
 import { createServerQueryClient } from "@/lib/react-query/server";
 import { buildFeedPageJsonLd } from "@/lib/structured-data";
 import { feedKeys, type FeedInfiniteQueryData } from "@/queries/feed";
@@ -42,7 +42,12 @@ export default async function HomePage({
       includeActiveUsers: false,
     }),
     activeView === "for-you" && user?.id
-      ? getStarterTracks({ viewerId: user.id, limit: 6 })
+      ? getStarterTracksForSurface({
+          viewerId: user.id,
+          limit: 6,
+          surface: "home",
+          contextKey: "home",
+        })
       : Promise.resolve([]),
   ]);
   const viewerStatePromise =

--- a/apps/web/app/api/starter/rail/route.ts
+++ b/apps/web/app/api/starter/rail/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from "next/server";
+import { getCurrentUser } from "@/lib/auth/server";
+import { getStarterTracksForSurface } from "@/lib/queries/starter";
+import {
+  getStarterContextKey,
+  isStarterSurface,
+  type StarterSurface,
+} from "@/lib/starter/surface";
+
+function getRailLimit(req: Request) {
+  const url = new URL(req.url);
+  const parsedLimit = Number(url.searchParams.get("limit") ?? 6);
+
+  if (!Number.isFinite(parsedLimit)) {
+    return 6;
+  }
+
+  return Math.max(1, Math.min(Math.trunc(parsedLimit), 8));
+}
+
+function getRailSurface(req: Request): StarterSurface {
+  const url = new URL(req.url);
+  const surface = url.searchParams.get("surface");
+
+  return isStarterSurface(surface) ? surface : "app";
+}
+
+function getRailContextKey(req: Request, surface: StarterSurface) {
+  const url = new URL(req.url);
+  const explicitContext = url.searchParams.get("context")?.trim();
+
+  if (explicitContext) {
+    return explicitContext.slice(0, 120);
+  }
+
+  return surface === "app" ? getStarterContextKey(null) : surface;
+}
+
+export async function GET(req: Request) {
+  const user = await getCurrentUser();
+
+  if (!user) {
+    return NextResponse.json({ tracks: [] });
+  }
+
+  const surface = getRailSurface(req);
+  const tracks = await getStarterTracksForSurface({
+    viewerId: user.id,
+    limit: getRailLimit(req),
+    surface,
+    contextKey: getRailContextKey(req, surface),
+  });
+
+  return NextResponse.json({ tracks });
+}

--- a/apps/web/components/who-to-follow-rail.tsx
+++ b/apps/web/components/who-to-follow-rail.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { usePathname } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
 import FollowProfileButton from "@/components/follow-profile-button";
 import { WhoToFollowRailSkeleton } from "@/components/feed-loading-skeletons";
@@ -8,14 +9,20 @@ import NewReviewDialog from "@/components/new-review-dialog";
 import PrefetchLink from "@/components/prefetch-link";
 import TrackCarousel from "@/components/track-carousel";
 import TrackTile from "@/components/track-tile";
+import { Skeleton } from "@/components/ui/skeleton";
 import UserAvatar from "@/components/user-avatar";
 import { helpFooterLinks } from "@/lib/help";
 import type { StarterTrack } from "@/lib/starter";
+import { getStarterRailQueryPath } from "@/lib/starter/surface";
+import { fetchJson } from "@/queries/http";
 import { activeProfilesQueryOptions } from "@/queries/profiles";
 
 type WhoToFollowRailProps = {
   isAuthenticated: boolean;
-  starterTracks?: StarterTrack[];
+};
+
+type StarterRailResponse = {
+  tracks: StarterTrack[];
 };
 
 function useDesktopRail() {
@@ -77,17 +84,44 @@ function StarterPickReviewTrigger({
   );
 }
 
-export default function WhoToFollowRail({
-  isAuthenticated,
-  starterTracks = [],
-}: WhoToFollowRailProps) {
+function StarterRailSkeleton() {
+  return (
+    <div className="flex gap-3 overflow-hidden" aria-hidden="true">
+      {Array.from({ length: 3 }).map((_, index) => (
+        <div key={`starter-rail-skeleton-${index}`} className="w-[6.35rem] shrink-0 space-y-2">
+          <Skeleton className="aspect-square w-full rounded-[0.58rem] bg-muted-foreground/[0.1]" />
+          <div className="space-y-1.5">
+            <Skeleton className="h-3 w-[88%] rounded-full bg-muted-foreground/[0.12]" />
+            <Skeleton className="h-2.5 w-[64%] rounded-full bg-muted-foreground/[0.08]" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function WhoToFollowRail({ isAuthenticated }: WhoToFollowRailProps) {
   const isDesktop = useDesktopRail();
+  const pathname = usePathname();
+  const starterRailQueryPath = useMemo(
+    () => getStarterRailQueryPath(pathname),
+    [pathname],
+  );
   const { data, isLoading } = useQuery({
     ...activeProfilesQueryOptions(3),
     enabled: isDesktop,
   });
+  const { data: starterRail, isLoading: isStarterRailLoading } = useQuery({
+    queryKey: ["starter", "rail", starterRailQueryPath],
+    queryFn: () => fetchJson<StarterRailResponse>(starterRailQueryPath),
+    enabled: isDesktop && isAuthenticated,
+    staleTime: 5 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
+  });
   const profiles = data?.profiles ?? [];
-  const visibleStarterTracks = starterTracks.slice(0, 6);
+  const visibleStarterTracks = (starterRail?.tracks ?? []).slice(0, 6);
+  const showStarterRail =
+    isAuthenticated && (isStarterRailLoading || visibleStarterTracks.length > 0);
 
   return (
     <aside
@@ -159,27 +193,31 @@ export default function WhoToFollowRail({
           )}
         </section>
 
-        {visibleStarterTracks.length > 0 ? (
+        {showStarterRail ? (
           <section className="mt-6 min-h-[12.25rem] space-y-3" aria-label="Starter picks">
             <p className="px-1 text-[12px] font-medium leading-none text-muted-foreground/70">
               Starter picks
             </p>
-            <TrackCarousel
-              ariaLabel="Starter picks"
-              compactControls
-              contentClassName="gap-3"
-              controlClassName="[--kocteau-carousel-cover-size:6.35rem]"
-              fadeClassName="kocteau-carousel-mask-r-from-tight"
-              itemClassName="basis-[6.35rem]"
-            >
-              {visibleStarterTracks.map((track) => (
-                <StarterPickReviewTrigger
-                  key={track.id}
-                  track={track}
-                  isAuthenticated={isAuthenticated}
-                />
-              ))}
-            </TrackCarousel>
+            {isStarterRailLoading ? (
+              <StarterRailSkeleton />
+            ) : (
+              <TrackCarousel
+                ariaLabel="Starter picks"
+                compactControls
+                contentClassName="gap-3"
+                controlClassName="[--kocteau-carousel-cover-size:6.35rem]"
+                fadeClassName="kocteau-carousel-mask-r-from-tight"
+                itemClassName="basis-[6.35rem]"
+              >
+                {visibleStarterTracks.map((track) => (
+                  <StarterPickReviewTrigger
+                    key={track.id}
+                    track={track}
+                    isAuthenticated={isAuthenticated}
+                  />
+                ))}
+              </TrackCarousel>
+            )}
           </section>
         ) : null}
 

--- a/apps/web/lib/queries/starter.ts
+++ b/apps/web/lib/queries/starter.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import { measureServerTask } from "@/lib/perf";
+import type { StarterSurface } from "@/lib/starter/surface";
 import { supabaseServer } from "@/lib/supabase/server";
 import type { StarterTrack } from "@/lib/starter";
 
@@ -21,6 +22,14 @@ function getStarterTrackKey(track: {
   type: string;
 }) {
   return `${track.provider}:${track.type}:${track.provider_id}`;
+}
+
+function isMissingSurfaceRpc(error: { code?: string | null; message?: string | null }) {
+  return (
+    error.code === "PGRST202" ||
+    error.code === "42883" ||
+    Boolean(error.message?.includes("get_starter_tracks_for_surface"))
+  );
 }
 
 export async function getStarterTracks({
@@ -114,6 +123,61 @@ export async function getStarterTracks({
     {
       viewerId,
       limit,
+    },
+  );
+}
+
+export async function getStarterTracksForSurface({
+  viewerId,
+  limit = 6,
+  surface = "home",
+  contextKey,
+  excludeProviderIds = [],
+}: {
+  viewerId: string | null | undefined;
+  limit?: number;
+  surface?: StarterSurface;
+  contextKey?: string | null;
+  excludeProviderIds?: string[];
+}): Promise<StarterTrack[]> {
+  return measureServerTask(
+    "getStarterTracksForSurface",
+    async () => {
+      if (!viewerId) {
+        return [];
+      }
+
+      const supabase = await supabaseServer();
+      const requestedLimit = Math.max(1, Math.min(limit, 12));
+      const { data, error } = await supabase.rpc("get_starter_tracks_for_surface", {
+        p_limit: requestedLimit,
+        p_surface: surface,
+        p_context_key: contextKey ?? surface,
+        p_exclude_provider_ids: excludeProviderIds,
+      });
+
+      if (error) {
+        console.error("[starter.getStarterTracksForSurface] failed", {
+          code: error.code ?? null,
+          message: error.message ?? null,
+          surface,
+          contextKey,
+        });
+
+        if (isMissingSurfaceRpc(error)) {
+          return getStarterTracks({ viewerId, limit: requestedLimit });
+        }
+
+        return [];
+      }
+
+      return ((data ?? []) as StarterTrack[]).slice(0, requestedLimit);
+    },
+    {
+      viewerId,
+      limit,
+      surface,
+      contextKey,
     },
   );
 }

--- a/apps/web/lib/starter/surface.test.ts
+++ b/apps/web/lib/starter/surface.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  getStarterContextKey,
+  getStarterRailQueryPath,
+  getStarterSurfaceFromPathname,
+  isStarterSurface,
+} from "./surface.ts";
+
+describe("starter rail surface helpers", () => {
+  it("maps primary app routes to editorial starter surfaces", () => {
+    assert.equal(getStarterSurfaceFromPathname("/"), "home");
+    assert.equal(getStarterSurfaceFromPathname("/track/3135556"), "track");
+    assert.equal(getStarterSurfaceFromPathname("/u/kocteau"), "profile");
+    assert.equal(getStarterSurfaceFromPathname("/reviews/review-1"), "review");
+    assert.equal(getStarterSurfaceFromPathname("/search"), "search");
+    assert.equal(getStarterSurfaceFromPathname("/saved"), "saved");
+    assert.equal(getStarterSurfaceFromPathname("/studio/health"), "studio");
+    assert.equal(getStarterSurfaceFromPathname("/notifications"), "notifications");
+    assert.equal(getStarterSurfaceFromPathname("/activity"), "activity");
+    assert.equal(getStarterSurfaceFromPathname("/unknown/place"), "app");
+  });
+
+  it("builds stable context keys from the route shape", () => {
+    assert.equal(getStarterContextKey("/"), "home");
+    assert.equal(getStarterContextKey("/track/3135556"), "track:3135556");
+    assert.equal(getStarterContextKey("/u/kocteau"), "profile:kocteau");
+    assert.equal(getStarterContextKey("/reviews/review-1"), "review:review-1");
+    assert.equal(getStarterContextKey("/studio/health"), "studio:health");
+    assert.equal(getStarterContextKey(null), "app");
+  });
+
+  it("validates API surface values", () => {
+    assert.equal(isStarterSurface("profile"), true);
+    assert.equal(isStarterSurface("starter-picks"), false);
+    assert.equal(isStarterSurface(null), false);
+  });
+
+  it("creates the client API path for the active rail", () => {
+    assert.equal(
+      getStarterRailQueryPath("/u/kocteau"),
+      "/api/starter/rail?surface=profile&context=profile%3Akocteau",
+    );
+  });
+});

--- a/apps/web/lib/starter/surface.ts
+++ b/apps/web/lib/starter/surface.ts
@@ -1,0 +1,120 @@
+const starterSurfaces = [
+  "home",
+  "track",
+  "profile",
+  "review",
+  "search",
+  "saved",
+  "studio",
+  "notifications",
+  "activity",
+  "app",
+] as const;
+
+const starterSurfaceSet = new Set<string>(starterSurfaces);
+
+export type StarterSurface = (typeof starterSurfaces)[number];
+
+export function isStarterSurface(value: unknown): value is StarterSurface {
+  return typeof value === "string" && starterSurfaceSet.has(value);
+}
+
+function safeDecode(value: string) {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function normalizeSegment(value: string | null | undefined) {
+  const normalized = safeDecode(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64);
+
+  return normalized || null;
+}
+
+function getRouteSegments(pathname: string | null | undefined) {
+  const rawPathname = typeof pathname === "string" ? pathname : "";
+  const [pathWithoutHash] = rawPathname.split("#");
+  const [pathOnly] = (pathWithoutHash ?? "").split("?");
+
+  return pathOnly
+    .split("/")
+    .map(normalizeSegment)
+    .filter((segment): segment is string => Boolean(segment));
+}
+
+export function getStarterSurfaceFromPathname(
+  pathname: string | null | undefined,
+): StarterSurface {
+  if (typeof pathname !== "string") {
+    return "app";
+  }
+
+  const [section] = getRouteSegments(pathname);
+
+  if (!section) {
+    return "home";
+  }
+
+  if (section === "u") {
+    return "profile";
+  }
+
+  if (section === "review" || section === "reviews") {
+    return "review";
+  }
+
+  if (isStarterSurface(section)) {
+    return section;
+  }
+
+  return "app";
+}
+
+export function getStarterContextKey(pathname: string | null | undefined) {
+  if (typeof pathname !== "string") {
+    return "app";
+  }
+
+  const segments = getRouteSegments(pathname);
+  const [section, detail] = segments;
+
+  if (!section) {
+    return "home";
+  }
+
+  if (section === "u") {
+    return detail ? `profile:${detail}` : "profile";
+  }
+
+  if (section === "track") {
+    return detail ? `track:${detail}` : "track";
+  }
+
+  if (section === "review" || section === "reviews") {
+    return detail ? `review:${detail}` : "review";
+  }
+
+  if (section === "studio") {
+    return detail ? `studio:${detail}` : "studio";
+  }
+
+  const surface = getStarterSurfaceFromPathname(pathname);
+
+  return surface === "app" ? "app" : surface;
+}
+
+export function getStarterRailQueryPath(pathname: string | null | undefined) {
+  const params = new URLSearchParams({
+    surface: getStarterSurfaceFromPathname(pathname),
+    context: getStarterContextKey(pathname),
+  });
+
+  return `/api/starter/rail?${params.toString()}`;
+}

--- a/apps/web/lib/supabase/database.types.ts
+++ b/apps/web/lib/supabase/database.types.ts
@@ -1019,6 +1019,30 @@ export type Database = {
           type: Database["public"]["Enums"]["entity_type"]
         }[]
       }
+      get_starter_tracks_for_surface: {
+        Args: {
+          p_context_key?: string
+          p_exclude_provider_ids?: string[]
+          p_limit?: number
+          p_surface?: string
+        }
+        Returns: {
+          artist_name: string
+          collection_slug: string
+          collection_title: string
+          cover_url: string
+          deezer_url: string
+          editorial_note: string
+          id: string
+          matched_tag_count: number
+          prompt: string
+          provider: string
+          provider_id: string
+          score: number
+          title: string
+          type: Database["public"]["Enums"]["entity_type"]
+        }[]
+      }
       get_viewer_review_collection_state: {
         Args: { p_review_ids: string[] }
         Returns: {

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -312,6 +312,23 @@ Acceptance criteria:
 - Starter tags remain compatible with recommendation RPCs.
 - The UI remains quiet, editorial, and focused on the starter layer.
 
+### Starter Rail Diversity Follow-Up
+
+Suggested issue: `feat(web): evaluate contextual starter rail diversity`
+
+- Review the contextual starter rail across home, profile, track, saved, and Studio surfaces after `get_starter_tracks_for_surface()` is live.
+- Compare SQL editor checks, production logs, and screenshots from desktop/narrow viewports.
+- Tune only the surface/context weighting, skeleton timing, or copy if the rail still feels repetitive.
+- Avoid adding heavy recommendation logic or fake activity.
+
+Suggested labels: `feature`, `area:web`, `area:recommendations`, `needs maintainer decision`
+
+Acceptance criteria:
+
+- Maintainers can tell whether the rail varies by surface without harming editorial quality.
+- Any ranking tweak has a before/after note with the affected surfaces.
+- The rail remains client-loaded and does not block the main layout render.
+
 ### Editorial Candidate Queue
 
 Suggested issue: `feat(web): design editorial candidate queue for starter picks`

--- a/docs/discovery-curation.md
+++ b/docs/discovery-curation.md
@@ -172,12 +172,17 @@ Useful checks:
 - tag coverage across starter picks
 - reviews with high read depth but low engagement
 
-### Phase 3: Starter Studio V2
+### Phase 3: Starter Studio V2 And Contextual Starter Rails
 
 Improve `/studio/starter` as a quiet editorial tool for the official curator.
 
+Phase 3A starts with the secondary starter rail: starter picks should not feel identical on every screen, and they should not block the main layout render. The rail can use a lightweight surface/context contract, such as `home`, `profile:{username}`, `track:{id}`, `review:{id}`, or `studio:health`, to request a stable daily editorial rotation from `get_starter_tracks_for_surface()`.
+
 Priorities:
 
+- contextual starter pick rotation by route surface
+- client-loaded rail picks through `/api/starter/rail`
+- reviewed-track filtering inside the starter RPC
 - faster tag assignment
 - clearer pick status
 - warnings for picks without signals

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -153,7 +153,23 @@ select *
 from public.get_starter_tracks(6);
 ```
 
+Useful contextual starter rail check:
+
+```sql
+select *
+from public.get_starter_tracks_for_surface(
+  6,
+  'profile',
+  'profile:kocteau',
+  '{}'::text[]
+);
+```
+
 Seed at least 8-12 active `starter_tracks` before inviting first users, and tag them with `starter_track_tags` so onboarding preferences can rank them.
+
+Apply `supabase/migrations/20260601195115_starter_tracks_for_surface.sql` before deploying the contextual starter rail. The rail calls `/api/starter/rail` from the client so the main app layout does not wait on starter pick ranking for every route. The route uses the current pathname as a surface/context pair, such as `home`, `profile:kocteau`, `track:{id}`, or `studio:health`, then asks the RPC for a stable daily rotation.
+
+Use `supabase/scripts/maintenance/starter-rail-surface-check.sql` to compare several surfaces from the SQL editor. Direct SQL editor calls may not have `auth.uid()`, so validate viewer-specific taste ranking and reviewed-track filtering from the app after logging in.
 
 The easiest way to seed starter picks is the internal route:
 

--- a/supabase/migrations/20260601195115_starter_tracks_for_surface.sql
+++ b/supabase/migrations/20260601195115_starter_tracks_for_surface.sql
@@ -1,0 +1,207 @@
+-- Context-aware starter picks for editorial rails and sparse For You states.
+--
+-- Run from the Supabase SQL editor after
+-- 20260531160852_editorial_starter_layer.sql.
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '90s';
+
+DROP FUNCTION IF EXISTS public.get_starter_tracks_for_surface(
+  integer,
+  text,
+  text,
+  text[]
+);
+
+CREATE OR REPLACE FUNCTION public.get_starter_tracks_for_surface(
+  p_limit integer DEFAULT 6,
+  p_surface text DEFAULT 'home',
+  p_context_key text DEFAULT NULL,
+  p_exclude_provider_ids text[] DEFAULT '{}'::text[]
+)
+RETURNS TABLE (
+  id uuid,
+  provider text,
+  provider_id text,
+  type public.entity_type,
+  title text,
+  artist_name text,
+  cover_url text,
+  deezer_url text,
+  prompt text,
+  editorial_note text,
+  collection_slug text,
+  collection_title text,
+  matched_tag_count integer,
+  score numeric
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+WITH bounded AS (
+  SELECT
+    greatest(1, least(coalesce(p_limit, 6), 12)) AS page_limit,
+    left(coalesce(nullif(btrim(lower(p_surface)), ''), 'home'), 48) AS surface,
+    left(coalesce(nullif(btrim(lower(p_context_key)), ''), 'global'), 120) AS context_key,
+    coalesce(p_exclude_provider_ids, '{}'::text[]) AS excluded_provider_ids,
+    auth.uid() AS viewer_id
+),
+viewer_tags AS (
+  SELECT
+    upt.tag_id,
+    greatest(upt.weight, 0.1) AS preference_weight
+  FROM public.user_preference_tags upt
+  CROSS JOIN bounded
+  WHERE bounded.viewer_id IS NOT NULL
+    AND upt.user_id = bounded.viewer_id
+),
+ranked AS (
+  SELECT
+    st.id,
+    st.provider,
+    st.provider_id,
+    st.type,
+    st.title,
+    st.artist_name,
+    st.cover_url,
+    st.deezer_url,
+    st.prompt,
+    st.editorial_note,
+    (
+      array_agg(ec.slug ORDER BY ec.sort_order, eci.position)
+        FILTER (WHERE ec.id IS NOT NULL)
+    )[1] AS collection_slug,
+    (
+      array_agg(ec.title ORDER BY ec.sort_order, eci.position)
+        FILTER (WHERE ec.id IS NOT NULL)
+    )[1] AS collection_title,
+    count(DISTINCT vt.tag_id)::integer AS matched_tag_count,
+    (
+      coalesce(sum(vt.preference_weight * stt.weight), 0)
+      + CASE WHEN st.is_featured THEN 0.35 ELSE 0 END
+      + CASE WHEN bool_or(ec.id IS NOT NULL) THEN 0.2 ELSE 0 END
+    )::numeric AS base_score,
+    (
+      get_byte(
+        decode(
+          substr(
+            md5(
+              st.id::text
+              || ':'
+              || coalesce(bounded.viewer_id::text, 'anon')
+              || ':'
+              || bounded.surface
+              || ':'
+              || bounded.context_key
+              || ':'
+              || current_date::text
+            ),
+            1,
+            2
+          ),
+          'hex'
+        ),
+        0
+      )::numeric / 255.0
+    ) AS rotation_score,
+    CASE
+      WHEN bounded.surface IN ('track', 'profile', 'review') THEN 0.45
+      WHEN bounded.surface IN ('studio', 'search', 'saved', 'notifications', 'activity', 'home') THEN 0.28
+      ELSE 0.18
+    END AS rotation_weight,
+    coalesce(
+      min(eci.position) FILTER (WHERE ec.id IS NOT NULL),
+      st.sort_order
+    ) AS editorial_position,
+    st.is_featured,
+    st.sort_order,
+    st.created_at
+  FROM public.starter_tracks st
+  CROSS JOIN bounded
+  LEFT JOIN public.starter_track_tags stt
+    ON stt.starter_track_id = st.id
+  LEFT JOIN viewer_tags vt
+    ON vt.tag_id = stt.tag_id
+  LEFT JOIN public.editorial_collection_items eci
+    ON eci.starter_track_id = st.id
+  LEFT JOIN public.editorial_collections ec
+    ON ec.id = eci.collection_id
+    AND ec.is_published
+  WHERE st.is_active
+    AND NOT (st.provider_id = ANY(bounded.excluded_provider_ids))
+    AND NOT EXISTS (
+      SELECT 1
+      FROM public.entities reviewed_entity
+      JOIN public.reviews viewer_review
+        ON viewer_review.entity_id = reviewed_entity.id
+      WHERE bounded.viewer_id IS NOT NULL
+        AND viewer_review.author_id = bounded.viewer_id
+        AND reviewed_entity.provider = st.provider
+        AND reviewed_entity.provider_id = st.provider_id
+        AND reviewed_entity.type = st.type
+    )
+  GROUP BY
+    st.id,
+    st.provider,
+    st.provider_id,
+    st.type,
+    st.title,
+    st.artist_name,
+    st.cover_url,
+    st.deezer_url,
+    st.prompt,
+    st.editorial_note,
+    st.is_featured,
+    st.sort_order,
+    st.created_at,
+    bounded.viewer_id,
+    bounded.surface,
+    bounded.context_key
+)
+SELECT
+  ranked.id,
+  ranked.provider,
+  ranked.provider_id,
+  ranked.type,
+  ranked.title,
+  ranked.artist_name,
+  ranked.cover_url,
+  ranked.deezer_url,
+  ranked.prompt,
+  ranked.editorial_note,
+  ranked.collection_slug,
+  ranked.collection_title,
+  ranked.matched_tag_count,
+  (ranked.base_score + ranked.rotation_score * ranked.rotation_weight)::numeric AS score
+FROM ranked
+CROSS JOIN bounded
+ORDER BY
+  (ranked.base_score + ranked.rotation_score * ranked.rotation_weight) DESC,
+  ranked.matched_tag_count DESC,
+  ranked.is_featured DESC,
+  ranked.editorial_position ASC,
+  ranked.sort_order ASC,
+  ranked.created_at DESC,
+  ranked.id DESC
+LIMIT (SELECT page_limit FROM bounded);
+$$;
+
+REVOKE ALL ON FUNCTION public.get_starter_tracks_for_surface(
+  integer,
+  text,
+  text,
+  text[]
+) FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION public.get_starter_tracks_for_surface(
+  integer,
+  text,
+  text,
+  text[]
+) TO authenticated;
+
+COMMIT;

--- a/supabase/scripts/maintenance/starter-rail-surface-check.sql
+++ b/supabase/scripts/maintenance/starter-rail-surface-check.sql
@@ -1,0 +1,37 @@
+-- Starter rail surface checks.
+--
+-- Run from the Supabase SQL editor after applying:
+-- supabase/migrations/20260601195115_starter_tracks_for_surface.sql
+--
+-- This is read-only. Direct SQL editor calls may not have auth.uid(), so this
+-- mainly validates editorial rotation by surface/context. Test through the app
+-- to verify viewer-specific taste ranking and reviewed-track filtering.
+
+with surface_checks(surface, context_key) as (
+  values
+    ('home', 'home'),
+    ('profile', 'profile:kocteau'),
+    ('track', 'track:sample'),
+    ('studio', 'studio:health'),
+    ('saved', 'saved')
+)
+select
+  surface_checks.surface,
+  surface_checks.context_key,
+  starter.provider_id,
+  starter.title,
+  starter.artist_name,
+  starter.collection_slug,
+  starter.matched_tag_count,
+  starter.score
+from surface_checks
+cross join lateral public.get_starter_tracks_for_surface(
+  6,
+  surface_checks.surface,
+  surface_checks.context_key,
+  '{}'::text[]
+) starter
+order by
+  surface_checks.surface,
+  starter.score desc,
+  starter.title;


### PR DESCRIPTION
## What changed

- Added contextual starter rail picks through `/api/starter/rail`.
- Added `get_starter_tracks_for_surface()` RPC for stable daily rotation by surface/context.
- Moved secondary rail starter picks out of the blocking main layout render.
- Updated home starter layer to use the contextual starter RPC.
- Added surface/context helpers and tests.
- Added SQL maintenance check and docs/backlog notes.

## Why

Starter picks were feeling too repetitive across screens and were also contributing to slow main route loads. This makes the rail more contextual per surface while keeping the recommendation logic lightweight, editorial, and reversible.

## Testing

- [ ] Ran `pnpm check`
- [ ] Added screenshots or a short recording for visible web UI changes
- [ ] Confirmed this does not touch auth, Supabase, recommendations, analytics, CI, or release behavior

Additional checks run:

- [x] `node --test apps/web/lib/starter/surface.test.ts`
- [x] `pnpm --filter web lint`
- [x] `pnpm --filter web build`
- [x] `git diff --check`
- [x] Confirmed `/api/starter/rail?surface=profile&context=profile%3Akocteau` returns `200` in dev

Note: this PR touches Supabase/recommendation-adjacent starter curation behavior intentionally. SQL migration to apply:

`supabase/migrations/20260601195115_starter_tracks_for_surface.sql`

Optional SQL check:

`supabase/scripts/maintenance/starter-rail-surface-check.sql`

## Changelog impact

No manual `CHANGELOG.md` edit is required. Release Please generates release notes from PR titles and squash commits.

- [x] User-facing web change
- [x] Developer experience or documentation change
- [ ] Internal-only change