### PR TITLE
feat(web): add anti-mainstream starter candidates

### DIFF
--- a/apps/web/app/api/starter/candidates/route.ts
+++ b/apps/web/app/api/starter/candidates/route.ts
@@ -1,0 +1,179 @@
+import { NextResponse } from "next/server";
+import { requireStarterCurator } from "@/lib/curation/access";
+import {
+  getDeezerAlbumTracks,
+  getDeezerArtistAlbums,
+  getDeezerArtistTopTracks,
+  getDeezerRelatedArtists,
+  searchDeezerArtists,
+  searchDeezerTracks,
+  type DeezerArtistResult,
+  type DeezerTrackResult,
+} from "@/lib/deezer";
+import {
+  buildStarterCandidateTracks,
+  type StarterCandidateSource,
+} from "@/lib/starter/candidates";
+import { starterCandidateQuerySchema } from "@/lib/validation/schemas";
+import { validationErrorResponse } from "@/lib/validation/server";
+
+function dedupeArtists(artists: DeezerArtistResult[]) {
+  const seenArtistIds = new Set<string>();
+
+  return artists.filter((artist) => {
+    if (seenArtistIds.has(artist.id)) {
+      return false;
+    }
+
+    seenArtistIds.add(artist.id);
+    return true;
+  });
+}
+
+function dedupeTracks(tracks: DeezerTrackResult[]) {
+  const seenProviderIds = new Set<string>();
+
+  return tracks.filter((track) => {
+    if (seenProviderIds.has(track.provider_id)) {
+      return false;
+    }
+
+    seenProviderIds.add(track.provider_id);
+    return true;
+  });
+}
+
+async function getRelatedSeedTracks({
+  query,
+  limit,
+}: {
+  query: string;
+  limit: number;
+}) {
+  const seedArtists = await searchDeezerArtists(query, 2);
+  const seedArtistIds = new Set(seedArtists.map((artist) => artist.id));
+  const relatedArtistGroups = await Promise.all(
+    seedArtists.map((artist) => getDeezerRelatedArtists(artist.id, 8)),
+  );
+  const relatedArtists = dedupeArtists(relatedArtistGroups.flat())
+    .filter((artist) => !seedArtistIds.has(artist.id))
+    .slice(0, Math.max(limit, 6));
+  const trackGroups = await Promise.all(
+    relatedArtists.map((artist) => getDeezerArtistTopTracks(artist, 2)),
+  );
+
+  return {
+    seedLabel: seedArtists[0]?.name ?? query,
+    tracks: dedupeTracks(trackGroups.flat()),
+  };
+}
+
+async function getDeepCutTracks({
+  query,
+  limit,
+}: {
+  query: string;
+  limit: number;
+}) {
+  const [seedArtist] = await searchDeezerArtists(query, 1);
+
+  if (!seedArtist) {
+    return {
+      seedLabel: query,
+      tracks: await searchDeezerTracks(query, limit),
+    };
+  }
+
+  const [topTracks, albums] = await Promise.all([
+    getDeezerArtistTopTracks(seedArtist, 12),
+    getDeezerArtistAlbums(seedArtist.id, 10),
+  ]);
+  const topHitIds = new Set(topTracks.slice(0, 5).map((track) => track.provider_id));
+  const albumTracks = await Promise.all(
+    albums
+      .filter((album) => album.record_type === null || album.record_type === "album")
+      .slice(0, 5)
+      .map((album) => getDeezerAlbumTracks(album, seedArtist, 12)),
+  );
+
+  return {
+    seedLabel: seedArtist.name,
+    tracks: dedupeTracks(albumTracks.flat()).filter(
+      (track) => !topHitIds.has(track.provider_id),
+    ),
+  };
+}
+
+async function getCandidateSourceTracks({
+  mode,
+  query,
+  limit,
+}: {
+  mode: StarterCandidateSource;
+  query: string;
+  limit: number;
+}) {
+  if (mode === "deep-cut") {
+    return getDeepCutTracks({ query, limit });
+  }
+
+  return getRelatedSeedTracks({ query, limit });
+}
+
+export async function GET(req: Request) {
+  const curator = await requireStarterCurator();
+
+  if (!curator.ok) {
+    return curator.response;
+  }
+
+  const { searchParams } = new URL(req.url);
+  const parsed = starterCandidateQuerySchema.safeParse({
+    q: searchParams.get("q") ?? "",
+    mode: searchParams.get("mode") ?? undefined,
+    limit: searchParams.get("limit") ?? undefined,
+  });
+
+  if (!parsed.success) {
+    return validationErrorResponse(parsed.error, "Candidate search is invalid.");
+  }
+
+  const { q, mode, limit } = parsed.data;
+  const activeStarterResult = await curator.supabase
+    .from("starter_tracks")
+    .select("provider_id")
+    .eq("provider", "deezer")
+    .eq("is_active", true);
+
+  if (activeStarterResult.error) {
+    return NextResponse.json(
+      { error: "We could not check active starter picks." },
+      { status: 500 },
+    );
+  }
+
+  const existingProviderIds = new Set(
+    (activeStarterResult.data ?? []).flatMap((track) =>
+      track.provider_id ? [track.provider_id] : [],
+    ),
+  );
+  const sourceTracks = await getCandidateSourceTracks({
+    mode,
+    query: q,
+    limit,
+  });
+  const candidates = buildStarterCandidateTracks({
+    source: mode,
+    seedLabel: sourceTracks.seedLabel,
+    tracks: sourceTracks.tracks,
+    existingProviderIds,
+    limit,
+  });
+
+  return NextResponse.json({
+    mode,
+    query: q,
+    seed_label: sourceTracks.seedLabel,
+    tracks: candidates,
+  });
+}

--- a/apps/web/components/starter-studio-client.tsx
+++ b/apps/web/components/starter-studio-client.tsx
@@ -9,6 +9,7 @@ import {
   Pencil,
   Plus,
   Search,
+  Sparkles,
   Tags,
   X,
 } from "@/components/ui/icons";
@@ -27,9 +28,11 @@ import {
   preferenceKindOrder,
   type PreferenceKind,
 } from "@/lib/taste";
