### PR TITLE
feat(web): improve starter studio taxonomy

### DIFF
--- a/apps/web/app/(main)/layout.tsx
+++ b/apps/web/app/(main)/layout.tsx
@@ -5,6 +5,7 @@ import AppSidebar from "@/components/app-sidebar";
 import GlobalShortcuts from "@/components/global-shortcuts";
 import MobileBottomBar from "@/components/mobile-bottom-bar";
 import { RouteHeaderProvider } from "@/components/route-header-context";
+import { SecondaryRailProvider } from "@/components/secondary-rail-context";
 import WhoToFollowRail from "@/components/who-to-follow-rail";
 import { getCurrentOnboardingState, getCurrentUser, getCurrentViewerProfile } from "@/lib/auth/server";
 import { getStarterCuratorAccess } from "@/lib/queries/curation";
@@ -50,19 +51,21 @@ export default async function MainLayout({ children }: { children: React.ReactNo
         />
         <SidebarInset className="min-h-svh bg-[var(--kocteau-canvas)] lg:h-dvh lg:overflow-hidden lg:p-2.5">
           <RouteHeaderProvider>
-            <GlobalShortcuts isAuthenticated={Boolean(safeProfile)} />
-            <div className="kocteau-app-frame flex min-h-svh flex-1 flex-col lg:min-h-0 lg:h-full lg:overflow-hidden lg:rounded-[0.8rem]">
-              <Header profile={safeProfile} />
-              <div className="mx-auto flex min-h-0 w-full max-w-[82rem] flex-1 flex-col px-3.5 pt-[calc(env(safe-area-inset-top)+4rem)] pb-[calc(env(safe-area-inset-bottom)+6.5rem)] sm:px-6 sm:pt-[calc(env(safe-area-inset-top)+4.75rem)] sm:pb-28 lg:max-w-none lg:overflow-hidden lg:px-0 lg:py-0">
-                <div className="mx-auto grid min-h-0 w-full max-w-[76rem] flex-1 gap-5 lg:h-full lg:grid-cols-[minmax(0,44rem)_16rem] lg:items-stretch lg:justify-center lg:px-7 xl:gap-6 xl:px-8">
-                  <main className="no-scrollbar min-w-0 lg:min-h-0 lg:overflow-x-hidden lg:overflow-y-auto lg:pr-1">
-                    {children}
-                  </main>
-                  <WhoToFollowRail isAuthenticated={Boolean(safeProfile)} />
+            <SecondaryRailProvider>
+              <GlobalShortcuts isAuthenticated={Boolean(safeProfile)} />
+              <div className="kocteau-app-frame flex min-h-svh flex-1 flex-col lg:min-h-0 lg:h-full lg:overflow-hidden lg:rounded-[0.8rem]">
+                <Header profile={safeProfile} />
+                <div className="mx-auto flex min-h-0 w-full max-w-[82rem] flex-1 flex-col px-3.5 pt-[calc(env(safe-area-inset-top)+4rem)] pb-[calc(env(safe-area-inset-bottom)+6.5rem)] sm:px-6 sm:pt-[calc(env(safe-area-inset-top)+4.75rem)] sm:pb-28 lg:max-w-none lg:overflow-hidden lg:px-0 lg:py-0">
+                  <div className="mx-auto grid min-h-0 w-full max-w-[76rem] flex-1 gap-5 lg:h-full lg:grid-cols-[minmax(0,44rem)_16rem] lg:items-stretch lg:justify-center lg:px-7 xl:gap-6 xl:px-8">
+                    <main className="no-scrollbar min-w-0 lg:min-h-0 lg:overflow-x-hidden lg:overflow-y-auto lg:pr-1">
+                      {children}
+                    </main>
+                    <WhoToFollowRail isAuthenticated={Boolean(safeProfile)} />
+                  </div>
                 </div>
               </div>
-            </div>
-            <MobileBottomBar profile={safeProfile} />
+              <MobileBottomBar profile={safeProfile} />
+            </SecondaryRailProvider>
           </RouteHeaderProvider>
         </SidebarInset>
       </SidebarProvider>

--- a/apps/web/app/api/starter/tags/route.ts
+++ b/apps/web/app/api/starter/tags/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
 import { requireStarterCurator } from "@/lib/curation/access";
-import { starterPreferenceTagSchema } from "@/lib/validation/schemas";
+import {
+  starterPreferenceTagSchema,
+  starterPreferenceTagUpdateSchema,
+} from "@/lib/validation/schemas";
 import { validationErrorResponse } from "@/lib/validation/server";
 
 export async function POST(req: Request) {
@@ -32,6 +36,43 @@ export async function POST(req: Request) {
       { status: error.code === "42501" ? 403 : 500 },
     );
   }
+
+  revalidatePath("/studio/starter");
+
+  return NextResponse.json({ ok: true, tag: data });
+}
+
+export async function PATCH(req: Request) {
+  const curator = await requireStarterCurator();
+
+  if (!curator.ok) {
+    return curator.response;
+  }
+
+  const payload = (await req.json().catch(() => null)) as unknown;
+  const parsed = starterPreferenceTagUpdateSchema.safeParse(payload);
+
+  if (!parsed.success) {
+    return validationErrorResponse(parsed.error, "Starter tag is invalid.");
+  }
+
+  const tag = parsed.data;
+  const { data, error } = await curator.supabase.rpc("update_preference_tag", {
+    p_tag_id: tag.id,
+    p_kind: tag.kind,
+    p_label: tag.label,
+    p_description: tag.description ?? undefined,
+    p_is_featured: tag.is_featured,
+  });
+
+  if (error) {
+    return NextResponse.json(
+      { error: error.message ?? "We could not update that tag." },
+      { status: error.code === "42501" ? 403 : 500 },
+    );
+  }
+
+  revalidatePath("/studio/starter");
 
   return NextResponse.json({ ok: true, tag: data });
 }

--- a/apps/web/components/secondary-rail-context.tsx
+++ b/apps/web/components/secondary-rail-context.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useState,
+  type ReactNode,
+} from "react";
+
+type SetSecondaryRailContent = (content: ReactNode | null) => void;
+
+const SecondaryRailContentContext = createContext<ReactNode | null>(null);
+const SecondaryRailSetterContext = createContext<SetSecondaryRailContent | null>(null);
+
+export function SecondaryRailProvider({ children }: { children: ReactNode }) {
+  const [content, setRailContent] = useState<ReactNode | null>(null);
+  const setContent = useCallback((nextContent: ReactNode | null) => {
+    setRailContent(nextContent);
+  }, []);
+
+  return (
+    <SecondaryRailSetterContext.Provider value={setContent}>
+      <SecondaryRailContentContext.Provider value={content}>
+        {children}
+      </SecondaryRailContentContext.Provider>
+    </SecondaryRailSetterContext.Provider>
+  );
+}
+
+export function useSecondaryRailContent() {
+  return useContext(SecondaryRailContentContext);
+}
+
+export function useSecondaryRail() {
+  const setContent = useContext(SecondaryRailSetterContext);
+
+  return {
+    setContent: setContent ?? (() => undefined),
+  };
+}

--- a/apps/web/components/starter-studio-client.tsx
+++ b/apps/web/components/starter-studio-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   Archive,
@@ -9,18 +9,23 @@ import {
   Pencil,
   Plus,
   Search,
-  Star,
   Tags,
   X,
 } from "@/components/ui/icons";
 import { toast } from "sonner";
 import EntityCoverImage from "@/components/entity-cover-image";