+import type { StarterCandidateSource } from "@/lib/starter/candidates";
 import { cn } from "@/lib/utils";
 import { fetchJson } from "@/queries/http";
 import {
+  starterCandidatesQueryOptions,
   starterCuratorTracksQueryOptions,
   starterKeys,
   type StarterPreferenceTag,
@@ -73,6 +76,19 @@ const catalogFilters = [
   { value: "ready", label: "Ready" },
   { value: "featured", label: "Featured" },
 ] as const satisfies readonly { value: CatalogFilter; label: string }[];
+
+const candidateModes = [
+  { value: "related-seed", label: "Related" },
+  { value: "deep-cut", label: "Deep cuts" },
+] as const satisfies readonly { value: StarterCandidateSource; label: string }[];
+
+const candidateTierLabels: Record<string, string> = {
+  emerging: "Emerging",
+  undercovered: "Undercovered",
+  familiar: "Familiar",
+  "deep-cut": "Deep cut",
+  obvious: "Obvious",
+};
 
 type TagCoverage = {
   tag: StarterPreferenceTag;
@@ -177,6 +193,12 @@ export default function StarterStudioClient() {
   const queryClient = useQueryClient();
   const { setContent: setSecondaryRailContent } = useSecondaryRail();
   const [query, setQuery] = useState("");
+  const [candidateQuery, setCandidateQuery] = useState("");
+  const [candidateMode, setCandidateMode] =
+    useState<StarterCandidateSource>("related-seed");
+  const [dismissedCandidateKeys, setDismissedCandidateKeys] = useState<Set<string>>(
+    () => new Set(),
+  );
   const [prompt, setPrompt] = useState(defaultPrompt);
   const [editorialNote, setEditorialNote] = useState("");
   const [featured, setFeatured] = useState(true);
@@ -195,7 +217,17 @@ export default function StarterStudioClient() {
   const [editingTrack, setEditingTrack] =
     useState<StarterTrackWithTags | null>(null);
   const normalizedQuery = query.trim();
+  const normalizedCandidateQuery = candidateQuery.trim();
+  const candidateDismissalScope = `${candidateMode}:${normalizedCandidateQuery.toLowerCase()}`;
   const starterTracksQuery = useQuery(starterCuratorTracksQueryOptions());
+  const candidateTracksQuery = useQuery({
+    ...starterCandidatesQueryOptions({
+      mode: candidateMode,
+      query: normalizedCandidateQuery,
+      limit: 8,
+    }),
+    enabled: normalizedCandidateQuery.length >= 2,
+  });
   const {
     data: searchResults,
     isFetching: searchFetching,
@@ -215,6 +247,20 @@ export default function StarterStudioClient() {
   const existingProviderIds = useMemo(
     () => new Set(starterTracks.map((track) => track.provider_id)),
     [starterTracks],
+  );
+  const candidateResults = useMemo(
+    () =>
+      (candidateTracksQuery.data?.tracks ?? []).filter(
+        (track) =>
+          !dismissedCandidateKeys.has(`${candidateDismissalScope}:${track.provider_id}`) &&
+          !existingProviderIds.has(track.provider_id),
+      ),
+    [
+      candidateDismissalScope,
+      candidateTracksQuery.data,
+      dismissedCandidateKeys,
+      existingProviderIds,
+    ],
   );
   const selectedTags = useMemo(
     () => availableTags.filter((tag) => selectedTagIds.has(tag.id)),
@@ -1266,6 +1312,164 @@ export default function StarterStudioClient() {
 
       <div className="min-h-0">
         <section className="min-w-0 space-y-5">
+          <section className="space-y-3 rounded-xl border border-border/28 bg-card/18 p-3">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+              <div className="space-y-1">
+                <div className="flex items-center gap-2">
+                  <Sparkles className="size-4 text-muted-foreground" />
+                  <h2 className="text-sm font-semibold text-foreground">
+                    Candidate finder
+                  </h2>
+                </div>
+                <p className="text-xs leading-5 text-muted-foreground">
+                  Deezer suggests, Kocteau filters, you curate.
+                </p>
+              </div>
+              {candidateTracksQuery.isFetching ? (
+                <LoaderCircle className="size-4 animate-spin text-muted-foreground" />
+              ) : candidateTracksQuery.data?.seed_label ? (
+                <span className="rounded-md border border-border/28 bg-background/24 px-2 py-1 text-xs text-muted-foreground">
+                  Seed: {candidateTracksQuery.data.seed_label}
+                </span>
+              ) : null}
+            </div>
+
+            <div className="grid gap-2 md:grid-cols-[minmax(0,1fr)_auto]">
+              <div className="relative">
+                <Search className="pointer-events-none absolute top-1/2 left-3 size-3.5 -translate-y-1/2 text-muted-foreground" />
+                <Input
+                  value={candidateQuery}
+                  onChange={(event) => setCandidateQuery(event.target.value)}
+                  placeholder="Seed artist or scene"
+                  className="h-9 rounded-lg bg-background/44 pl-9 text-sm"
+                />
+              </div>
+              <div className="flex gap-1.5">
+                {candidateModes.map((mode) => {
+                  const isActive = candidateMode === mode.value;
+
+                  return (
+                    <button
+                      key={mode.value}
+                      type="button"
+                      onClick={() => setCandidateMode(mode.value)}
+                      className={cn(
+                        "h-9 rounded-md border px-3 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30",
+                        isActive
+                          ? "border-foreground/30 bg-foreground/[0.075] text-foreground"
+                          : "border-border/32 bg-background/24 text-muted-foreground hover:text-foreground",
+                      )}
+                    >
+                      {mode.label}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            {candidateTracksQuery.error ? (
+              <p className="rounded-lg border border-destructive/34 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                {candidateTracksQuery.error.message}
+              </p>
+            ) : null}
+
+            {normalizedCandidateQuery.length < 2 ? (
+              <p className="rounded-lg border border-border/24 bg-background/24 px-3 py-5 text-center text-sm text-muted-foreground">
+                Try a seed artist like Cocteau Twins, Broadcast, or Michael Jackson.
+              </p>
+            ) : null}
+
+            {normalizedCandidateQuery.length >= 2 &&
+            !candidateTracksQuery.isFetching &&
+            candidateResults.length === 0 ? (
+              <p className="rounded-lg border border-border/24 bg-background/24 px-3 py-5 text-center text-sm text-muted-foreground">
+                No candidates survived the filter. Try another seed or switch modes.
+              </p>
+            ) : null}
+
+            {candidateResults.length > 0 ? (
+              <div className="grid gap-2 xl:grid-cols-2">
+                {candidateResults.map((track) => {
+                  const isSelected =
+                    selectedDraftTrack?.provider_id === track.provider_id ||
+                    editingTrack?.provider_id === track.provider_id;
+
+                  return (
+                    <article
+                      key={track.candidate_id}
+                      className={cn(
+                        "grid min-h-[5.75rem] grid-cols-[minmax(0,1fr)_auto] gap-3 rounded-lg border border-border/28 bg-background/24 p-2.5 transition-colors",
+                        isSelected && "border-foreground/34 bg-foreground/[0.055]",
+                      )}
+                    >
+                      <button
+                        type="button"
+                        onClick={() => selectSearchTrack(track)}
+                        className="grid min-w-0 grid-cols-[3.5rem_minmax(0,1fr)] items-start gap-3 rounded-md text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30"
+                      >
+                        <TrackCover src={track.cover_url} title={track.title} />
+                        <span className="min-w-0 space-y-1">
+                          <span className="block truncate text-sm font-medium text-foreground">
+                            {track.title}
+                          </span>
+                          <span className="block truncate text-xs text-muted-foreground">
+                            {track.artist_name ?? "Unknown artist"}
+                          </span>
+                          <span className="flex flex-wrap gap-1">
+                            <Badge
+                              variant="outline"
+                              className="h-4 border-border/42 px-1.5 text-[0.56rem] text-muted-foreground"
+                            >
+                              {track.source_label}
+                            </Badge>
+                            <Badge
+                              variant="outline"
+                              className="h-4 border-border/42 px-1.5 text-[0.56rem] text-muted-foreground"
+                            >
+                              {candidateTierLabels[track.tier] ?? track.tier}
+                            </Badge>
+                          </span>
+                          <span className="block line-clamp-2 text-xs leading-5 text-muted-foreground">
+                            {track.reason}
+                          </span>
+                        </span>
+                      </button>
+                      <div className="flex flex-col gap-1.5">
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant={isSelected ? "secondary" : "outline"}
+                          disabled={addMutation.isPending}
+                          onClick={() => selectSearchTrack(track)}
+                          className="h-8 gap-1.5"
+                        >
+                          {isSelected ? <Check className="size-3" /> : <Plus className="size-3" />}
+                          {isSelected ? "Selected" : "Select"}
+                        </Button>
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="ghost"
+                          onClick={() =>
+                            setDismissedCandidateKeys((current) =>
+                              new Set(current).add(
+                                `${candidateDismissalScope}:${track.provider_id}`,
+                              ),
+                            )
+                          }
+                          className="h-8 gap-1.5 text-muted-foreground"
+                        >
+                          <X className="size-3" />
+                          Skip
+                        </Button>
+                      </div>
+                    </article>
+                  );
+                })}
+              </div>
+            ) : null}
+          </section>
+
           <section className="space-y-3">
             <div className="flex items-center justify-between gap-3">
               <h2 className="text-sm font-semibold text-foreground">Deezer results</h2>

--- a/apps/web/lib/deezer.ts
+++ b/apps/web/lib/deezer.ts
@@ -4,16 +4,40 @@ export type DeezerTrackResult = {
   type: "track";
   title: string;
   artist_name: string | null;
+  artist_id: string | null;
+  artist_fan_count: number | null;
   cover_url: string | null;
   deezer_url: string | null;
+  rank: number | null;
+};
+
+export type DeezerArtistResult = {
+  provider: "deezer";
+  id: string;
+  name: string;
+  fan_count: number | null;
+  picture_url: string | null;
+  deezer_url: string | null;
+};
+
+export type DeezerAlbumResult = {
+  provider: "deezer";
+  id: string;
+  title: string;
+  cover_url: string | null;
+  record_type: string | null;
+  release_date: string | null;
 };
 
 type DeezerTrackApiItem = {
   id: number | string;
   title: string;
   link?: string | null;
+  rank?: number | null;
   artist?: {
+    id?: number | string | null;
     name?: string | null;
+    nb_fan?: number | null;
   } | null;
   album?: {
     cover_medium?: string | null;
@@ -25,15 +49,71 @@ type DeezerSearchResponse = {
   data?: DeezerTrackApiItem[];
 };
 
-function mapDeezerTrack(item: DeezerTrackApiItem): DeezerTrackResult {
+type DeezerArtistApiItem = {
+  id: number | string;
+  name?: string | null;
+  nb_fan?: number | null;
+  picture_medium?: string | null;
+  picture?: string | null;
+  link?: string | null;
+};
+
+type DeezerArtistSearchResponse = {
+  data?: DeezerArtistApiItem[];
+};
+
+type DeezerRelatedArtistsResponse = {
+  data?: DeezerArtistApiItem[];
+};
+
+type DeezerArtistTopTracksResponse = {
+  data?: DeezerTrackApiItem[];
+};
+
+type DeezerAlbumApiItem = {
+  id: number | string;
+  title?: string | null;
+  cover_medium?: string | null;
+  cover?: string | null;
+  record_type?: string | null;
+  release_date?: string | null;
+};
+
+type DeezerArtistAlbumsResponse = {
+  data?: DeezerAlbumApiItem[];
+};
+
+type DeezerAlbumTracksResponse = {
+  data?: DeezerTrackApiItem[];
+};
+
+type DeezerTrackMapOptions = {
+  artist_id?: string | null;
+  artist_name?: string | null;
+  artist_fan_count?: number | null;
+  cover_url?: string | null;
+};
+
+function getOptionalNumber(value: number | null | undefined) {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function mapDeezerTrack(
+  item: DeezerTrackApiItem,
+  options: DeezerTrackMapOptions = {},
+): DeezerTrackResult {
   return {
     provider: "deezer",
     provider_id: String(item.id),
     type: "track",
     title: item.title,
-    artist_name: item.artist?.name ?? null,
-    cover_url: item.album?.cover_medium ?? item.album?.cover ?? null,
+    artist_name: item.artist?.name ?? options.artist_name ?? null,
+    artist_id: options.artist_id ?? (item.artist?.id ? String(item.artist.id) : null),
+    artist_fan_count:
+      options.artist_fan_count ?? getOptionalNumber(item.artist?.nb_fan),
+    cover_url: item.album?.cover_medium ?? item.album?.cover ?? options.cover_url ?? null,
     deezer_url: item.link ?? null,
+    rank: getOptionalNumber(item.rank),
   };
 }
 
@@ -48,7 +128,172 @@ export async function searchDeezerTracks(query: string, limit = 12): Promise<Dee
   }
 
   const json = (await response.json()) as DeezerSearchResponse;
-  return (json.data ?? []).map(mapDeezerTrack);
+  return (json.data ?? []).map((item) => mapDeezerTrack(item));
+}
+
+function mapDeezerArtist(item: DeezerArtistApiItem): DeezerArtistResult | null {
+  if (!item.id || !item.name) {
+    return null;
+  }
+
+  return {
+    provider: "deezer",
+    id: String(item.id),
+    name: item.name,
+    fan_count: getOptionalNumber(item.nb_fan),
+    picture_url: item.picture_medium ?? item.picture ?? null,
+    deezer_url: item.link ?? null,
+  };
+}
+
+export async function searchDeezerArtists(
+  query: string,
+  limit = 3,
+): Promise<DeezerArtistResult[]> {
+  const url = `https://api.deezer.com/search/artist?q=${encodeURIComponent(query)}&limit=${limit}`;
+  const response = await fetch(url, {
+    next: { revalidate: 300 },
+  });
+
+  if (!response.ok) {
+    throw new Error("Deezer artist request failed");
+  }
+
+  const json = (await response.json()) as DeezerArtistSearchResponse;
+  return (json.data ?? []).flatMap((item) => {
+    const artist = mapDeezerArtist(item);
+    return artist ? [artist] : [];
+  });
+}
+
+function mapDeezerAlbum(item: DeezerAlbumApiItem): DeezerAlbumResult | null {
+  if (!item.id || !item.title) {
+    return null;
+  }
+
+  return {
+    provider: "deezer",
+    id: String(item.id),
+    title: item.title,
+    cover_url: item.cover_medium ?? item.cover ?? null,
+    record_type: item.record_type ?? null,
+    release_date: item.release_date ?? null,
+  };
+}
+
+export async function getDeezerRelatedArtists(
+  artistId: string,
+  limit = 8,
+): Promise<DeezerArtistResult[]> {
+  const url = `https://api.deezer.com/artist/${encodeURIComponent(artistId)}/related?limit=${limit}`;
+  const response = await fetch(url, {
+    next: { revalidate: 300 },
+  });
+
+  if (!response.ok) {
+    return [];
+  }
+
+  const json = (await response.json()) as DeezerRelatedArtistsResponse & {
+    error?: unknown;
+  };
+
+  if ("error" in json) {
+    return [];
+  }
+
+  return (json.data ?? []).flatMap((item) => {
+    const artist = mapDeezerArtist(item);
+    return artist ? [artist] : [];
+  });
+}
+
+export async function getDeezerArtistAlbums(
+  artistId: string,
+  limit = 8,
+): Promise<DeezerAlbumResult[]> {
+  const url = `https://api.deezer.com/artist/${encodeURIComponent(artistId)}/albums?limit=${limit}`;
+  const response = await fetch(url, {
+    next: { revalidate: 300 },
+  });
+
+  if (!response.ok) {
+    return [];
+  }
+
+  const json = (await response.json()) as DeezerArtistAlbumsResponse & {
+    error?: unknown;
+  };
+
+  if ("error" in json) {
+    return [];
+  }
+
+  return (json.data ?? []).flatMap((item) => {
+    const album = mapDeezerAlbum(item);
+    return album ? [album] : [];
+  });
+}
+
+export async function getDeezerArtistTopTracks(
+  artist: Pick<DeezerArtistResult, "id" | "fan_count">,
+  limit = 6,
+): Promise<DeezerTrackResult[]> {
+  const url = `https://api.deezer.com/artist/${encodeURIComponent(artist.id)}/top?limit=${limit}`;
+  const response = await fetch(url, {
+    next: { revalidate: 300 },
+  });
+
+  if (!response.ok) {
+    return [];
+  }
+
+  const json = (await response.json()) as DeezerArtistTopTracksResponse & {
+    error?: unknown;
+  };
+
+  if ("error" in json) {
+    return [];
+  }
+
+  return (json.data ?? []).map((item) =>
+    mapDeezerTrack(item, {
+      artist_id: artist.id,
+      artist_fan_count: artist.fan_count,
+    }),
+  );
+}
+
+export async function getDeezerAlbumTracks(
+  album: Pick<DeezerAlbumResult, "id" | "cover_url">,
+  artist: Pick<DeezerArtistResult, "id" | "name" | "fan_count">,
+  limit = 12,
+): Promise<DeezerTrackResult[]> {
+  const url = `https://api.deezer.com/album/${encodeURIComponent(album.id)}/tracks?limit=${limit}`;
+  const response = await fetch(url, {
+    next: { revalidate: 300 },
+  });
+
+  if (!response.ok) {
+    return [];
+  }
+
+  const json = (await response.json()) as DeezerAlbumTracksResponse & {
+    error?: unknown;
+  };
+
+  if ("error" in json) {
+    return [];
+  }
+
+  return (json.data ?? []).map((item) =>
+    mapDeezerTrack(item, {
+      artist_id: artist.id,
+      artist_name: artist.name,
+      artist_fan_count: artist.fan_count,
+      cover_url: album.cover_url,
+    }),
+  );
 }
 
 export async function getDeezerTrack(providerId: string): Promise<DeezerTrackResult | null> {

--- a/apps/web/lib/starter/candidates.test.ts
+++ b/apps/web/lib/starter/candidates.test.ts
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  buildStarterCandidateTracks,
+  getStarterCandidateTier,
+} from "./candidates.ts";
+
+const baseTrack = {
+  provider: "deezer" as const,
+  provider_id: "track-1",
+  type: "track" as const,
+  title: "Sea Signal",
+  artist_name: "Low Tide",
+  cover_url: "https://example.com/cover.jpg",
+  deezer_url: "https://www.deezer.com/track/1",
+  rank: 180_000,
+  artist_id: "artist-1",
+  artist_fan_count: 12_000,
+};
+
+describe("starter candidate helpers", () => {
+  it("filters obvious mainstream tracks from related seed mode", () => {
+    const candidates = buildStarterCandidateTracks({
+      source: "related-seed",
+      seedLabel: "Cocteau Twins",
+      tracks: [
+        baseTrack,
+        {
+          ...baseTrack,
+          provider_id: "track-2",
+          title: "Arena Single",
+          artist_name: "Chart Giant",
+          rank: 940_000,
+          artist_fan_count: 2_300_000,
+        },
+      ],
+      existingProviderIds: new Set(),
+    });
+
+    assert.deepEqual(
+      candidates.map((candidate) => candidate.provider_id),
+      ["track-1"],
+    );
+    assert.equal(candidates[0]?.tier, "emerging");
+    assert.match(candidates[0]?.reason ?? "", /related to Cocteau Twins/i);
+  });
+
+  it("allows famous artists when the track is framed as a deep cut", () => {
+    const candidates = buildStarterCandidateTracks({
+      source: "deep-cut",
+      seedLabel: "Michael Jackson",
+      tracks: [
+        {
+          ...baseTrack,
+          provider_id: "track-3",
+          title: "Quiet Album Track",
+          artist_name: "Michael Jackson",
+          rank: 145_000,
+          artist_fan_count: 5_000_000,
+        },
+      ],
+      existingProviderIds: new Set(),
+    });
+
+    assert.equal(candidates.length, 1);
+    assert.equal(candidates[0]?.tier, "deep-cut");
+    assert.equal(candidates[0]?.source_label, "Deep cut");
+    assert.match(candidates[0]?.reason ?? "", /less obvious/i);
+  });
+
+  it("deduplicates candidates and excludes active starter picks", () => {
+    const candidates = buildStarterCandidateTracks({
+      source: "related-seed",
+      seedLabel: "Slowdive",
+      tracks: [
+        baseTrack,
+        { ...baseTrack, provider_id: "track-1", title: "Duplicate" },
+        { ...baseTrack, provider_id: "track-4", title: "Already Curated" },
+      ],
+      existingProviderIds: new Set(["track-4"]),
+    });
+
+    assert.deepEqual(
+      candidates.map((candidate) => candidate.provider_id),
+      ["track-1"],
+    );
+  });
+
+  it("uses Deezer rank and artist fan count to describe the candidate tier", () => {
+    assert.equal(
+      getStarterCandidateTier({ rank: 85_000, artist_fan_count: 4_000 }),
+      "emerging",
+    );
+    assert.equal(
+      getStarterCandidateTier({ rank: 390_000, artist_fan_count: 120_000 }),
+      "undercovered",
+    );
+    assert.equal(
+      getStarterCandidateTier({ rank: 950_000, artist_fan_count: 3_000_000 }),
+      "obvious",
+    );
+  });
+});

--- a/apps/web/lib/starter/candidates.ts
+++ b/apps/web/lib/starter/candidates.ts
@@ -1,0 +1,199 @@
+export type StarterCandidateSource = "related-seed" | "deep-cut";
+
+export type StarterCandidateTier =
+  | "emerging"
+  | "undercovered"
+  | "familiar"
+  | "deep-cut"
+  | "obvious";
+
+export type StarterCandidateInputTrack = {
+  provider: "deezer";
+  provider_id: string;
+  type: "track";
+  title: string;
+  artist_name: string | null;
+  cover_url: string | null;
+  deezer_url: string | null;
+  rank: number | null;
+  artist_id: string | null;
+  artist_fan_count: number | null;
+};
+
+export type StarterCandidateTrack = StarterCandidateInputTrack & {
+  candidate_id: string;
+  source: StarterCandidateSource;
+  source_label: string;
+  seed_label: string;
+  tier: StarterCandidateTier;
+  reason: string;
+  score: number;
+  entity_id: null;
+};
+
+type StarterCandidateOptions = {
+  source: StarterCandidateSource;
+  seedLabel: string;
+  tracks: StarterCandidateInputTrack[];
+  existingProviderIds: Set<string>;
+  limit?: number;
+};
+
+type CandidatePopularity = {
+  rank: number | null;
+  artist_fan_count: number | null;
+};
+
+const obviousRankFloor = 900_000;
+const obviousFanFloor = 750_000;
+const deepCutRankCeiling = obviousRankFloor - 1;
+
+function getNumber(value: number | null | undefined) {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+export function getStarterCandidateTier({
+  rank,
+  artist_fan_count,
+}: CandidatePopularity): StarterCandidateTier {
+  const safeRank = getNumber(rank);
+  const safeFanCount = getNumber(artist_fan_count);
+
+  if (
+    safeRank !== null &&
+    safeFanCount !== null &&
+    safeRank >= obviousRankFloor &&
+    safeFanCount >= obviousFanFloor
+  ) {
+    return "obvious";
+  }
+
+  if (
+    (safeFanCount === null || safeFanCount <= 50_000) &&
+    (safeRank === null || safeRank <= 250_000)
+  ) {
+    return "emerging";
+  }
+
+  if (
+    (safeFanCount === null || safeFanCount <= 250_000) &&
+    (safeRank === null || safeRank <= 450_000)
+  ) {
+    return "undercovered";
+  }
+
+  return "familiar";
+}
+
+function getSourceLabel(source: StarterCandidateSource) {
+  return source === "deep-cut" ? "Deep cut" : "Related seed";
+}
+
+function getCandidateReason({
+  source,
+  seedLabel,
+  tier,
+}: {
+  source: StarterCandidateSource;
+  seedLabel: string;
+  tier: StarterCandidateTier;
+}) {
+  if (source === "deep-cut") {
+    return `A less obvious ${seedLabel} pick for deep-cut curation.`;
+  }
+
+  if (tier === "emerging") {
+    return `Related to ${seedLabel}, with a quieter artist profile.`;
+  }
+
+  return `Related to ${seedLabel}, but still outside the most obvious chart lane.`;
+}
+
+function getCandidateScore(track: StarterCandidateInputTrack, tier: StarterCandidateTier) {
+  const rank = getNumber(track.rank);
+  const fanCount = getNumber(track.artist_fan_count);
+  let score = 50;
+
+  if (tier === "emerging") {
+    score += 35;
+  } else if (tier === "undercovered") {
+    score += 24;
+  } else if (tier === "deep-cut") {
+    score += 18;
+  } else if (tier === "obvious") {
+    score -= 40;
+  }
+
+  if (rank !== null) {
+    if (rank <= 150_000) {
+      score += 12;
+    } else if (rank >= 750_000) {
+      score -= 20;
+    }
+  }
+
+  if (fanCount !== null) {
+    if (fanCount <= 25_000) {
+      score += 12;
+    } else if (fanCount >= 1_000_000) {
+      score -= 18;
+    }
+  }
+
+  return score;
+}
+
+function isUsableForSource(track: StarterCandidateInputTrack, source: StarterCandidateSource) {
+  const tier = getStarterCandidateTier(track);
+
+  if (source === "related-seed") {
+    return tier !== "obvious";
+  }
+
+  const rank = getNumber(track.rank);
+  return rank === null || rank <= deepCutRankCeiling;
+}
+
+export function buildStarterCandidateTracks({
+  source,
+  seedLabel,
+  tracks,
+  existingProviderIds,
+  limit = 12,
+}: StarterCandidateOptions): StarterCandidateTrack[] {
+  const seenProviderIds = new Set<string>();
+  const sourceLabel = getSourceLabel(source);
+
+  return tracks
+    .filter((track) => {
+      if (existingProviderIds.has(track.provider_id)) {
+        return false;
+      }
+
+      if (seenProviderIds.has(track.provider_id)) {
+        return false;
+      }
+
+      seenProviderIds.add(track.provider_id);
+      return isUsableForSource(track, source);
+    })
+    .map((track) => {
+      const baseTier = getStarterCandidateTier(track);
+      const tier = source === "deep-cut" ? "deep-cut" : baseTier;
+      const score = getCandidateScore(track, tier);
+
+      return {
+        ...track,
+        candidate_id: `${source}:${track.provider_id}`,
+        source,
+        source_label: sourceLabel,
+        seed_label: seedLabel,
+        tier,
+        reason: getCandidateReason({ source, seedLabel, tier }),
+        score,
+        entity_id: null,
+      };
+    })
+    .sort((left, right) => right.score - left.score)
+    .slice(0, limit);
+}

--- a/apps/web/lib/validation/schemas.ts
+++ b/apps/web/lib/validation/schemas.ts
@@ -82,6 +82,16 @@ export const deezerSearchQuerySchema = z.object({
   type: z.enum(searchableEntityTypes).optional().default("track"),
 });
 
+export const starterCandidateQuerySchema = z.object({
+  q: z
+    .string()
+    .trim()
+    .min(2, "Use at least 2 characters.")
+    .max(80, "Search queries can be up to 80 characters."),
+  mode: z.enum(["related-seed", "deep-cut"]).optional().default("related-seed"),
+  limit: z.coerce.number().int().min(1).max(12).optional().default(8),
+});
+
 export const loginSchema = z.object({
   email: z.string().trim().email("Enter a valid email address.").transform((value) => value.toLowerCase()),
   password: z.string().min(1, "Enter your password."),
@@ -293,6 +303,7 @@ export type StarterTrackUpsertInput = z.infer<typeof starterTrackUpsertSchema>;
 export type StarterTrackArchiveInput = z.infer<typeof starterTrackArchiveSchema>;
 export type StarterPreferenceTagInput = z.infer<typeof starterPreferenceTagSchema>;
 export type StarterPreferenceTagUpdateInput = z.infer<typeof starterPreferenceTagUpdateSchema>;
+export type StarterCandidateQueryInput = z.infer<typeof starterCandidateQuerySchema>;
 export type UpdateReviewInput = z.infer<typeof updateReviewSchema>;
 export type CreateCommentInput = z.infer<typeof createCommentSchema>;
 export type ReviewCollectionStateInput = z.infer<typeof reviewCollectionStateSchema>;

--- a/apps/web/queries/starter.ts
+++ b/apps/web/queries/starter.ts
@@ -1,4 +1,8 @@
 import { queryOptions } from "@tanstack/react-query";
+import type {
+  StarterCandidateSource,
+  StarterCandidateTrack,
+} from "@/lib/starter/candidates";
 import type { Tables } from "@/lib/supabase/database.types";
 import { fetchJson } from "@/queries/http";
 
@@ -19,9 +23,18 @@ export type StarterStudioData = {
   tags: StarterPreferenceTag[];
 };
 
+export type StarterCandidateData = {
+  mode: StarterCandidateSource;
+  query: string;
+  seed_label: string;
+  tracks: StarterCandidateTrack[];
+};
+
 export const starterKeys = {
   all: ["starter"] as const,
   curatorTracks: () => ["starter", "curator-tracks"] as const,
+  candidates: (mode: StarterCandidateSource, query: string, limit: number) =>
+    ["starter", "candidates", mode, query, limit] as const,
 };
 
 export function starterCuratorTracksQueryOptions() {
@@ -29,6 +42,30 @@ export function starterCuratorTracksQueryOptions() {
     queryKey: starterKeys.curatorTracks(),
     queryFn: () => fetchJson<StarterStudioData>("/api/starter/tracks"),
     staleTime: 30_000,
+    gcTime: 5 * 60_000,
+  });
+}
+
+export function starterCandidatesQueryOptions({
+  mode,
+  query,
+  limit = 8,
+}: {
+  mode: StarterCandidateSource;
+  query: string;
+  limit?: number;
+}) {
+  const params = new URLSearchParams({
+    mode,
+    q: query,
+    limit: String(limit),
+  });
+
+  return queryOptions({
+    queryKey: starterKeys.candidates(mode, query, limit),
+    queryFn: () =>
+      fetchJson<StarterCandidateData>(`/api/starter/candidates?${params.toString()}`),
+    staleTime: 60_000,
     gcTime: 5 * 60_000,
   });
 }

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -25,6 +25,20 @@ For discovery, curation, recommendation, and analytics work, start with `docs/di
 - `blocked`: cannot move until another task lands.
 - `done`: shipped or no longer relevant.
 
+## Discovery Work Already Completed
+
+These items should not be reopened unless a maintainer finds a regression or starts a focused follow-up.
+
+| Work | State | Notes |
+| --- | --- | --- |
+| Discovery signal contract | done | Event names, metadata rules, and validation are documented for the hybrid recommendation loop. |
+| Recommendation health V1 | done | Maintainers have a safe health surface and aggregate checks without exposing raw analytics rows. |
+| Contextual starter rail | done | Starter picks can vary by route surface and load outside the main layout render. |
+| Starter tag taxonomy | done | `era` and `format` are first-class starter signals alongside genre, mood, scene, and style. |
+| Starter Studio tag editing | done | Curators can create and edit starter signals without leaving Studio. |
+| Starter Studio selected-track inspector | done | The secondary rail focuses on the selected song instead of generic modules while curating. |
+| Starter Studio workflow polish | in review | Catalog filters, readiness labels, editorial notes, and archive confirmation live in `feat/starter-studio-workflow-polish`. |
+
 ## Near-Term Priorities
 
 These are the next useful moves after enabling public contribution.
@@ -153,6 +167,8 @@ Acceptance criteria:
 
 Suggested issue: `fix(web): clarify starter studio empty states and helper copy`
 
+State: `done` for the core starter workflow. Reopen only as a narrow visual QA issue if screenshots reveal confusing empty states after the candidate finder lands.
+
 - Improve `/studio/starter` copy for empty search, no starter picks, picks without tags, and archive confirmation language.
 - Preserve the current curation workflow and API behavior.
 - Keep the tone editorial and concise.
@@ -258,6 +274,8 @@ These can be public issues, but they should require maintainer review and carefu
 
 Suggested issue: `feat(web): add lightweight recommendation health checks for maintainers`
 
+State: `done` for V1. Future work should use real traffic snapshots before changing recommendation ranking.
+
 - Track fallback rate, action rate, read-depth rate, and starter-pick usage.
 - Prefer simple SQL/admin notes before building a dashboard.
 - Use the signal contract in `docs/discovery-curation.md` before adding new events.
@@ -281,6 +299,8 @@ Acceptance criteria:
 
 Suggested issue: `feat(web): implement the discovery analytics signal contract`
 
+State: `done` for the initial contract and validation layer. Additional instrumentation should be added only when it answers a specific product question.
+
 - Add the first instrumentation pass for the events defined in `docs/discovery-curation.md`.
 - Start with For You load, recommendation fallback, review impression/open, entity open, and starter pick actions.
 - Keep analytics best-effort so product interactions never fail because an event fails.
@@ -299,6 +319,8 @@ Acceptance criteria:
 
 Suggested issue: `feat(web): improve starter pick curation workflow`
 
+State: `done` for the current Studio V2 foundation. Keep future work narrow: candidate discovery, visual QA, or measured rail diversity.
+
 - Improve `/studio/starter` ergonomics for the official curator.
 - Make tag assignment and archive behavior easier to trust.
 - Add lightweight visibility into tag coverage, untagged picks, and starter pick conversion once analytics events exist.
@@ -313,6 +335,34 @@ Acceptance criteria:
 - Starter tags remain compatible with recommendation RPCs.
 - The UI remains quiet, editorial, and focused on the starter layer.
 - Curators can see tags with low or zero starter coverage while assigning signals.
+
+### Anti-Mainstream Candidate Finder V0
+
+Suggested issue: `feat(web): add anti-mainstream Deezer candidate finder`
+
+State: `ready`, maintainer-led. This is the next starter curation phase.
+
+- Add a curator-only `/api/starter/candidates` route.
+- Use Deezer related artists and artist top tracks as candidate sources.
+- Prefer emerging or undercovered artists for related-seed mode.
+- Allow famous artists only through a deep-cut mode where the candidate track is less obvious.
+- Exclude tracks already present in active starter picks.
+- Return an explainable reason and anti-mainstream tier with every candidate.
+- In `/studio/starter`, show candidates near the existing Deezer search flow.
+- Let the curator select a candidate into the existing starter draft or skip it locally.
+- Do not write candidates to the database in V0.
+- Do not import charts or auto-create starter picks.
+
+Suggested labels: `feature`, `area:web`, `area:recommendations`, `needs maintainer decision`
+
+Acceptance criteria:
+
+- The finder works with a seed like `Cocteau Twins` or `Michael Jackson`.
+- Related mode avoids obvious chart-first recommendations.
+- Deep-cut mode treats known artists as valid only when the track is framed as a less obvious pick.
+- Candidate cards include track identity, cover, reason, tier, and Select/Skip actions.
+- The existing starter pick save flow remains the only database write.
+- Focused tests cover scoring, deduplication, existing starter exclusions, and deep-cut labeling.
 
 ### Starter Rail Diversity Follow-Up
 
@@ -334,6 +384,8 @@ Acceptance criteria:
 ### Editorial Candidate Queue
 
 Suggested issue: `feat(web): design editorial candidate queue for starter picks`
+
+State: `blocked` until the anti-mainstream candidate finder proves the curator flow is useful.
 
 - Add a maintainer-reviewed design for `editorial_candidates` before implementation.
 - Candidate reasons may include review velocity, bookmark growth, read depth, trusted-user activity, emerging tags, and undercovered taste areas.
@@ -405,6 +457,18 @@ Suggested RFC: `rfc: define a manual taste graph for entity relationships`
 - Focus on explainability for track pages, Explore, and future For You tuning.
 
 Suggested labels: `rfc`, `area:recommendations`, `area:product`, `needs maintainer decision`
+
+### Cover Color Signals
+
+Suggested RFC: `rfc: model cover color as a lightweight discovery signal`
+
+- Define when cover colors are analyzed: only after a track or album enters Kocteau through review, starter pick, or curator candidate review.
+- Compare automatic palette extraction with curator overrides.
+- Start with broad visual categories such as red, black, white, pastel, dark, saturated, muted, and high-contrast.
+- Decide whether color belongs on entities, starter metadata, or a separate visual-signal table.
+- Keep color as a discovery hint, not a substitute for taste tags, reviews, or editorial judgment.
+
+Suggested labels: `rfc`, `area:recommendations`, `area:product`, `area:supabase`, `needs maintainer decision`
 
 ### Native Artist Discovery
 

--- a/docs/discovery-curation.md
+++ b/docs/discovery-curation.md
@@ -36,6 +36,18 @@ Kocteau already has the core primitives for hybrid discovery:
 
 The next work should improve measurement, editorial workflow, and ranking confidence before introducing embeddings, vector search, or machine learning.
 
+## Status Snapshot
+
+This roadmap is intentionally phased. Current shipped or in-review work:
+
+- Phase 1 signal contract and analytics validation are in place.
+- Phase 2 recommendation health has a maintainer Studio surface and aggregate checks.
+- Phase 3A contextual starter rails are in place through a surface/context contract.
+- Phase 3B starter taxonomy work is in place for `era` and `format` signals.
+- Phase 3C starter Studio workflow polish is in review with catalog filters, readiness labels, editorial notes, and safer archive confirmation.
+
+The active next step is Phase 3D: an anti-mainstream Deezer candidate finder for the curator. It should not write to the database in v0. It proposes candidates, explains why they might fit Kocteau, and lets the curator decide whether to select them into the existing starter pick workflow.
+
 ## Product Model
 
 Discovery should work through three layers.
@@ -150,6 +162,8 @@ Use only fields that help answer a product question:
 
 Expand the analytics contract around For You, reviews, entities, and starter picks.
 
+Status: shipped enough for the first discovery work. Keep expanding only when a real product question needs another signal.
+
 Outcomes:
 
 - maintainers can see feed load health
@@ -160,6 +174,8 @@ Outcomes:
 ### Phase 2: Recommendation Health
 
 Add lightweight health checks before building a dashboard.
+
+Status: shipped enough for maintainer use. Future work should improve interpretation, not expose raw analytics rows.
 
 Phase 2 starts with a read-only SQL playbook for maintainers and a curator-only Studio health surface powered by safe aggregate RPCs. Do not expose raw `analytics_events` rows to the web app.
 
@@ -175,6 +191,8 @@ Useful checks:
 ### Phase 3: Starter Studio V2 And Contextual Starter Rails
 
 Improve `/studio/starter` as a quiet editorial tool for the official curator.
+
+Status: active. The rail, taxonomy, tag editing, selected-song rail inspector, and workflow polish are in place or in review.
 
 Phase 3A starts with the secondary starter rail: starter picks should not feel identical on every screen, and they should not block the main layout render. The rail can use a lightweight surface/context contract, such as `home`, `profile:{username}`, `track:{id}`, `review:{id}`, or `studio:health`, to request a stable daily editorial rotation from `get_starter_tracks_for_surface()`.
 
@@ -194,9 +212,47 @@ Priorities:
 
 Keep it editorial and focused. Do not turn it into a generic admin dashboard.
 
+### Phase 3D: Anti-Mainstream Candidate Finder V0
+
+Add a curator-only finder inside `/studio/starter` where Deezer proposes possible starter picks and Kocteau filters them through editorial rules.
+
+Principle:
+
+```text
+Deezer proposes -> Kocteau filters -> curator decides
+```
+
+V0 constraints:
+
+- no new database tables
+- no persistent dismissal queue
+- no automatic starter pick creation
+- no global chart ingestion
+- no heavy ML
+- no fake reviews or fake engagement
+
+Candidate sources:
+
+- related artists from an existing seed artist
+- deep cuts from a known artist, where the artist can be famous but the selected track should be less obvious
+- search queries shaped by undercovered tags or scenes
+- future visual-color intent, once cover color signals are modeled
+
+Each candidate should show:
+
+- track identity and cover
+- the source mode, such as `related seed` or `deep cut`
+- an anti-mainstream tier
+- a short editorial reason
+- actions to select into the existing starter draft or skip locally
+
+This phase should prove whether a human curator can use algorithmic suggestions without making Kocteau feel commercial or chart-driven.
+
 ### Phase 4: Editorial Candidates
 
 Introduce `editorial_candidates` as a queue where the system proposes tracks that might deserve human review.
+
+Status: future persistent version. Do not start with a table until Phase 3D proves the curator flow is useful.
 
 Candidate reasons can include:
 
@@ -241,6 +297,19 @@ Possible relationship types:
 
 This can power track pages, Explore, and future recommendation explainability.
 
+### Phase 7: Cover Visual Signals
+
+Cover color can become a lightweight taste signal after starter curation proves useful.
+
+The preferred model is hybrid:
+
+- compute a dominant cover color and simple palette only when a track or album enters Kocteau
+- store broad visual tags such as `red`, `black`, `white`, `pastel`, `dark`, or `high-contrast`
+- let curators override or verify the result when it matters
+- use visual color as a discovery hint, not as a replacement for taste tags or reviews
+
+Do not index the whole Deezer catalog for color. Kocteau should only analyze music that enters the local editorial or review layer.
+
 ### Future Research
 
 These ideas are promising but should remain RFCs until the web core is healthier:
@@ -250,6 +319,7 @@ These ideas are promising but should remain RFCs until the web core is healthier
 - artist-as-curator flows
 - review premieres
 - native Kocteau tracks for music outside Deezer
+- cover color as a discovery signal beyond starter picks
 - embeddings and vector search
 - creator programs or public curator applications
 
@@ -261,6 +331,8 @@ Good contributor work:
 - event contract examples
 - Explore copy and empty states
 - UI polish for starter curation
+- tests around anti-mainstream candidate scoring
+- non-sensitive Deezer metadata mapping helpers
 - query notes that help maintainers inspect health
 - tests around analytics payload validation
 
@@ -271,6 +343,8 @@ Maintainer-led work:
 - recommendation RPC changes
 - analytics schema changes
 - starter curator permissions
+- persistent editorial candidate queues
+- cover color schema and migration decisions
 - editorial candidate approval logic
 
 Future RFC work:


### PR DESCRIPTION
## What changed

- Adds the anti-mainstream candidate finder foundation for Starter Studio.
- Adds `/api/starter/candidates` for curated discovery candidates.
- Adds Deezer-backed candidate helpers, validation, tests, and Studio UI entry points.
- Updates backlog and discovery docs with the anti-mainstream/deep-cuts direction.

## Why

Kocteau needs discovery that can use Deezer as a source without defaulting to obvious mainstream picks. This gives the curator a faster way to find emerging artists, deep cuts, and editorial candidates while keeping human taste in control.

## Testing

- [ ] Ran `pnpm check`
- [ ] Added screenshots or a short recording for visible web UI changes
- [ ] Confirmed this does not touch auth, Supabase, recommendations, analytics, CI, or release behavior

Additional checks run:

- [x] Ran `node --test apps\web\lib\starter\candidates.test.ts apps\web\lib\starter\surface.test.ts`
- [x] Ran `git diff --check`

## Changelog impact

No manual `CHANGELOG.md` edit is required. Release Please generates release notes from PR titles and squash commits.

- [x] User-facing web change
- [x] Developer experience or documentation change
- [x] Internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced "Candidate Finder" feature in Starter Studio with two discovery modes ("related-seed" and "deep-cut") to suggest alternative tracks
  * Candidates display tier classifications and support individual skipping to refine suggestions

* **Documentation**
  * Updated discovery/curation roadmap documenting implementation phases and visual signal strategy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->