+import { useSecondaryRail } from "@/components/secondary-rail-context";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { useDeezerSearch, type DeezerSearchResult } from "@/hooks/use-deezer-search";
-import { preferenceKindLabels, type PreferenceKind } from "@/lib/taste";
+import {
+  preferenceKindDescriptions,
+  preferenceKindLabels,
+  preferenceKindOrder,
+  type PreferenceKind,
+} from "@/lib/taste";
 import { cn } from "@/lib/utils";
 import { fetchJson } from "@/queries/http";
 import {
@@ -54,13 +59,22 @@ type StarterDraftTrack = Pick<
 
 const defaultPrompt = "What should people pay attention to here?";
 const starterTagLimit = 6;
-const starterTagKinds = [
-  "genre",
-  "mood",
-  "scene",
-  "style",
-] as const satisfies readonly PreferenceKind[];
-const starterTagKindSet = new Set<string>(starterTagKinds);
+const starterTagKinds = preferenceKindOrder;
+const starterTagKindSet = new Set<PreferenceKind>(starterTagKinds);
+const requiredEditorialKinds = ["era", "format"] as const satisfies readonly PreferenceKind[];
+
+type TagCoverage = {
+  tag: StarterPreferenceTag;
+  trackCount: number;
+};
+
+type KindCoverage = {
+  kind: PreferenceKind;
+  label: string;
+  tagCount: number;
+  coveredTagCount: number;
+  uncoveredTagCount: number;
+};
 
 function TrackCover({
   src,
@@ -85,7 +99,7 @@ function getTagKindLabel(kind: string) {
 }
 
 function groupTagsByKind(tags: StarterPreferenceTag[]) {
-  const groups = new Map<string, StarterPreferenceTag[]>();
+  const groups = new Map<PreferenceKind, StarterPreferenceTag[]>();
 
   tags.forEach((tag) => {
     const current = groups.get(tag.kind) ?? [];
@@ -117,8 +131,25 @@ function normalizeTagLabel(label: string) {
   return label.trim().toLowerCase();
 }
 
+function getTrackPreferenceTags(track: StarterTrackWithTags) {
+  return (track.starter_track_tags ?? []).flatMap((tag) =>
+    tag.preference_tags ? [tag.preference_tags] : [],
+  );
+}
+
+function getMissingEditorialKindsFromTags(tags: StarterPreferenceTag[]) {
+  const trackKinds = new Set(tags.map((tag) => tag.kind));
+
+  return requiredEditorialKinds.filter((kind) => !trackKinds.has(kind));
+}
+
+function getMissingEditorialKinds(track: StarterTrackWithTags) {
+  return getMissingEditorialKindsFromTags(getTrackPreferenceTags(track));
+}
+
 export default function StarterStudioClient() {
   const queryClient = useQueryClient();
+  const { setContent: setSecondaryRailContent } = useSecondaryRail();
   const [query, setQuery] = useState("");
   const [prompt, setPrompt] = useState(defaultPrompt);
   const [featured, setFeatured] = useState(true);
@@ -126,6 +157,12 @@ export default function StarterStudioClient() {
   const [tagQuery, setTagQuery] = useState("");
   const [newTagLabel, setNewTagLabel] = useState("");
   const [newTagKind, setNewTagKind] = useState<PreferenceKind>("mood");
+  const [newTagDescription, setNewTagDescription] = useState("");
+  const [newTagFeatured, setNewTagFeatured] = useState(true);
+  const [tagKindFilter, setTagKindFilter] = useState<PreferenceKind | "all">("all");
+  const [editingTag, setEditingTag] = useState<StarterPreferenceTag | null>(null);
+  const [selectedDraftTrack, setSelectedDraftTrack] =
+    useState<StarterDraftTrack | null>(null);
   const [editingTrack, setEditingTrack] =
     useState<StarterTrackWithTags | null>(null);
   const normalizedQuery = query.trim();
@@ -159,6 +196,10 @@ export default function StarterStudioClient() {
 
     return availableTags
       .filter((tag) => {
+        if (tagKindFilter !== "all" && tag.kind !== tagKindFilter) {
+          return false;
+        }
+
         if (!normalizedTagQuery) {
           return tag.is_featured;
         }
@@ -168,7 +209,7 @@ export default function StarterStudioClient() {
           .includes(normalizedTagQuery);
       })
       .slice(0, 36);
-  }, [availableTags, tagQuery]);
+  }, [availableTags, tagKindFilter, tagQuery]);
   const filteredTagGroups = useMemo(
     () => groupTagsByKind(filteredTags),
     [filteredTags],
@@ -176,6 +217,53 @@ export default function StarterStudioClient() {
   const selectedTagGroups = useMemo(
     () => groupTagsByKind(selectedTags),
     [selectedTags],
+  );
+  const tagCoverageById = useMemo(() => {
+    const coverage = new Map<string, number>();
+
+    starterTracks.forEach((track) => {
+      const uniqueTagIds = new Set(
+        (track.starter_track_tags ?? []).map((tag) => tag.tag_id),
+      );
+
+      uniqueTagIds.forEach((tagId) => {
+        coverage.set(tagId, (coverage.get(tagId) ?? 0) + 1);
+      });
+    });
+
+    return coverage;
+  }, [starterTracks]);
+  const tagCoverage = useMemo<TagCoverage[]>(
+    () =>
+      availableTags.map((tag) => ({
+        tag,
+        trackCount: tagCoverageById.get(tag.id) ?? 0,
+      })),
+    [availableTags, tagCoverageById],
+  );
+  const coverageByTagId = useMemo(
+    () => new Map(tagCoverage.map((item) => [item.tag.id, item.trackCount])),
+    [tagCoverage],
+  );
+  const kindCoverage = useMemo<KindCoverage[]>(
+    () =>
+      starterTagKinds.map((kind) => {
+        const kindTags = tagCoverage.filter((item) => item.tag.kind === kind);
+        const coveredTagCount = kindTags.filter((item) => item.trackCount > 0).length;
+
+        return {
+          kind,
+          label: preferenceKindLabels[kind],
+          tagCount: kindTags.length,
+          coveredTagCount,
+          uncoveredTagCount: Math.max(kindTags.length - coveredTagCount, 0),
+        };
+      }),
+    [tagCoverage],
+  );
+  const untaggedStarterCount = useMemo(
+    () => starterTracks.filter((track) => (track.starter_track_tags ?? []).length === 0).length,
+    [starterTracks],
   );
 
   function toggleTag(tagId: string) {
@@ -197,15 +285,25 @@ export default function StarterStudioClient() {
     });
   }
 
-  function resetDraft() {
+  const resetDraft = useCallback(() => {
     setEditingTrack(null);
+    setSelectedDraftTrack(null);
     setPrompt(defaultPrompt);
     setFeatured(true);
     setSelectedTagIds(new Set());
     setTagQuery("");
+  }, []);
+
+  function resetTagDraft() {
+    setEditingTag(null);
+    setNewTagLabel("");
+    setNewTagKind("mood");
+    setNewTagDescription("");
+    setNewTagFeatured(true);
   }
 
-  function startEditing(track: StarterTrackWithTags) {
+  const startEditing = useCallback((track: StarterTrackWithTags) => {
+    setSelectedDraftTrack(null);
     setEditingTrack(track);
     setPrompt(track.prompt ?? defaultPrompt);
     setFeatured(track.is_featured);
@@ -213,6 +311,32 @@ export default function StarterStudioClient() {
       new Set((track.starter_track_tags ?? []).map((tag) => tag.tag_id)),
     );
     setTagQuery("");
+  }, []);
+
+  const selectSearchTrack = useCallback((track: DeezerSearchResult) => {
+    const existingTrack = starterTracks.find(
+      (starterTrack) => starterTrack.provider_id === track.provider_id,
+    );
+
+    if (existingTrack) {
+      startEditing(existingTrack);
+      return;
+    }
+
+    setEditingTrack(null);
+    setSelectedDraftTrack(track);
+    setPrompt(defaultPrompt);
+    setFeatured(true);
+    setSelectedTagIds(new Set());
+    setTagQuery("");
+  }, [startEditing, starterTracks]);
+
+  function startEditingTag(tag: StarterPreferenceTag) {
+    setEditingTag(tag);
+    setNewTagLabel(tag.label);
+    setNewTagKind(tag.kind);
+    setNewTagDescription(tag.description ?? "");
+    setNewTagFeatured(tag.is_featured);
   }
 
   const addMutation = useMutation({
@@ -251,7 +375,10 @@ export default function StarterStudioClient() {
     },
     onSuccess: (_payload, track) => {
       toast.success(`${track.title} saved to Starter picks.`);
-      if (editingTrack?.provider_id === track.provider_id) {
+      if (
+        editingTrack?.provider_id === track.provider_id ||
+        selectedDraftTrack?.provider_id === track.provider_id
+      ) {
         resetDraft();
       }
       void queryClient.invalidateQueries({ queryKey: starterKeys.curatorTracks() });
@@ -289,14 +416,41 @@ export default function StarterStudioClient() {
         body: JSON.stringify({
           label: newTagLabel,
           kind: newTagKind,
-          description: null,
-          is_featured: true,
+          description: newTagDescription || null,
+          is_featured: newTagFeatured,
         }),
       }),
     onSuccess: (payload) => {
       toast.success(`${payload.tag.label} created.`);
       setSelectedTagIds((current) => new Set(current).add(payload.tag.id));
-      setNewTagLabel("");
+      resetTagDraft();
+      setTagKindFilter(payload.tag.kind);
+      setTagQuery("");
+      void queryClient.invalidateQueries({ queryKey: starterKeys.curatorTracks() });
+    },
+    onError: (error) => {
+      toast.error(error.message);
+    },
+  });
+  const updateTagMutation = useMutation({
+    mutationFn: (tag: StarterPreferenceTag) =>
+      fetchJson<StarterTagResponse>("/api/starter/tags", {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          id: tag.id,
+          label: newTagLabel,
+          kind: newTagKind,
+          description: newTagDescription || null,
+          is_featured: newTagFeatured,
+        }),
+      }),
+    onSuccess: (payload) => {
+      toast.success(`${payload.tag.label} updated.`);
+      resetTagDraft();
+      setTagKindFilter(payload.tag.kind);
       setTagQuery("");
       void queryClient.invalidateQueries({ queryKey: starterKeys.curatorTracks() });
     },
@@ -311,38 +465,266 @@ export default function StarterStudioClient() {
   const pendingArchiveId = archiveMutation.isPending
     ? archiveMutation.variables ?? null
     : null;
+  const inspectedTrack = editingTrack ?? selectedDraftTrack;
+  const inspectedTags = useMemo(
+    () => (editingTrack ? getTrackPreferenceTags(editingTrack) : selectedTags),
+    [editingTrack, selectedTags],
+  );
+  const inspectedTagGroups = useMemo(
+    () => groupTagsByKind(inspectedTags),
+    [inspectedTags],
+  );
+  const inspectedMissingKinds = useMemo(
+    () => getMissingEditorialKindsFromTags(inspectedTags),
+    [inspectedTags],
+  );
+  const inspectedIsPending =
+    Boolean(inspectedTrack) && pendingProviderId === inspectedTrack?.provider_id;
   const canCreateTag =
     newTagLabel.trim().length >= 2 &&
-    selectedTagIds.size < starterTagLimit &&
-    !createTagMutation.isPending;
+    (Boolean(editingTag) || selectedTagIds.size < starterTagLimit) &&
+    !createTagMutation.isPending &&
+    !updateTagMutation.isPending;
 
-  function handleCreateTag() {
+  function handleSaveTag() {
     const normalizedNewTag = normalizeTagLabel(newTagLabel);
 
-    if (!normalizedNewTag || selectedTagIds.size >= starterTagLimit) {
+    if (!normalizedNewTag || (!editingTag && selectedTagIds.size >= starterTagLimit)) {
       return;
     }
 
     const existingTag = availableTags.find(
       (tag) =>
-        normalizeTagLabel(tag.label) === normalizedNewTag ||
-        normalizeTagLabel(tag.slug) === normalizedNewTag,
+        tag.id !== editingTag?.id &&
+        (normalizeTagLabel(tag.label) === normalizedNewTag ||
+          normalizeTagLabel(tag.slug) === normalizedNewTag),
     );
 
     if (existingTag) {
-      setSelectedTagIds((current) => new Set(current).add(existingTag.id));
-      setNewTagLabel("");
-      setTagQuery("");
+      if (!editingTag) {
+        setSelectedTagIds((current) => new Set(current).add(existingTag.id));
+        resetTagDraft();
+        setTagQuery("");
+      } else {
+        toast.error("A tag with that name already exists.");
+      }
       return;
     }
 
-    if (canCreateTag) {
+    if (editingTag && canCreateTag) {
+      updateTagMutation.mutate(editingTag);
+      return;
+    }
+
+    if (!editingTag && canCreateTag) {
       createTagMutation.mutate();
     }
   }
 
+  const railInspectorContent = useMemo(
+    () => (
+      <section className="space-y-3 rounded-xl border border-border/28 bg-card/18 p-3">
+        {inspectedTrack ? (
+          <>
+            <div className="space-y-3">
+              <EntityCoverImage
+                src={inspectedTrack.cover_url}
+                alt={`${inspectedTrack.title} cover`}
+                sizes="256px"
+                className="aspect-square w-full rounded-[0.85rem] border border-border/24 bg-muted/20"
+                iconClassName="size-8"
+              />
+              <div className="min-w-0 space-y-1">
+                <p className="text-[0.68rem] font-medium uppercase text-muted-foreground">
+                  {editingTrack ? "Editing starter pick" : "Selected from Deezer"}
+                </p>
+                <h2 className="text-pretty font-serif text-xl font-semibold leading-6 text-foreground">
+                  {inspectedTrack.title}
+                </h2>
+                <p className="truncate text-sm text-muted-foreground">
+                  {inspectedTrack.artist_name ?? "Unknown artist"}
+                </p>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-2 text-xs">
+              <div className="rounded-lg border border-border/22 bg-background/24 px-3 py-2">
+                <p className="text-muted-foreground">Signals</p>
+                <p className="mt-1 tabular-nums text-foreground">
+                  {inspectedTags.length}/{starterTagLimit}
+                </p>
+              </div>
+              <div className="rounded-lg border border-border/22 bg-background/24 px-3 py-2">
+                <p className="text-muted-foreground">Missing</p>
+                <p className="mt-1 truncate text-foreground">
+                  {inspectedMissingKinds.length
+                    ? inspectedMissingKinds.map((kind) => getTagKindLabel(kind)).join(", ")
+                    : "Ready"}
+                </p>
+              </div>
+            </div>
+
+            <div className="space-y-2 rounded-lg border border-border/22 bg-background/24 p-2.5">
+              {inspectedTagGroups.length > 0 ? (
+                inspectedTagGroups.map((group) => (
+                  <div key={group.kind} className="space-y-1.5">
+                    <p className="text-[0.65rem] font-medium uppercase text-muted-foreground">
+                      {group.label}
+                    </p>
+                    <div className="flex flex-wrap gap-1.5">
+                      {group.tags.map((tag) => (
+                        <Badge
+                          key={tag.id}
+                          variant="outline"
+                          className="h-5 border-border/42 px-1.5 text-[0.62rem] text-muted-foreground"
+                        >
+                          {tag.label}
+                        </Badge>
+                      ))}
+                    </div>
+                  </div>
+                ))
+              ) : (
+                <p className="text-xs leading-5 text-muted-foreground">
+                  No signals yet. Choose tags from the library before saving.
+                </p>
+              )}
+
+              {inspectedMissingKinds.length > 0 ? (
+                <div className="flex flex-wrap gap-1.5 border-t border-border/18 pt-2">
+                  {inspectedMissingKinds.map((kind) => (
+                    <Badge
+                      key={kind}
+                      variant="outline"
+                      className="h-5 border-amber-500/22 bg-amber-500/7 px-1.5 text-[0.62rem] text-amber-100/78"
+                    >
+                      Add {getTagKindLabel(kind)}
+                    </Badge>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+
+            <Input
+              value={prompt}
+              onChange={(event) => setPrompt(event.target.value)}
+              placeholder="Editorial prompt"
+              className="h-9 rounded-lg bg-background/44 text-sm"
+            />
+
+            <div className="flex items-center gap-3 rounded-lg border border-border/24 bg-background/24 px-3 py-2">
+              <div className="min-w-0 flex-1">
+                <p className="text-xs font-medium text-foreground">Featured</p>
+                <p className="truncate text-xs text-muted-foreground">
+                  Prioritize this pick
+                </p>
+              </div>
+              <Switch
+                checked={featured}
+                onCheckedChange={setFeatured}
+                aria-label="Prioritize this starter pick"
+              />
+            </div>
+
+            <div className="grid gap-2">
+              <Button
+                type="button"
+                size="sm"
+                disabled={addMutation.isPending}
+                onClick={() => addMutation.mutate(inspectedTrack)}
+                className="h-9"
+              >
+                {inspectedIsPending ? (
+                  <LoaderCircle className="size-3 animate-spin" />
+                ) : editingTrack ? (
+                  <Check className="size-3" />
+                ) : (
+                  <Plus className="size-3" />
+                )}
+                {editingTrack ? "Save changes" : "Add starter pick"}
+              </Button>
+
+              <div className="grid grid-cols-2 gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  disabled={addMutation.isPending}
+                  onClick={resetDraft}
+                  className="h-9"
+                >
+                  <X className="size-3" />
+                  Clear
+                </Button>
+                {editingTrack ? (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    disabled={archiveMutation.isPending}
+                    onClick={() => archiveMutation.mutate(editingTrack.id)}
+                    className="h-9"
+                  >
+                    {pendingArchiveId === editingTrack.id ? (
+                      <LoaderCircle className="size-3 animate-spin" />
+                    ) : (
+                      <Archive className="size-3" />
+                    )}
+                    Archive
+                  </Button>
+                ) : (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    disabled
+                    className="h-9"
+                  >
+                    Draft
+                  </Button>
+                )}
+              </div>
+            </div>
+          </>
+        ) : (
+          <div className="space-y-3 py-2">
+            <div className="aspect-square rounded-[0.85rem] border border-dashed border-border/28 bg-background/20" />
+            <div className="space-y-1">
+              <p className="text-sm font-medium text-foreground">No song selected</p>
+              <p className="text-xs leading-5 text-muted-foreground">
+                Select a Deezer result or an existing starter pick to inspect cover, signals, and missing context.
+              </p>
+            </div>
+          </div>
+        )}
+      </section>
+    ),
+    [
+      addMutation,
+      archiveMutation,
+      editingTrack,
+      featured,
+      inspectedIsPending,
+      inspectedMissingKinds,
+      inspectedTagGroups,
+      inspectedTags.length,
+      inspectedTrack,
+      pendingArchiveId,
+      prompt,
+      resetDraft,
+    ],
+  );
+
+  useEffect(() => {
+    setSecondaryRailContent(railInspectorContent);
+
+    return () => {
+      setSecondaryRailContent(null);
+    };
+  }, [railInspectorContent, setSecondaryRailContent]);
+
   return (
-    <div className="mx-auto flex w-full max-w-5xl flex-1 flex-col gap-6">
+    <div className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-6">
       <header className="space-y-1.5">
         <p className="text-xs font-medium text-muted-foreground">Kocteau editorial</p>
         <h1 className="font-serif text-3xl font-semibold tracking-normal text-foreground">
@@ -353,7 +735,7 @@ export default function StarterStudioClient() {
         </p>
       </header>
 
-      <section className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_18rem]">
+      <section className="relative">
         <div className="relative">
           <Search className="pointer-events-none absolute top-1/2 left-3.5 size-4 -translate-y-1/2 text-muted-foreground" />
           <Input
@@ -364,413 +746,590 @@ export default function StarterStudioClient() {
             autoFocus
           />
         </div>
-
-        <div className="flex items-center gap-3 rounded-lg border border-border/38 bg-card/30 px-3 py-2">
-          <div className="min-w-0 flex-1">
-            <p className="text-xs font-medium text-foreground">Featured</p>
-            <p className="truncate text-xs text-muted-foreground">
-              Prioritize new picks
-            </p>
-          </div>
-          <Switch
-            checked={featured}
-            onCheckedChange={setFeatured}
-            aria-label="Prioritize this starter pick"
-          />
-        </div>
       </section>
 
-      <Input
-        value={prompt}
-        onChange={(event) => setPrompt(event.target.value)}
-        placeholder="Editorial prompt"
-        className="h-9 rounded-lg bg-card/34 text-sm"
-      />
-
-      {editingTrack ? (
-        <section className="grid gap-3 rounded-lg border border-primary/28 bg-primary/8 p-3 md:grid-cols-[3.5rem_minmax(0,1fr)_auto] md:items-center">
-          <TrackCover src={editingTrack.cover_url} title={editingTrack.title} />
-          <div className="min-w-0">
-            <p className="text-xs font-medium text-primary">Editing starter pick</p>
-            <h2 className="truncate text-sm font-semibold text-foreground">
-              {editingTrack.title}
-            </h2>
-            <p className="truncate text-xs text-muted-foreground">
-              {editingTrack.artist_name ?? "Unknown artist"}
-            </p>
+      {inspectedTrack ? (
+        <section className="space-y-3 rounded-xl border border-border/28 bg-card/18 p-3 lg:hidden">
+          <div className="grid grid-cols-[4.25rem_minmax(0,1fr)] gap-3">
+            <EntityCoverImage
+              src={inspectedTrack.cover_url}
+              alt={`${inspectedTrack.title} cover`}
+              sizes="68px"
+              className="aspect-square w-full rounded-[0.65rem] border border-border/24 bg-muted/20"
+              iconClassName="size-5"
+            />
+            <div className="min-w-0 space-y-1">
+              <p className="text-[0.68rem] font-medium uppercase text-muted-foreground">
+                {editingTrack ? "Editing starter pick" : "Selected from Deezer"}
+              </p>
+              <h2 className="truncate text-sm font-semibold text-foreground">
+                {inspectedTrack.title}
+              </h2>
+              <p className="truncate text-xs text-muted-foreground">
+                {inspectedTrack.artist_name ?? "Unknown artist"}
+              </p>
+              <p className="text-xs text-muted-foreground">
+                {inspectedTags.length}/{starterTagLimit} signals
+                {inspectedMissingKinds.length
+                  ? ` · add ${inspectedMissingKinds.map((kind) => getTagKindLabel(kind)).join(", ")}`
+                  : " · ready"}
+              </p>
+            </div>
           </div>
-          <div className="flex flex-wrap gap-2">
+
+          <Input
+            value={prompt}
+            onChange={(event) => setPrompt(event.target.value)}
+            placeholder="Editorial prompt"
+            className="h-9 rounded-lg bg-background/44 text-sm"
+          />
+
+          <div className="grid grid-cols-[minmax(0,1fr)_auto] gap-2">
+            <Button
+              type="button"
+              size="sm"
+              disabled={addMutation.isPending}
+              onClick={() => addMutation.mutate(inspectedTrack)}
+              className="h-9"
+            >
+              {inspectedIsPending ? (
+                <LoaderCircle className="size-3 animate-spin" />
+              ) : editingTrack ? (
+                <Check className="size-3" />
+              ) : (
+                <Plus className="size-3" />
+              )}
+              {editingTrack ? "Save" : "Add"}
+            </Button>
             <Button
               type="button"
               variant="outline"
               size="sm"
               disabled={addMutation.isPending}
               onClick={resetDraft}
+              className="h-9"
             >
               <X className="size-3" />
-              Cancel
-            </Button>
-            <Button
-              type="button"
-              size="sm"
-              disabled={addMutation.isPending}
-              onClick={() => addMutation.mutate(editingTrack)}
-            >
-              {addMutation.isPending &&
-              addMutation.variables?.provider_id === editingTrack.provider_id ? (
-                <LoaderCircle className="size-3 animate-spin" />
-              ) : (
-                <Check className="size-3" />
-              )}
-              Save changes
+              Clear
             </Button>
           </div>
         </section>
       ) : null}
 
-      <section className="space-y-3 rounded-lg border border-border/34 bg-card/20 p-3">
-        <div className="flex items-center justify-between gap-3">
+      <section className="space-y-3 rounded-xl border border-border/28 bg-card/18 p-3">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex items-center gap-2 text-sm font-medium text-foreground">
             <Tags className="size-4 text-muted-foreground" />
-            Starter signals
+            Signal library
           </div>
-          <div className="flex items-center gap-2">
-            {editingTrack ? (
-              <Button
-                type="button"
-                variant="outline"
-                size="xs"
-                disabled={addMutation.isPending}
-                onClick={() => addMutation.mutate(editingTrack)}
-              >
-                {addMutation.isPending &&
-                addMutation.variables?.provider_id === editingTrack.provider_id ? (
-                  <LoaderCircle className="size-2.5 animate-spin" />
-                ) : (
-                  <Check className="size-2.5" />
-                )}
-                Save
-              </Button>
-            ) : null}
-            <Button
-              type="button"
-              variant="ghost"
-              size="xs"
-              disabled={selectedTagIds.size === 0}
-              onClick={() => setSelectedTagIds(new Set())}
-            >
-              <X className="size-2.5" />
-              Clear
-            </Button>
-            <span className="text-xs text-muted-foreground">
-              {selectedTagIds.size}/{starterTagLimit}
-            </span>
+          <div className="flex items-center gap-2 text-xs tabular-nums text-muted-foreground">
+            <span>{starterTracks.length} picks</span>
+            <span className="size-1 rounded-full bg-muted-foreground/30" />
+            <span>{selectedTagIds.size}/{starterTagLimit} selected</span>
           </div>
         </div>
 
-        <div className="rounded-md border border-border/28 bg-background/24 p-2">
-          {selectedTagGroups.length > 0 ? (
-            <div className="space-y-2">
-              {selectedTagGroups.map((group) => (
-                <div
-                  key={group.kind}
-                  className="grid gap-1.5 sm:grid-cols-[4.5rem_minmax(0,1fr)] sm:items-start"
-                >
-                  <p className="pt-1 text-[0.65rem] font-medium uppercase tracking-wide text-muted-foreground">
-                    {group.label}
+        <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
+          {kindCoverage.map((stat) => {
+            const isActive = tagKindFilter === stat.kind;
+            const coverageLabel =
+              stat.tagCount === 0
+                ? "No tags"
+                : `${stat.coveredTagCount}/${stat.tagCount} covered`;
+
+            return (
+              <button
+                key={stat.kind}
+                type="button"
+                onClick={() => setTagKindFilter(isActive ? "all" : stat.kind)}
+                className={cn(
+                  "rounded-lg border px-3 py-2 text-left transition-[background-color,border-color,transform] duration-150 ease-out active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30",
+                  isActive
+                    ? "border-foreground/32 bg-foreground/[0.075]"
+                    : "border-border/30 bg-background/24 hover:border-foreground/18 hover:bg-muted/18",
+                )}
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <p className="truncate text-xs font-medium text-foreground">
+                    {stat.label}
                   </p>
-                  <div className="flex flex-wrap gap-1.5">
-                    {group.tags.map((tag) => (
-                      <Badge
-                        key={tag.id}
-                        asChild
-                        variant="outline"
-                        className="h-6 border-primary/42 bg-primary/10 px-2 text-xs text-foreground"
-                      >
-                        <button type="button" onClick={() => toggleTag(tag.id)}>
-                          {tag.label}
-                          <X className="size-2.5" />
-                        </button>
-                      </Badge>
-                    ))}
+                  <span className="text-[0.65rem] tabular-nums text-muted-foreground">
+                    {stat.uncoveredTagCount}
+                  </span>
+                </div>
+                <p className="mt-1 text-[0.68rem] text-muted-foreground">
+                  {coverageLabel}
+                </p>
+              </button>
+            );
+          })}
+        </div>
+
+        {untaggedStarterCount > 0 ? (
+          <p className="rounded-lg border border-amber-500/24 bg-amber-500/7 px-3 py-2 text-xs text-amber-100/78">
+            {untaggedStarterCount} starter pick{untaggedStarterCount === 1 ? "" : "s"} need signals.
+          </p>
+        ) : null}
+
+        <div className="grid gap-3 xl:grid-cols-[minmax(0,1fr)_21rem]">
+          <div className="min-w-0 space-y-3">
+            <div className="rounded-lg border border-border/24 bg-background/24 p-2.5">
+              {selectedTagGroups.length > 0 ? (
+                <div className="space-y-2">
+                  {selectedTagGroups.map((group) => (
+                    <div
+                      key={group.kind}
+                      className="grid gap-1.5 sm:grid-cols-[4.75rem_minmax(0,1fr)] sm:items-start"
+                    >
+                      <p className="pt-1 text-[0.65rem] font-medium uppercase text-muted-foreground">
+                        {group.label}
+                      </p>
+                      <div className="flex flex-wrap gap-1.5">
+                        {group.tags.map((tag) => (
+                          <Badge
+                            key={tag.id}
+                            asChild
+                            variant="outline"
+                            className="h-6 border-foreground/28 bg-foreground/[0.06] px-2 text-xs text-foreground"
+                          >
+                            <button type="button" onClick={() => toggleTag(tag.id)}>
+                              {tag.label}
+                              <X className="size-2.5" />
+                            </button>
+                          </Badge>
+                        ))}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <p className="px-1 py-1.5 text-xs text-muted-foreground">
+                  Pick up to six signals before adding or updating a starter pick.
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <Input
+                value={tagQuery}
+                onChange={(event) => setTagQuery(event.target.value)}
+                placeholder="Filter signals..."
+                className="h-9 rounded-lg bg-background/44 text-sm"
+              />
+              <div className="flex flex-wrap gap-1.5">
+                <button
+                  type="button"
+                  onClick={() => setTagKindFilter("all")}
+                  className={cn(
+                    "h-7 rounded-md border px-2.5 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30",
+                    tagKindFilter === "all"
+                      ? "border-foreground/30 bg-foreground/[0.075] text-foreground"
+                      : "border-border/32 bg-background/24 text-muted-foreground hover:text-foreground",
+                  )}
+                >
+                  All
+                </button>
+                {starterTagKinds.map((kind) => (
+                  <button
+                    key={kind}
+                    type="button"
+                    onClick={() => setTagKindFilter(kind)}
+                    className={cn(
+                      "h-7 rounded-md border px-2.5 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30",
+                      tagKindFilter === kind
+                        ? "border-foreground/30 bg-foreground/[0.075] text-foreground"
+                        : "border-border/32 bg-background/24 text-muted-foreground hover:text-foreground",
+                    )}
+                  >
+                    {preferenceKindLabels[kind]}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div className="max-h-64 space-y-3 overflow-y-auto pr-1">
+              {filteredTagGroups.map((group) => (
+                <div key={group.kind} className="space-y-1.5">
+                  <div className="flex items-center justify-between gap-2">
+                    <p className="text-[0.65rem] font-medium uppercase text-muted-foreground">
+                      {group.label}
+                    </p>
+                    <p className="truncate text-[0.65rem] text-muted-foreground/70">
+                      {preferenceKindDescriptions[group.kind as PreferenceKind]}
+                    </p>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {group.tags.map((tag) => {
+                      const isSelected = selectedTagIds.has(tag.id);
+                      const coverageCount = coverageByTagId.get(tag.id) ?? 0;
+
+                      return (
+                        <span
+                          key={tag.id}
+                          className={cn(
+                            "inline-flex h-8 max-w-full items-center rounded-md border text-xs font-medium transition-colors",
+                            isSelected
+                              ? "border-foreground/38 bg-foreground text-background"
+                              : "border-border/42 bg-muted/14 text-foreground hover:border-foreground/22 hover:bg-muted/36",
+                          )}
+                        >
+                          <button
+                            type="button"
+                            aria-pressed={isSelected}
+                            onClick={() => toggleTag(tag.id)}
+                            className="flex h-full min-w-0 items-center gap-1.5 px-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30"
+                          >
+                            <span className="truncate">{tag.label}</span>
+                            <span
+                              className={cn(
+                                "rounded-full px-1.5 text-[0.62rem] tabular-nums",
+                                isSelected
+                                  ? "bg-background/14 text-background"
+                                  : coverageCount > 0
+                                    ? "bg-foreground/[0.06] text-muted-foreground"
+                                    : "bg-amber-500/10 text-amber-100/78",
+                              )}
+                            >
+                              {coverageCount}
+                            </span>
+                            {isSelected ? <Check className="size-3" /> : null}
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => startEditingTag(tag)}
+                            className={cn(
+                              "grid h-full w-7 place-items-center border-l transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30",
+                              isSelected
+                                ? "border-background/20 text-background/76 hover:text-background"
+                                : "border-border/34 text-muted-foreground hover:text-foreground",
+                            )}
+                            aria-label={`Edit ${tag.label}`}
+                          >
+                            <Pencil className="size-3" />
+                          </button>
+                        </span>
+                      );
+                    })}
                   </div>
                 </div>
               ))}
-            </div>
-          ) : (
-            <p className="px-1 py-1.5 text-xs text-muted-foreground">
-              Pick up to six signals before adding or updating a starter pick.
-            </p>
-          )}
-        </div>
 
-        <div className="grid gap-2 md:grid-cols-[minmax(0,1fr)_12rem_auto]">
-          <Input
-            value={tagQuery}
-            onChange={(event) => setTagQuery(event.target.value)}
-            placeholder="Filter tags..."
-            className="h-8 rounded-md bg-background/44 text-sm"
-          />
-          <select
-            value={newTagKind}
-            onChange={(event) => setNewTagKind(event.target.value as PreferenceKind)}
-            aria-label="New tag kind"
-            className="h-8 rounded-md border border-input bg-input px-2 text-xs text-foreground outline-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/30"
-          >
-            {starterTagKinds.map((kind) => (
-              <option key={kind} value={kind}>
-                {preferenceKindLabels[kind]}
-              </option>
-            ))}
-          </select>
-          <div className="flex gap-2">
+              {filteredTagGroups.length === 0 ? (
+                <p className="rounded-lg border border-border/24 bg-background/24 px-3 py-5 text-center text-xs text-muted-foreground">
+                  No matching signals.
+                </p>
+              ) : null}
+            </div>
+          </div>
+
+          <aside className="space-y-3 rounded-lg border border-border/24 bg-background/24 p-3">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <p className="text-xs font-medium text-foreground">
+                  {editingTag ? "Edit signal" : "Create signal"}
+                </p>
+                <p className="mt-0.5 text-xs text-muted-foreground">
+                  {editingTag ? editingTag.slug : "Build the vocabulary as you curate."}
+                </p>
+              </div>
+              {editingTag ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="xs"
+                  onClick={resetTagDraft}
+                >
+                  <X className="size-2.5" />
+                  New
+                </Button>
+              ) : null}
+            </div>
+
             <Input
               value={newTagLabel}
               onChange={(event) => setNewTagLabel(event.target.value)}
               onKeyDown={(event) => {
                 if (event.key === "Enter") {
                   event.preventDefault();
-                  handleCreateTag();
+                  handleSaveTag();
                 }
               }}
-              placeholder="New tag"
-              className="h-8 rounded-md bg-background/44 text-sm md:w-28"
+              placeholder="Signal name"
+              className="h-9 rounded-lg bg-background/44 text-sm"
             />
+
+            <div className="grid grid-cols-2 gap-1.5">
+              {starterTagKinds.map((kind) => (
+                <button
+                  key={kind}
+                  type="button"
+                  aria-pressed={newTagKind === kind}
+                  onClick={() => setNewTagKind(kind)}
+                  className={cn(
+                    "h-8 rounded-md border px-2 text-left text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30",
+                    newTagKind === kind
+                      ? "border-foreground/32 bg-foreground/[0.075] text-foreground"
+                      : "border-border/32 bg-background/24 text-muted-foreground hover:text-foreground",
+                  )}
+                >
+                  {preferenceKindLabels[kind]}
+                </button>
+              ))}
+            </div>
+
+            <Input
+              value={newTagDescription}
+              onChange={(event) => setNewTagDescription(event.target.value)}
+              placeholder="Short note"
+              className="h-9 rounded-lg bg-background/44 text-sm"
+            />
+
+            <div className="flex items-center gap-3 rounded-lg border border-border/24 bg-card/18 px-3 py-2">
+              <div className="min-w-0 flex-1">
+                <p className="text-xs font-medium text-foreground">Featured</p>
+                <p className="truncate text-xs text-muted-foreground">
+                  Show in default tag views
+                </p>
+              </div>
+              <Switch
+                checked={newTagFeatured}
+                onCheckedChange={setNewTagFeatured}
+                aria-label="Feature this signal"
+              />
+            </div>
+
             <Button
               type="button"
               variant="outline"
               size="sm"
               disabled={!canCreateTag}
-              onClick={handleCreateTag}
-              className="h-8"
+              onClick={handleSaveTag}
+              className="h-9 w-full"
             >
-              {createTagMutation.isPending ? (
+              {createTagMutation.isPending || updateTagMutation.isPending ? (
                 <LoaderCircle className="size-3 animate-spin" />
+              ) : editingTag ? (
+                <Check className="size-3" />
               ) : (
                 <Plus className="size-3" />
               )}
-              Tag
+              {editingTag ? "Save signal" : "Create signal"}
             </Button>
-          </div>
-        </div>
-
-        <div className="max-h-44 space-y-3 overflow-y-auto pr-1">
-          {filteredTagGroups.map((group) => (
-            <div key={group.kind} className="space-y-1.5">
-              <p className="text-[0.65rem] font-medium uppercase tracking-wide text-muted-foreground">
-                {group.label}
-              </p>
-              <div className="flex flex-wrap gap-2">
-                {group.tags.map((tag) => {
-                  const isSelected = selectedTagIds.has(tag.id);
-
-                  return (
-                    <button
-                      key={tag.id}
-                      type="button"
-                      aria-pressed={isSelected}
-                      onClick={() => toggleTag(tag.id)}
-                      className={cn(
-                        "inline-flex h-7 max-w-full items-center gap-1.5 rounded-md border px-2 text-xs font-medium transition-colors focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:outline-none",
-                        isSelected
-                          ? "border-primary bg-primary text-primary-foreground"
-                          : "border-border/60 bg-muted/18 text-foreground hover:border-foreground/25 hover:bg-muted/45",
-                      )}
-                    >
-                      <span className="truncate">{tag.label}</span>
-                      {isSelected ? <Check className="size-3" /> : null}
-                    </button>
-                  );
-                })}
-              </div>
-            </div>
-          ))}
-
-          {filteredTagGroups.length === 0 ? (
-            <p className="rounded-md border border-border/28 bg-background/24 px-3 py-4 text-center text-xs text-muted-foreground">
-              No matching tags.
-            </p>
-          ) : null}
+          </aside>
         </div>
       </section>
 
-      <div className="grid min-h-0 gap-6 lg:grid-cols-[minmax(0,1fr)_20rem]">
-        <section className="min-w-0 space-y-3">
-          <div className="flex items-center justify-between gap-3">
-            <h2 className="text-sm font-semibold text-foreground">Deezer results</h2>
-            {searchFetching ? (
-              <LoaderCircle className="size-4 animate-spin text-muted-foreground" />
-            ) : null}
-          </div>
-
-          <div className="space-y-2">
-            {searchError ? (
-              <p className="rounded-lg border border-destructive/34 bg-destructive/10 px-3 py-2 text-sm text-destructive">
-                {searchError.message}
-              </p>
-            ) : null}
-
-            {normalizedQuery.length < 2 ? (
-              <p className="rounded-lg border border-border/34 bg-card/26 px-3 py-8 text-center text-sm text-muted-foreground">
-                Search by track, artist, or album.
-              </p>
-            ) : null}
-
-            {(searchResults ?? []).map((track) => {
-              const alreadyAdded = existingProviderIds.has(track.provider_id);
-              const isPending = pendingProviderId === track.provider_id;
-
-              return (
-                <article
-                  key={track.provider_id}
-                  className="grid min-h-[4.75rem] grid-cols-[3.5rem_minmax(0,1fr)_auto] items-center gap-3 rounded-lg border border-border/34 bg-card/24 p-2.5"
-                >
-                  <TrackCover src={track.cover_url} title={track.title} />
-                  <div className="min-w-0">
-                    <h3 className="truncate text-sm font-medium text-foreground">
-                      {track.title}
-                    </h3>
-                    <p className="truncate text-xs text-muted-foreground">
-                      {track.artist_name ?? "Unknown artist"}
-                    </p>
-                  </div>
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant={alreadyAdded ? "secondary" : "default"}
-                    disabled={addMutation.isPending}
-                    onClick={() => addMutation.mutate(track)}
-                    className="gap-1.5"
-                  >
-                    {isPending ? (
-                      <LoaderCircle className="size-3 animate-spin" />
-                    ) : alreadyAdded ? (
-                      <Star className="size-3" />
-                    ) : (
-                      <Plus className="size-3" />
-                    )}
-                    {alreadyAdded ? "Update" : "Add"}
-                  </Button>
-                </article>
-              );
-            })}
-          </div>
-        </section>
-
-        <aside className="min-w-0 space-y-3">
-          <div className="flex items-center justify-between gap-3">
-            <h2 className="text-sm font-semibold text-foreground">Starter picks</h2>
-            <span className="text-xs text-muted-foreground">
-              {starterTracks.length}
-            </span>
-          </div>
-
-          <div className="space-y-2">
-            {starterTracksQuery.isLoading ? (
-              <div className="flex min-h-24 items-center justify-center rounded-lg border border-border/34 bg-card/24">
+      <div className="min-h-0">
+        <section className="min-w-0 space-y-5">
+          <section className="space-y-3">
+            <div className="flex items-center justify-between gap-3">
+              <h2 className="text-sm font-semibold text-foreground">Deezer results</h2>
+              {searchFetching ? (
                 <LoaderCircle className="size-4 animate-spin text-muted-foreground" />
-              </div>
-            ) : null}
+              ) : null}
+            </div>
 
-            {!starterTracksQuery.isLoading && starterTracks.length === 0 ? (
-              <p className="rounded-lg border border-border/34 bg-card/24 px-3 py-8 text-center text-sm text-muted-foreground">
-                No starter picks yet.
-              </p>
-            ) : null}
+            <div className="space-y-2">
+              {searchError ? (
+                <p className="rounded-lg border border-destructive/34 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                  {searchError.message}
+                </p>
+              ) : null}
 
-            {starterTracks.map((track) => {
-              const isArchiving = pendingArchiveId === track.id;
-              const tags = track.starter_track_tags ?? [];
-              const isEditing = editingTrack?.id === track.id;
+              {normalizedQuery.length < 2 ? (
+                <p className="rounded-lg border border-border/28 bg-card/18 px-3 py-8 text-center text-sm text-muted-foreground">
+                  Search by track, artist, or album.
+                </p>
+              ) : null}
 
-              return (
-                <article
-                  key={track.id}
-                  className={cn(
-                    "grid min-h-[4.5rem] grid-cols-[minmax(0,1fr)_auto] items-center gap-2 rounded-lg border border-border/34 bg-card/24 p-2 transition-colors",
-                    track.is_featured && "border-foreground/20",
-                    isEditing && "border-primary/50 bg-primary/8",
-                  )}
-                >
-                  <button
-                    type="button"
-                    onClick={() => startEditing(track)}
-                    className="grid min-w-0 grid-cols-[3.25rem_minmax(0,1fr)] items-center gap-2.5 rounded-md text-left focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:outline-none"
+              {(searchResults ?? []).map((track) => {
+                const alreadyAdded = existingProviderIds.has(track.provider_id);
+                const isSelected =
+                  selectedDraftTrack?.provider_id === track.provider_id ||
+                  editingTrack?.provider_id === track.provider_id;
+
+                return (
+                  <article
+                    key={track.provider_id}
+                    className={cn(
+                      "grid min-h-[4.75rem] grid-cols-[minmax(0,1fr)_auto] items-center gap-3 rounded-lg border border-border/28 bg-card/18 p-2.5 transition-colors",
+                      isSelected && "border-foreground/34 bg-foreground/[0.055]",
+                    )}
                   >
-                    <TrackCover src={track.cover_url} title={track.title} />
-                    <span className="min-w-0">
-                      <span className="block truncate text-sm font-medium text-foreground">
-                        {track.title}
+                    <button
+                      type="button"
+                      onClick={() => selectSearchTrack(track)}
+                      className="grid min-w-0 grid-cols-[3.5rem_minmax(0,1fr)] items-center gap-3 rounded-md text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30"
+                    >
+                      <TrackCover src={track.cover_url} title={track.title} />
+                      <span className="min-w-0">
+                        <span className="block truncate text-sm font-medium text-foreground">
+                          {track.title}
+                        </span>
+                        <span className="block truncate text-xs text-muted-foreground">
+                          {track.artist_name ?? "Unknown artist"}
+                        </span>
                       </span>
-                      <span className="block truncate text-xs text-muted-foreground">
-                        {track.artist_name ?? "Unknown artist"}
-                      </span>
-                      <span className="mt-1 flex flex-wrap gap-1">
-                        {tags.length ? (
-                          <>
-                            {tags.slice(0, 3).flatMap((tag) =>
-                              tag.preference_tags ? (
+                    </button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant={isSelected ? "secondary" : "outline"}
+                      disabled={addMutation.isPending}
+                      onClick={() => selectSearchTrack(track)}
+                      className="gap-1.5"
+                    >
+                      {isSelected ? (
+                        <Check className="size-3" />
+                      ) : alreadyAdded ? (
+                        <Pencil className="size-3" />
+                      ) : (
+                        <Plus className="size-3" />
+                      )}
+                      {isSelected ? "Selected" : alreadyAdded ? "Edit" : "Select"}
+                    </Button>
+                  </article>
+                );
+              })}
+            </div>
+          </section>
+
+          <section className="space-y-3">
+            <div className="flex items-center justify-between gap-3">
+              <h2 className="text-sm font-semibold text-foreground">Starter catalog</h2>
+              <span className="text-xs tabular-nums text-muted-foreground">
+                {starterTracks.length}
+              </span>
+            </div>
+
+            <div className="grid gap-2 xl:grid-cols-2">
+              {starterTracksQuery.isLoading ? (
+                <div className="flex min-h-24 items-center justify-center rounded-lg border border-border/28 bg-card/18 xl:col-span-2">
+                  <LoaderCircle className="size-4 animate-spin text-muted-foreground" />
+                </div>
+              ) : null}
+
+              {!starterTracksQuery.isLoading && starterTracks.length === 0 ? (
+                <p className="rounded-lg border border-border/28 bg-card/18 px-3 py-8 text-center text-sm text-muted-foreground xl:col-span-2">
+                  No starter picks yet.
+                </p>
+              ) : null}
+
+              {starterTracks.map((track) => {
+                const isArchiving = pendingArchiveId === track.id;
+                const tags = track.starter_track_tags ?? [];
+                const isEditing = editingTrack?.id === track.id;
+                const missingKinds = getMissingEditorialKinds(track);
+
+                return (
+                  <article
+                    key={track.id}
+                    className={cn(
+                      "grid min-h-[4.5rem] grid-cols-[minmax(0,1fr)_auto] items-center gap-2 rounded-lg border border-border/28 bg-card/18 p-2 transition-colors",
+                      track.is_featured && "border-foreground/18",
+                      isEditing && "border-foreground/34 bg-foreground/[0.055]",
+                    )}
+                  >
+                    <button
+                      type="button"
+                      onClick={() => startEditing(track)}
+                      className="grid min-w-0 grid-cols-[3.25rem_minmax(0,1fr)] items-center gap-2.5 rounded-md text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30"
+                    >
+                      <TrackCover src={track.cover_url} title={track.title} />
+                      <span className="min-w-0">
+                        <span className="block truncate text-sm font-medium text-foreground">
+                          {track.title}
+                        </span>
+                        <span className="block truncate text-xs text-muted-foreground">
+                          {track.artist_name ?? "Unknown artist"}
+                        </span>
+                        <span className="mt-1 flex flex-wrap gap-1">
+                          {track.is_featured ? (
+                            <Badge
+                              variant="outline"
+                              className="h-4 border-border/42 px-1.5 text-[0.56rem] text-muted-foreground"
+                            >
+                              Featured
+                            </Badge>
+                          ) : null}
+                          {tags.length ? (
+                            <>
+                              {tags.slice(0, 2).flatMap((tag) =>
+                                tag.preference_tags ? (
+                                  <Badge
+                                    key={tag.tag_id}
+                                    variant="outline"
+                                    className="h-4 border-border/42 px-1.5 text-[0.56rem] text-muted-foreground"
+                                  >
+                                    {tag.preference_tags.label}
+                                  </Badge>
+                                ) : [],
+                              )}
+                              {tags.length > 2 ? (
                                 <Badge
-                                  key={tag.tag_id}
                                   variant="outline"
                                   className="h-4 border-border/42 px-1.5 text-[0.56rem] text-muted-foreground"
                                 >
-                                  {tag.preference_tags.label}
+                                  +{tags.length - 2}
                                 </Badge>
-                              ) : [],
-                            )}
-                            {tags.length > 3 ? (
-                              <Badge
-                                variant="outline"
-                                className="h-4 border-border/42 px-1.5 text-[0.56rem] text-muted-foreground"
-                              >
-                                +{tags.length - 3}
-                              </Badge>
-                            ) : null}
-                          </>
-                        ) : (
-                          <Badge
-                            variant="outline"
-                            className="h-4 border-amber-500/28 bg-amber-500/8 px-1.5 text-[0.56rem] text-amber-200/80"
-                          >
-                            No signals
-                          </Badge>
-                        )}
+                              ) : null}
+                            </>
+                          ) : (
+                            <Badge
+                              variant="outline"
+                              className="h-4 border-amber-500/28 bg-amber-500/8 px-1.5 text-[0.56rem] text-amber-200/80"
+                            >
+                              No signals
+                            </Badge>
+                          )}
+                          {tags.length > 0 && missingKinds.length > 0
+                            ? missingKinds.map((kind) => (
+                                <Badge
+                                  key={kind}
+                                  variant="outline"
+                                  className="h-4 border-amber-500/22 bg-amber-500/7 px-1.5 text-[0.56rem] text-amber-100/78"
+                                >
+                                  No {getTagKindLabel(kind).toLowerCase()}
+                                </Badge>
+                              ))
+                            : null}
+                        </span>
                       </span>
-                    </span>
-                  </button>
-                  <div className="flex items-center gap-1">
-                    <Button
-                      type="button"
-                      variant={isEditing ? "secondary" : "ghost"}
-                      size="icon-sm"
-                      onClick={() => startEditing(track)}
-                      title="Edit starter pick"
-                    >
-                      <Pencil className="size-3" />
-                      <span className="sr-only">Edit starter pick</span>
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon-sm"
-                      disabled={archiveMutation.isPending}
-                      onClick={() => archiveMutation.mutate(track.id)}
-                      title="Archive starter pick"
-                    >
-                      {isArchiving ? (
-                        <LoaderCircle className="size-3 animate-spin" />
-                      ) : (
-                        <Archive className="size-3" />
-                      )}
-                      <span className="sr-only">Archive starter pick</span>
-                    </Button>
-                  </div>
-                </article>
-              );
-            })}
-          </div>
-        </aside>
+                    </button>
+                    <div className="flex items-center gap-1">
+                      <Button
+                        type="button"
+                        variant={isEditing ? "secondary" : "ghost"}
+                        size="icon-sm"
+                        onClick={() => startEditing(track)}
+                        title="Edit starter pick"
+                      >
+                        <Pencil className="size-3" />
+                        <span className="sr-only">Edit starter pick</span>
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon-sm"
+                        disabled={archiveMutation.isPending}
+                        onClick={() => archiveMutation.mutate(track.id)}
+                        title="Archive starter pick"
+                      >
+                        {isArchiving ? (
+                          <LoaderCircle className="size-3 animate-spin" />
+                        ) : (
+                          <Archive className="size-3" />
+                        )}
+                        <span className="sr-only">Archive starter pick</span>
+                      </Button>
+                    </div>
+                  </article>
+                );
+              })}
+            </div>
+          </section>
+        </section>
+
       </div>
     </div>
   );

--- a/apps/web/components/who-to-follow-rail.tsx
+++ b/apps/web/components/who-to-follow-rail.tsx
@@ -9,6 +9,7 @@ import NewReviewDialog from "@/components/new-review-dialog";
 import PrefetchLink from "@/components/prefetch-link";
 import TrackCarousel from "@/components/track-carousel";
 import TrackTile from "@/components/track-tile";
+import { useSecondaryRailContent } from "@/components/secondary-rail-context";
 import { Skeleton } from "@/components/ui/skeleton";
 import UserAvatar from "@/components/user-avatar";
 import { helpFooterLinks } from "@/lib/help";
@@ -103,25 +104,31 @@ function StarterRailSkeleton() {
 export default function WhoToFollowRail({ isAuthenticated }: WhoToFollowRailProps) {
   const isDesktop = useDesktopRail();
   const pathname = usePathname();
+  const isStudioRoute = pathname?.startsWith("/studio") ?? false;
+  const customRailContent = useSecondaryRailContent();
+  const hasCustomRailContent = customRailContent !== null;
   const starterRailQueryPath = useMemo(
     () => getStarterRailQueryPath(pathname),
     [pathname],
   );
   const { data, isLoading } = useQuery({
     ...activeProfilesQueryOptions(3),
-    enabled: isDesktop,
+    enabled: isDesktop && !isStudioRoute,
   });
   const { data: starterRail, isLoading: isStarterRailLoading } = useQuery({
     queryKey: ["starter", "rail", starterRailQueryPath],
     queryFn: () => fetchJson<StarterRailResponse>(starterRailQueryPath),
-    enabled: isDesktop && isAuthenticated,
+    enabled: isDesktop && isAuthenticated && !isStudioRoute,
     staleTime: 5 * 60 * 1000,
     gcTime: 30 * 60 * 1000,
   });
   const profiles = data?.profiles ?? [];
   const visibleStarterTracks = (starterRail?.tracks ?? []).slice(0, 6);
   const showStarterRail =
-    isAuthenticated && (isStarterRailLoading || visibleStarterTracks.length > 0);
+    !hasCustomRailContent &&
+    !isStudioRoute &&
+    isAuthenticated &&
+    (isStarterRailLoading || visibleStarterTracks.length > 0);
 
   return (
     <aside
@@ -129,69 +136,77 @@ export default function WhoToFollowRail({ isAuthenticated }: WhoToFollowRailProp
       aria-label="Editorial rail"
     >
       <div className="flex h-full min-h-0 flex-col">
-        <section className="min-h-[11.25rem] space-y-3 overflow-hidden" aria-label="Writers to notice">
-          <p className="px-1 text-[12px] font-medium leading-none text-muted-foreground/70">
-            Writers to notice
-          </p>
+        {hasCustomRailContent ? (
+          <div className="min-h-0 flex-1 overflow-y-auto pr-1">
+            {customRailContent}
+          </div>
+        ) : !isStudioRoute ? (
+          <section className="min-h-[11.25rem] space-y-3 overflow-hidden" aria-label="Writers to notice">
+            <p className="px-1 text-[12px] font-medium leading-none text-muted-foreground/70">
+              Writers to notice
+            </p>
 
-          {isLoading ? (
-            <WhoToFollowRailSkeleton showHeading={false} />
-          ) : profiles.length > 0 ? (
-            <div>
-              {profiles.map((profile) => {
-                const primaryLabel = profile.display_name ?? `@${profile.username}`;
+            {isLoading ? (
+              <WhoToFollowRailSkeleton showHeading={false} />
+            ) : profiles.length > 0 ? (
+              <div>
+                {profiles.map((profile) => {
+                  const primaryLabel = profile.display_name ?? `@${profile.username}`;
 
-                return (
-                  <div
-                    key={profile.id}
-                    className="kocteau-rail-row rounded-[0.62rem] px-1 py-3"
-                  >
-                    <div className="flex items-start gap-2.5">
-                      <PrefetchLink
-                        href={`/u/${profile.username}`}
-                        className="group min-w-0 flex-1 rounded-[0.7rem] transition-colors hover:text-foreground"
-                      >
-                        <div className="flex items-start gap-2.5">
-                          <UserAvatar
-                            avatarUrl={profile.avatar_url}
-                            displayName={profile.display_name}
-                            username={profile.username}
-                            className="size-8 shrink-0 ring-1 ring-white/[0.05]"
-                            sizes="32px"
-                            initialsLength={2}
-                          />
+                  return (
+                    <div
+                      key={profile.id}
+                      className="kocteau-rail-row rounded-[0.62rem] px-1 py-3"
+                    >
+                      <div className="flex items-start gap-2.5">
+                        <PrefetchLink
+                          href={`/u/${profile.username}`}
+                          className="group min-w-0 flex-1 rounded-[0.7rem] transition-colors hover:text-foreground"
+                        >
+                          <div className="flex items-start gap-2.5">
+                            <UserAvatar
+                              avatarUrl={profile.avatar_url}
+                              displayName={profile.display_name}
+                              username={profile.username}
+                              className="size-8 shrink-0 ring-1 ring-white/[0.05]"
+                              sizes="32px"
+                              initialsLength={2}
+                            />
 
-                          <div className="min-w-0 flex-1 space-y-0.5">
-                            <p className="truncate text-[13px] font-medium text-foreground">
-                              {primaryLabel}
-                            </p>
-                            <p className="truncate text-[12px] text-muted-foreground/78">
-                              Reviewing lately
-                            </p>
+                            <div className="min-w-0 flex-1 space-y-0.5">
+                              <p className="truncate text-[13px] font-medium text-foreground">
+                                {primaryLabel}
+                              </p>
+                              <p className="truncate text-[12px] text-muted-foreground/78">
+                                Reviewing lately
+                              </p>
+                            </div>
                           </div>
-                        </div>
-                      </PrefetchLink>
+                        </PrefetchLink>
 
-                      {isAuthenticated ? (
-                        <FollowProfileButton
-                          profileId={profile.id}
-                          initialFollowing={profile.viewer_is_following}
-                          isAuthenticated
-                          size="xs"
-                          className="h-7 shrink-0 rounded-md px-2 text-[10px] !border-transparent !bg-transparent !text-foreground/88 hover:!bg-foreground/[0.055] hover:!text-foreground"
-                        />
-                      ) : null}
+                        {isAuthenticated ? (
+                          <FollowProfileButton
+                            profileId={profile.id}
+                            initialFollowing={profile.viewer_is_following}
+                            isAuthenticated
+                            size="xs"
+                            className="h-7 shrink-0 rounded-md px-2 text-[10px] !border-transparent !bg-transparent !text-foreground/88 hover:!bg-foreground/[0.055] hover:!text-foreground"
+                          />
+                        ) : null}
+                      </div>
                     </div>
-                  </div>
-                );
-              })}
-            </div>
-          ) : (
-            <div className="px-1 py-3 text-[13px] text-muted-foreground/78">
-              No writers to notice yet.
-            </div>
-          )}
-        </section>
+                  );
+                })}
+              </div>
+            ) : (
+              <div className="px-1 py-3 text-[13px] text-muted-foreground/78">
+                No writers to notice yet.
+              </div>
+            )}
+          </section>
+        ) : (
+          <div className="min-h-0 flex-1" aria-hidden="true" />
+        )}
 
         {showStarterRail ? (
           <section className="mt-6 min-h-[12.25rem] space-y-3" aria-label="Starter picks">

--- a/apps/web/lib/supabase/database.types.ts
+++ b/apps/web/lib/supabase/database.types.ts
@@ -1096,6 +1096,31 @@ export type Database = {
           likes_count: number
         }[]
       }
+      update_preference_tag: {
+        Args: {
+          p_description?: string
+          p_is_featured?: boolean
+          p_kind: Database["public"]["Enums"]["preference_kind"]
+          p_label: string
+          p_tag_id: string
+        }
+        Returns: {
+          created_at: string
+          description: string | null
+          id: string
+          is_featured: boolean
+          kind: Database["public"]["Enums"]["preference_kind"]
+          label: string
+          slug: string
+          sort_order: number
+        }
+        SetofOptions: {
+          from: "*"
+          to: "preference_tags"
+          isOneToOne: true
+          isSetofReturn: false
+        }
+      }
       upsert_preference_tag: {
         Args: {
           p_description?: string

--- a/apps/web/lib/validation/schemas.ts
+++ b/apps/web/lib/validation/schemas.ts
@@ -207,6 +207,10 @@ export const starterPreferenceTagSchema = z.object({
   is_featured: z.boolean().optional().default(true),
 });
 
+export const starterPreferenceTagUpdateSchema = starterPreferenceTagSchema.extend({
+  id: z.string().uuid("Invalid starter tag id."),
+});
+
 export const updateReviewSchema = z.object({
   review_title: optionalTrimmedString(120),
   review_body: optionalTrimmedString(2000),
@@ -288,6 +292,7 @@ export type CreateReviewInput = z.infer<typeof createReviewSchema>;
 export type StarterTrackUpsertInput = z.infer<typeof starterTrackUpsertSchema>;
 export type StarterTrackArchiveInput = z.infer<typeof starterTrackArchiveSchema>;
 export type StarterPreferenceTagInput = z.infer<typeof starterPreferenceTagSchema>;
+export type StarterPreferenceTagUpdateInput = z.infer<typeof starterPreferenceTagUpdateSchema>;
 export type UpdateReviewInput = z.infer<typeof updateReviewSchema>;
 export type CreateCommentInput = z.infer<typeof createCommentSchema>;
 export type ReviewCollectionStateInput = z.infer<typeof reviewCollectionStateSchema>;

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -303,6 +303,7 @@ Suggested issue: `feat(web): improve starter pick curation workflow`
 - Make tag assignment and archive behavior easier to trust.
 - Add lightweight visibility into tag coverage, untagged picks, and starter pick conversion once analytics events exist.
 - Do not add a broad admin dashboard in this issue.
+- Treat `era` and `format` as first-class curator signals, not hidden onboarding leftovers.
 
 Suggested labels: `feature`, `area:web`, `area:recommendations`, `needs maintainer decision`
 
@@ -311,6 +312,7 @@ Acceptance criteria:
 - Curators can seed and maintain starter picks faster.
 - Starter tags remain compatible with recommendation RPCs.
 - The UI remains quiet, editorial, and focused on the starter layer.
+- Curators can see tags with low or zero starter coverage while assigning signals.
 
 ### Starter Rail Diversity Follow-Up
 

--- a/docs/discovery-curation.md
+++ b/docs/discovery-curation.md
@@ -183,6 +183,8 @@ Priorities:
 - contextual starter pick rotation by route surface
 - client-loaded rail picks through `/api/starter/rail`
 - reviewed-track filtering inside the starter RPC
+- fuller `era` and `format` vocabularies for editorial coverage
+- curator-side tag editing without leaving Studio
 - faster tag assignment
 - clearer pick status
 - warnings for picks without signals

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -171,6 +171,10 @@ Apply `supabase/migrations/20260601195115_starter_tracks_for_surface.sql` before
 
 Use `supabase/scripts/maintenance/starter-rail-surface-check.sql` to compare several surfaces from the SQL editor. Direct SQL editor calls may not have `auth.uid()`, so validate viewer-specific taste ranking and reviewed-track filtering from the app after logging in.
 
+Apply `supabase/migrations/20260601211257_starter_tag_taxonomy.sql` when Starter Studio needs the expanded `era` and `format` vocabulary plus curator-only tag editing. This migration is additive: it upserts baseline eras/formats and adds `update_preference_tag()` without deleting existing tags.
+
+Use `supabase/scripts/maintenance/starter-tag-coverage-check.sql` to find preference tags with no active starter picks. Zero coverage is not a database error; it means the vocabulary exists before the curated catalog has caught up.
+
 The easiest way to seed starter picks is the internal route:
 
 ```text

--- a/supabase/migrations/20260601211257_starter_tag_taxonomy.sql
+++ b/supabase/migrations/20260601211257_starter_tag_taxonomy.sql
@@ -1,3 +1,13 @@
+-- Starter Studio taxonomy expansion and curator tag editing.
+--
+-- Run from the Supabase SQL editor after
+-- 20260531160852_editorial_starter_layer.sql.
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '90s';
+
 INSERT INTO public.preference_tags (
   kind,
   slug,
@@ -7,17 +17,6 @@ INSERT INTO public.preference_tags (
   sort_order
 )
 VALUES
-  ('genre', 'dream-pop', 'Dream pop', 'Weightless guitars, blurred edges, and melodic drift.', true, 10),
-  ('genre', 'trip-hop', 'Trip hop', 'Downtempo breakbeats, smoky rooms, and late-night tension.', true, 20),
-  ('genre', 'art-pop', 'Art pop', 'Pop forms bent by texture, performance, and left turns.', true, 30),
-  ('genre', 'electronic', 'Electronic', 'Synthetic rhythm, atmosphere, and club-adjacent detail.', true, 40),
-  ('genre', 'indie-rock', 'Indie rock', 'Guitars, intimate scale, and a writerly center.', true, 50),
-  ('mood', 'melancholic', 'Melancholic', 'For songs that sit with longing instead of rushing past it.', true, 110),
-  ('mood', 'nocturnal', 'Nocturnal', 'Late-night records with shadow, space, and pulse.', true, 120),
-  ('mood', 'euphoric', 'Euphoric', 'Songs that lift without turning loud for its own sake.', true, 130),
-  ('mood', 'intimate', 'Intimate', 'Close-mic detail, private-room writing, and vulnerable delivery.', true, 140),
-  ('scene', 'uk-underground', 'UK underground', 'Club mutations, pirate-radio memory, and bass pressure.', true, 210),
-  ('style', 'textural', 'Textural', 'Records where surface, grain, and atmosphere carry meaning.', true, 310),
   ('era', 'pre-1970s', 'Pre-1970s', 'Older catalog, standards, early scenes, and records that feel outside the modern cycle.', true, 380),
   ('era', '1970s', '1970s', 'Analog rooms, disco, punk, soul, dub, and early electronic edges.', true, 390),
   ('era', '1980s', '1980s', 'Drum machines, synth gloss, post-punk shadows, and pop becoming cinematic.', true, 400),
@@ -41,3 +40,83 @@ DO UPDATE SET
   description = EXCLUDED.description,
   is_featured = EXCLUDED.is_featured,
   sort_order = EXCLUDED.sort_order;
+
+DROP FUNCTION IF EXISTS public.update_preference_tag(
+  uuid,
+  public.preference_kind,
+  text,
+  text,
+  boolean
+);
+
+CREATE OR REPLACE FUNCTION public.update_preference_tag(
+  p_tag_id uuid,
+  p_kind public.preference_kind,
+  p_label text,
+  p_description text DEFAULT NULL,
+  p_is_featured boolean DEFAULT true
+)
+RETURNS public.preference_tags
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_slug text;
+  v_tag public.preference_tags%rowtype;
+BEGIN
+  IF NOT public.is_starter_curator() THEN
+    RAISE EXCEPTION 'Not allowed to edit preference tags.'
+      USING ERRCODE = '42501';
+  END IF;
+
+  v_slug := lower(
+    regexp_replace(
+      regexp_replace(coalesce(nullif(p_label, ''), ''), '[^a-zA-Z0-9]+', '-', 'g'),
+      '(^-|-$)',
+      '',
+      'g'
+    )
+  );
+
+  IF v_slug !~ '^[a-z0-9]+(?:-[a-z0-9]+)*$' THEN
+    RAISE EXCEPTION 'Preference tag label is invalid.'
+      USING ERRCODE = '22023';
+  END IF;
+
+  UPDATE public.preference_tags
+  SET
+    kind = p_kind,
+    slug = v_slug,
+    label = btrim(p_label),
+    description = nullif(btrim(coalesce(p_description, '')), ''),
+    is_featured = coalesce(p_is_featured, true)
+  WHERE id = p_tag_id
+  RETURNING * INTO v_tag;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Preference tag not found.'
+      USING ERRCODE = '02000';
+  END IF;
+
+  RETURN v_tag;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.update_preference_tag(
+  uuid,
+  public.preference_kind,
+  text,
+  text,
+  boolean
+) FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION public.update_preference_tag(
+  uuid,
+  public.preference_kind,
+  text,
+  text,
+  boolean
+) TO authenticated;
+
+COMMIT;

--- a/supabase/scripts/maintenance/starter-tag-coverage-check.sql
+++ b/supabase/scripts/maintenance/starter-tag-coverage-check.sql
@@ -1,0 +1,26 @@
+-- Starter tag coverage by active starter tracks.
+--
+-- Run from the Supabase SQL editor to find tags that exist in the vocabulary
+-- but are not attached to active starter picks yet.
+
+select
+  pt.kind,
+  pt.label,
+  pt.slug,
+  count(stt.starter_track_id) as total_starter_track_count,
+  count(stt.starter_track_id) filter (where st.is_active) as active_starter_track_count
+from public.preference_tags pt
+left join public.starter_track_tags stt
+  on stt.tag_id = pt.id
+left join public.starter_tracks st
+  on st.id = stt.starter_track_id
+group by
+  pt.id,
+  pt.kind,
+  pt.label,
+  pt.slug
+order by
+  active_starter_track_count asc,
+  total_starter_track_count asc,
+  pt.kind,
+  pt.label;


### PR DESCRIPTION
## What changed

- Expanded Starter Studio taxonomy support for `era` and `format` signals.
- Added curator-side signal editing through `/api/starter/tags`.
- Moved the selected-song preview/inspector into the secondary rail on desktop.
- Added a compact selected-song fallback for mobile.
- Updated Starter Studio coverage UI, starter catalog states, docs, seeds, and Supabase maintenance SQL.

## Why

Starter Studio needed a clearer daily curation flow: search/select in the main content, inspect/save in the secondary rail, and manage signals without leaving the page. The expanded taxonomy also gives future starter picks better editorial context for cold-start recommendations.

## Testing

- [ ] Ran `pnpm check`
- [ ] Added screenshots or a short recording for visible web UI changes
- [ ] Confirmed this does not touch auth, Supabase, recommendations, analytics, CI, or release behavior

Verified manually with:

- `pnpm --filter web lint`
- `pnpm --filter web build`
- `node --test apps/web/lib/starter/surface.test.ts apps/web/lib/recommendation-health/metrics.test.ts apps/web/lib/analytics/events.test.ts`
- `git diff --check`

Note: this PR does touch Supabase via `supabase/migrations/20260601211257_starter_tag_taxonomy.sql`.

## Changelog impact

No manual `CHANGELOG.md` edit is required. Release Please generates release notes from PR titles and squash commits.

- [x] User-facing web change
- [x] Developer experience or documentation change
- [ ] Internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Curators can now edit preference tags directly within Starter Studio.
  * Expanded era and format tag taxonomies for enhanced curation options.
  * Redesigned tag management workflow with improved inspector interface.

* **Documentation**
  * Updated curation guidance for era and format as first-class curator signals.
  * Added post-deploy verification steps for tag taxonomy migrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->