### PR TITLE
feat(web): add editorial candidate queue

### DIFF
--- a/apps/web/app/api/starter/candidate-queue/route.ts
+++ b/apps/web/app/api/starter/candidate-queue/route.ts
@@ -1,0 +1,159 @@
+import { NextResponse } from "next/server";
+import { requireStarterCurator } from "@/lib/curation/access";
+import {
+  editorialCandidateDecisionSchema,
+  editorialCandidateListQuerySchema,
+  editorialCandidateUpsertSchema,
+} from "@/lib/validation/schemas";
+import { validationErrorResponse } from "@/lib/validation/server";
+
+function editorialCandidateErrorResponse(error: {
+  code?: string | null;
+  message?: string | null;
+}) {
+  if (error.code === "42501") {
+    return NextResponse.json({ error: "Not allowed" }, { status: 403 });
+  }
+
+  if (error.code === "02000") {
+    return NextResponse.json({ error: "Candidate not found" }, { status: 404 });
+  }
+
+  return NextResponse.json(
+    {
+      error:
+        error.message ?? "We could not update the editorial candidate queue.",
+    },
+    { status: 500 },
+  );
+}
+
+export async function GET(req: Request) {
+  const curator = await requireStarterCurator();
+
+  if (!curator.ok) {
+    return curator.response;
+  }
+
+  const { searchParams } = new URL(req.url);
+  const parsed = editorialCandidateListQuerySchema.safeParse({
+    status: searchParams.get("status") ?? undefined,
+    limit: searchParams.get("limit") ?? undefined,
+  });
+
+  if (!parsed.success) {
+    return validationErrorResponse(parsed.error, "Candidate queue query is invalid.");
+  }
+
+  const { status, limit } = parsed.data;
+  const { data, error } = await curator.supabase
+    .from("editorial_candidates")
+    .select(
+      `
+        id,
+        provider,
+        provider_id,
+        type,
+        title,
+        artist_name,
+        cover_url,
+        deezer_url,
+        source,
+        source_label,
+        seed_label,
+        tier,
+        reason,
+        score,
+        status,
+        decision_note,
+        metadata,
+        created_by,
+        decided_by,
+        starter_track_id,
+        created_at,
+        updated_at,
+        decided_at
+      `,
+    )
+    .eq("status", status)
+    .order("score", { ascending: false })
+    .order("created_at", { ascending: false })
+    .limit(limit);
+
+  if (error) {
+    return editorialCandidateErrorResponse(error);
+  }
+
+  return NextResponse.json({ candidates: data ?? [] });
+}
+
+export async function POST(req: Request) {
+  const curator = await requireStarterCurator();
+
+  if (!curator.ok) {
+    return curator.response;
+  }
+
+  const payload = (await req.json().catch(() => null)) as unknown;
+  const parsed = editorialCandidateUpsertSchema.safeParse(payload);
+
+  if (!parsed.success) {
+    return validationErrorResponse(parsed.error, "Editorial candidate is invalid.");
+  }
+
+  const candidate = parsed.data;
+  const { data, error } = await curator.supabase.rpc("upsert_editorial_candidate", {
+    p_provider: candidate.provider,
+    p_provider_id: candidate.provider_id,
+    p_type: candidate.type,
+    p_title: candidate.title,
+    p_artist_name: candidate.artist_name ?? undefined,
+    p_cover_url: candidate.cover_url ?? undefined,
+    p_deezer_url: candidate.deezer_url ?? undefined,
+    p_source: candidate.source,
+    p_source_label: candidate.source_label,
+    p_seed_label: candidate.seed_label ?? undefined,
+    p_tier: candidate.tier,
+    p_reason: candidate.reason ?? undefined,
+    p_score: candidate.score,
+    p_metadata: candidate.metadata,
+  });
+
+  if (error) {
+    return editorialCandidateErrorResponse(error);
+  }
+
+  return NextResponse.json({ ok: true, candidate: data });
+}
+
+export async function PATCH(req: Request) {
+  const curator = await requireStarterCurator();
+
+  if (!curator.ok) {
+    return curator.response;
+  }
+
+  const payload = (await req.json().catch(() => null)) as unknown;
+  const parsed = editorialCandidateDecisionSchema.safeParse(payload);
+
+  if (!parsed.success) {
+    return validationErrorResponse(parsed.error, "Editorial candidate decision is invalid.");
+  }
+
+  const decision = parsed.data;
+  const { data, error } = await curator.supabase.rpc(
+    "update_editorial_candidate_status",
+    {
+      p_candidate_id: decision.id,
+      p_status: decision.status,
+      p_decision_note: decision.decision_note ?? undefined,
+      p_starter_track_id: decision.starter_track_id ?? undefined,
+    },
+  );
+
+  if (error) {
+    return editorialCandidateErrorResponse(error);
+  }
+
+  return NextResponse.json({ ok: true, candidate: data });
+}

--- a/apps/web/components/starter-studio-client.tsx
+++ b/apps/web/components/starter-studio-client.tsx
@@ -21,7 +21,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
-import { useDeezerSearch, type DeezerSearchResult } from "@/hooks/use-deezer-search";
+import { useDeezerSearch } from "@/hooks/use-deezer-search";
 import {
   preferenceKindDescriptions,
   preferenceKindLabels,
@@ -29,12 +29,15 @@ import {
   type PreferenceKind,
 } from "@/lib/taste";
 import type { StarterCandidateSource } from "@/lib/starter/candidates";
+import { getEditorialCandidateStatusLabel } from "@/lib/starter/candidate-queue";
 import { cn } from "@/lib/utils";
 import { fetchJson } from "@/queries/http";
 import {
+  editorialCandidateQueueQueryOptions,
   starterCandidatesQueryOptions,
   starterCuratorTracksQueryOptions,
   starterKeys,
+  type EditorialCandidateRow,
   type StarterPreferenceTag,
   type StarterTrackRow,
   type StarterTrackWithTags,
@@ -48,6 +51,11 @@ type StarterTrackResponse = {
 type StarterTagResponse = {
   ok: boolean;
   tag: StarterPreferenceTag;
+};
+
+type EditorialCandidateResponse = {
+  ok: boolean;
+  candidate: EditorialCandidateRow;
 };
 
 type StarterDraftTrack = Pick<
@@ -214,6 +222,7 @@ export default function StarterStudioClient() {
   const [editingTag, setEditingTag] = useState<StarterPreferenceTag | null>(null);
   const [selectedDraftTrack, setSelectedDraftTrack] =
     useState<StarterDraftTrack | null>(null);
+  const [selectedCandidateId, setSelectedCandidateId] = useState<string | null>(null);
   const [editingTrack, setEditingTrack] =
     useState<StarterTrackWithTags | null>(null);
   const normalizedQuery = query.trim();
@@ -228,6 +237,12 @@ export default function StarterStudioClient() {
     }),
     enabled: normalizedCandidateQuery.length >= 2,
   });
+  const editorialCandidateQueueQuery = useQuery(
+    editorialCandidateQueueQueryOptions({
+      status: "queued",
+      limit: 12,
+    }),
+  );
   const {
     data: searchResults,
     isFetching: searchFetching,
@@ -247,6 +262,17 @@ export default function StarterStudioClient() {
   const existingProviderIds = useMemo(
     () => new Set(starterTracks.map((track) => track.provider_id)),
     [starterTracks],
+  );
+  const editorialCandidateQueue = useMemo(
+    () => editorialCandidateQueueQuery.data?.candidates ?? [],
+    [editorialCandidateQueueQuery.data],
+  );
+  const queuedCandidateProviderIds = useMemo(
+    () =>
+      new Set(
+        editorialCandidateQueue.map((candidate) => candidate.provider_id),
+      ),
+    [editorialCandidateQueue],
   );
   const candidateResults = useMemo(
     () =>
@@ -385,6 +411,7 @@ export default function StarterStudioClient() {
   const resetDraft = useCallback(() => {
     setEditingTrack(null);
     setSelectedDraftTrack(null);
+    setSelectedCandidateId(null);
     setPrompt(defaultPrompt);
     setEditorialNote("");
     setFeatured(true);
@@ -403,6 +430,7 @@ export default function StarterStudioClient() {
 
   const startEditing = useCallback((track: StarterTrackWithTags) => {
     setSelectedDraftTrack(null);
+    setSelectedCandidateId(null);
     setEditingTrack(track);
     setPrompt(track.prompt ?? defaultPrompt);
     setEditorialNote(track.editorial_note ?? "");
@@ -414,18 +442,23 @@ export default function StarterStudioClient() {
     setConfirmArchiveId(null);
   }, []);
 
-  const selectSearchTrack = useCallback((track: DeezerSearchResult) => {
+  const selectSearchTrack = useCallback((
+    track: StarterDraftTrack,
+    candidateId: string | null = null,
+  ) => {
     const existingTrack = starterTracks.find(
       (starterTrack) => starterTrack.provider_id === track.provider_id,
     );
 
     if (existingTrack) {
+      setSelectedCandidateId(null);
       startEditing(existingTrack);
       return;
     }
 
     setEditingTrack(null);
     setSelectedDraftTrack(track);
+    setSelectedCandidateId(candidateId);
     setPrompt(defaultPrompt);
     setEditorialNote("");
     setFeatured(true);
@@ -443,7 +476,7 @@ export default function StarterStudioClient() {
   }
 
   const addMutation = useMutation({
-    mutationFn: (track: DeezerSearchResult | StarterDraftTrack) => {
+    mutationFn: (track: StarterDraftTrack) => {
       const existingTrack = starterTracks.find(
         (starterTrack) => starterTrack.provider_id === track.provider_id,
       );
@@ -476,8 +509,33 @@ export default function StarterStudioClient() {
         }),
       });
     },
-    onSuccess: (_payload, track) => {
+    onSuccess: (payload, track) => {
       toast.success(`${track.title} saved to Starter picks.`);
+      const approvedCandidateId = selectedCandidateId;
+
+      if (approvedCandidateId) {
+        void fetchJson<EditorialCandidateResponse>("/api/starter/candidate-queue", {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            id: approvedCandidateId,
+            status: "approved",
+            starter_track_id: payload.track.id,
+            decision_note: "Approved into starter picks.",
+          }),
+        })
+          .then(() =>
+            queryClient.invalidateQueries({
+              queryKey: starterKeys.candidateQueue("queued", 12),
+            }),
+          )
+          .catch((error) => {
+            toast.error(error.message);
+          });
+      }
+
       if (
         editingTrack?.provider_id === track.provider_id ||
         selectedDraftTrack?.provider_id === track.provider_id
@@ -485,6 +543,82 @@ export default function StarterStudioClient() {
         resetDraft();
       }
       void queryClient.invalidateQueries({ queryKey: starterKeys.curatorTracks() });
+    },
+    onError: (error) => {
+      toast.error(error.message);
+    },
+  });
+
+  const queueCandidateMutation = useMutation({
+    mutationFn: (candidate: StarterDraftTrack & {
+      source: string;
+      source_label: string;
+      seed_label: string | null;
+      tier: string;
+      reason: string | null;
+      score: number;
+    }) =>
+      fetchJson<EditorialCandidateResponse>("/api/starter/candidate-queue", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          provider: candidate.provider,
+          provider_id: candidate.provider_id,
+          type: candidate.type,
+          title: candidate.title,
+          artist_name: candidate.artist_name,
+          cover_url: candidate.cover_url,
+          deezer_url: candidate.deezer_url,
+          source: candidate.source,
+          source_label: candidate.source_label,
+          seed_label: candidate.seed_label,
+          tier: candidate.tier,
+          reason: candidate.reason,
+          score: candidate.score,
+          metadata: {
+            mode: candidateMode,
+            seed: normalizedCandidateQuery,
+          },
+        }),
+      }),
+    onSuccess: (payload) => {
+      toast.success(`${payload.candidate.title} saved to the queue.`);
+      void queryClient.invalidateQueries({
+        queryKey: starterKeys.candidateQueue("queued", 12),
+      });
+    },
+    onError: (error) => {
+      toast.error(error.message);
+    },
+  });
+
+  const decideCandidateMutation = useMutation({
+    mutationFn: ({
+      id,
+      status,
+      decision_note,
+    }: {
+      id: string;
+      status: "queued" | "approved" | "dismissed" | "archived";
+      decision_note?: string;
+    }) =>
+      fetchJson<EditorialCandidateResponse>("/api/starter/candidate-queue", {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          id,
+          status,
+          decision_note,
+        }),
+      }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: starterKeys.candidateQueue("queued", 12),
+      });
     },
     onError: (error) => {
       toast.error(error.message);
@@ -1393,6 +1527,10 @@ export default function StarterStudioClient() {
                   const isSelected =
                     selectedDraftTrack?.provider_id === track.provider_id ||
                     editingTrack?.provider_id === track.provider_id;
+                  const isQueued = queuedCandidateProviderIds.has(track.provider_id);
+                  const isQueueing =
+                    queueCandidateMutation.isPending &&
+                    queueCandidateMutation.variables?.provider_id === track.provider_id;
 
                   return (
                     <article
@@ -1450,6 +1588,23 @@ export default function StarterStudioClient() {
                           type="button"
                           size="sm"
                           variant="ghost"
+                          disabled={isQueued || queueCandidateMutation.isPending}
+                          onClick={() => queueCandidateMutation.mutate(track)}
+                          className="h-8 gap-1.5 text-muted-foreground"
+                        >
+                          {isQueueing ? (
+                            <LoaderCircle className="size-3 animate-spin" />
+                          ) : isQueued ? (
+                            <Check className="size-3" />
+                          ) : (
+                            <Plus className="size-3" />
+                          )}
+                          {isQueued ? "Queued" : "Queue"}
+                        </Button>
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="ghost"
                           onClick={() =>
                             setDismissedCandidateKeys((current) =>
                               new Set(current).add(
@@ -1468,6 +1623,136 @@ export default function StarterStudioClient() {
                 })}
               </div>
             ) : null}
+
+            <div className="space-y-2 border-t border-border/20 pt-3">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <h3 className="text-xs font-medium text-foreground">
+                    Saved queue
+                  </h3>
+                  <p className="mt-0.5 text-xs text-muted-foreground">
+                    Keep candidates for slower listening before they become starter picks.
+                  </p>
+                </div>
+                <span className="rounded-md border border-border/28 bg-background/24 px-2 py-1 text-xs tabular-nums text-muted-foreground">
+                  {editorialCandidateQueue.length}
+                </span>
+              </div>
+
+              {editorialCandidateQueueQuery.isLoading ? (
+                <div className="flex min-h-20 items-center justify-center rounded-lg border border-border/24 bg-background/24">
+                  <LoaderCircle className="size-4 animate-spin text-muted-foreground" />
+                </div>
+              ) : null}
+
+              {editorialCandidateQueueQuery.error ? (
+                <p className="rounded-lg border border-amber-500/24 bg-amber-500/7 px-3 py-2 text-sm text-amber-100/78">
+                  Candidate queue needs the latest Supabase migration.
+                </p>
+              ) : null}
+
+              {!editorialCandidateQueueQuery.isLoading &&
+              !editorialCandidateQueueQuery.error &&
+              editorialCandidateQueue.length === 0 ? (
+                <p className="rounded-lg border border-border/24 bg-background/24 px-3 py-5 text-center text-sm text-muted-foreground">
+                  No saved candidates yet.
+                </p>
+              ) : null}
+
+              {editorialCandidateQueue.length > 0 ? (
+                <div className="grid gap-2 xl:grid-cols-2">
+                  {editorialCandidateQueue.map((candidate) => {
+                    const isSelected =
+                      selectedCandidateId === candidate.id ||
+                      selectedDraftTrack?.provider_id === candidate.provider_id ||
+                      editingTrack?.provider_id === candidate.provider_id;
+                    const isDeciding =
+                      decideCandidateMutation.isPending &&
+                      decideCandidateMutation.variables?.id === candidate.id;
+
+                    return (
+                      <article
+                        key={candidate.id}
+                        className={cn(
+                          "grid min-h-[5.25rem] grid-cols-[minmax(0,1fr)_auto] gap-3 rounded-lg border border-border/28 bg-background/24 p-2.5 transition-colors",
+                          isSelected && "border-foreground/34 bg-foreground/[0.055]",
+                        )}
+                      >
+                        <button
+                          type="button"
+                          onClick={() => selectSearchTrack(candidate, candidate.id)}
+                          className="grid min-w-0 grid-cols-[3.25rem_minmax(0,1fr)] items-start gap-3 rounded-md text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30"
+                        >
+                          <TrackCover src={candidate.cover_url} title={candidate.title} />
+                          <span className="min-w-0 space-y-1">
+                            <span className="block truncate text-sm font-medium text-foreground">
+                              {candidate.title}
+                            </span>
+                            <span className="block truncate text-xs text-muted-foreground">
+                              {candidate.artist_name ?? "Unknown artist"}
+                            </span>
+                            <span className="flex flex-wrap gap-1">
+                              <Badge
+                                variant="outline"
+                                className="h-4 border-border/42 px-1.5 text-[0.56rem] text-muted-foreground"
+                              >
+                                {getEditorialCandidateStatusLabel("queued")}
+                              </Badge>
+                              <Badge
+                                variant="outline"
+                                className="h-4 border-border/42 px-1.5 text-[0.56rem] text-muted-foreground"
+                              >
+                                {candidate.source_label}
+                              </Badge>
+                            </span>
+                            {candidate.reason ? (
+                              <span className="block line-clamp-2 text-xs leading-5 text-muted-foreground">
+                                {candidate.reason}
+                              </span>
+                            ) : null}
+                          </span>
+                        </button>
+
+                        <div className="flex flex-col gap-1.5">
+                          <Button
+                            type="button"
+                            size="sm"
+                            variant={isSelected ? "secondary" : "outline"}
+                            disabled={addMutation.isPending}
+                            onClick={() => selectSearchTrack(candidate, candidate.id)}
+                            className="h-8 gap-1.5"
+                          >
+                            {isSelected ? <Check className="size-3" /> : <Plus className="size-3" />}
+                            {isSelected ? "Selected" : "Select"}
+                          </Button>
+                          <Button
+                            type="button"
+                            size="sm"
+                            variant="ghost"
+                            disabled={decideCandidateMutation.isPending}
+                            onClick={() =>
+                              decideCandidateMutation.mutate({
+                                id: candidate.id,
+                                status: "dismissed",
+                                decision_note: "Dismissed from Studio queue.",
+                              })
+                            }
+                            className="h-8 gap-1.5 text-muted-foreground"
+                          >
+                            {isDeciding ? (
+                              <LoaderCircle className="size-3 animate-spin" />
+                            ) : (
+                              <X className="size-3" />
+                            )}
+                            Dismiss
+                          </Button>
+                        </div>
+                      </article>
+                    );
+                  })}
+                </div>
+              ) : null}
+            </div>
           </section>
 
           <section className="space-y-3">

--- a/apps/web/lib/starter/candidate-queue.test.ts
+++ b/apps/web/lib/starter/candidate-queue.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  editorialCandidateStatuses,
+  getEditorialCandidateStatusLabel,
+  isEditorialCandidateDecisionStatus,
+} from "./candidate-queue.ts";
+
+describe("editorial candidate queue helpers", () => {
+  it("keeps queue statuses ordered from active work to historical decisions", () => {
+    assert.deepEqual(editorialCandidateStatuses, [
+      "queued",
+      "approved",
+      "dismissed",
+      "archived",
+    ]);
+  });
+
+  it("separates active queued candidates from decision history", () => {
+    assert.equal(isEditorialCandidateDecisionStatus("queued"), false);
+    assert.equal(isEditorialCandidateDecisionStatus("approved"), true);
+    assert.equal(isEditorialCandidateDecisionStatus("dismissed"), true);
+    assert.equal(isEditorialCandidateDecisionStatus("archived"), true);
+  });
+
+  it("formats status labels for quiet Studio UI", () => {
+    assert.equal(getEditorialCandidateStatusLabel("queued"), "Queued");
+    assert.equal(getEditorialCandidateStatusLabel("approved"), "Approved");
+    assert.equal(getEditorialCandidateStatusLabel("dismissed"), "Dismissed");
+    assert.equal(getEditorialCandidateStatusLabel("archived"), "Archived");
+  });
+});

--- a/apps/web/lib/starter/candidate-queue.ts
+++ b/apps/web/lib/starter/candidate-queue.ts
@@ -1,0 +1,27 @@
+export const editorialCandidateStatuses = [
+  "queued",
+  "approved",
+  "dismissed",
+  "archived",
+] as const;
+
+export type EditorialCandidateStatus = (typeof editorialCandidateStatuses)[number];
+
+const editorialCandidateStatusLabels: Record<EditorialCandidateStatus, string> = {
+  queued: "Queued",
+  approved: "Approved",
+  dismissed: "Dismissed",
+  archived: "Archived",
+};
+
+export function isEditorialCandidateDecisionStatus(
+  status: EditorialCandidateStatus,
+) {
+  return status !== "queued";
+}
+
+export function getEditorialCandidateStatusLabel(
+  status: EditorialCandidateStatus,
+) {
+  return editorialCandidateStatusLabels[status];
+}

--- a/apps/web/lib/supabase/database.types.ts
+++ b/apps/web/lib/supabase/database.types.ts
@@ -69,6 +69,106 @@ export type Database = {
           },
         ]
       }
+      editorial_candidates: {
+        Row: {
+          artist_name: string | null
+          cover_url: string | null
+          created_at: string
+          created_by: string | null
+          decided_at: string | null
+          decided_by: string | null
+          decision_note: string | null
+          deezer_url: string | null
+          id: string
+          metadata: Json
+          provider: string
+          provider_id: string
+          reason: string | null
+          score: number
+          seed_label: string | null
+          source: string
+          source_label: string
+          starter_track_id: string | null
+          status: string
+          tier: string
+          title: string
+          type: Database["public"]["Enums"]["entity_type"]
+          updated_at: string
+        }
+        Insert: {
+          artist_name?: string | null
+          cover_url?: string | null
+          created_at?: string
+          created_by?: string | null
+          decided_at?: string | null
+          decided_by?: string | null
+          decision_note?: string | null
+          deezer_url?: string | null
+          id?: string
+          metadata?: Json
+          provider?: string
+          provider_id: string
+          reason?: string | null
+          score?: number
+          seed_label?: string | null
+          source: string
+          source_label: string
+          starter_track_id?: string | null
+          status?: string
+          tier: string
+          title: string
+          type?: Database["public"]["Enums"]["entity_type"]
+          updated_at?: string
+        }
+        Update: {
+          artist_name?: string | null
+          cover_url?: string | null
+          created_at?: string
+          created_by?: string | null
+          decided_at?: string | null
+          decided_by?: string | null
+          decision_note?: string | null
+          deezer_url?: string | null
+          id?: string
+          metadata?: Json
+          provider?: string
+          provider_id?: string
+          reason?: string | null
+          score?: number
+          seed_label?: string | null
+          source?: string
+          source_label?: string
+          starter_track_id?: string | null
+          status?: string
+          tier?: string
+          title?: string
+          type?: Database["public"]["Enums"]["entity_type"]
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "editorial_candidates_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "editorial_candidates_decided_by_fkey"
+            columns: ["decided_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "editorial_candidates_starter_track_id_fkey"
+            columns: ["starter_track_id"]
+            isOneToOne: false
+            referencedRelation: "starter_tracks"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       editorial_collection_items: {
         Row: {
           collection_id: string
@@ -1117,6 +1217,94 @@ export type Database = {
         SetofOptions: {
           from: "*"
           to: "preference_tags"
+          isOneToOne: true
+          isSetofReturn: false
+        }
+      }
+      update_editorial_candidate_status: {
+        Args: {
+          p_candidate_id: string
+          p_decision_note?: string
+          p_starter_track_id?: string
+          p_status: string
+        }
+        Returns: {
+          artist_name: string | null
+          cover_url: string | null
+          created_at: string
+          created_by: string | null
+          decided_at: string | null
+          decided_by: string | null
+          decision_note: string | null
+          deezer_url: string | null
+          id: string
+          metadata: Json
+          provider: string
+          provider_id: string
+          reason: string | null
+          score: number
+          seed_label: string | null
+          source: string
+          source_label: string
+          starter_track_id: string | null
+          status: string
+          tier: string
+          title: string
+          type: Database["public"]["Enums"]["entity_type"]
+          updated_at: string
+        }
+        SetofOptions: {
+          from: "*"
+          to: "editorial_candidates"
+          isOneToOne: true
+          isSetofReturn: false
+        }
+      }
+      upsert_editorial_candidate: {
+        Args: {
+          p_artist_name?: string
+          p_cover_url?: string
+          p_deezer_url?: string
+          p_metadata?: Json
+          p_provider: string
+          p_provider_id: string
+          p_reason?: string
+          p_score?: number
+          p_seed_label?: string
+          p_source?: string
+          p_source_label?: string
+          p_tier?: string
+          p_title: string
+          p_type: Database["public"]["Enums"]["entity_type"]
+        }
+        Returns: {
+          artist_name: string | null
+          cover_url: string | null
+          created_at: string
+          created_by: string | null
+          decided_at: string | null
+          decided_by: string | null
+          decision_note: string | null
+          deezer_url: string | null
+          id: string
+          metadata: Json
+          provider: string
+          provider_id: string
+          reason: string | null
+          score: number
+          seed_label: string | null
+          source: string
+          source_label: string
+          starter_track_id: string | null
+          status: string
+          tier: string
+          title: string
+          type: Database["public"]["Enums"]["entity_type"]
+          updated_at: string
+        }
+        SetofOptions: {
+          from: "*"
+          to: "editorial_candidates"
           isOneToOne: true
           isSetofReturn: false
         }

--- a/apps/web/lib/validation/schemas.ts
+++ b/apps/web/lib/validation/schemas.ts
@@ -5,6 +5,7 @@ import {
   isAllowedAnalyticsMetadataKey,
 } from "@/lib/analytics/events";
 import { searchableEntityTypes } from "@/lib/search-types";
+import { editorialCandidateStatuses } from "@/lib/starter/candidate-queue";
 import { tasteOnboardingMaxTags, tasteOnboardingMinTags } from "@/lib/taste";
 
 function optionalTrimmedString(maxLength: number) {
@@ -90,6 +91,48 @@ export const starterCandidateQuerySchema = z.object({
     .max(80, "Search queries can be up to 80 characters."),
   mode: z.enum(["related-seed", "deep-cut"]).optional().default("related-seed"),
   limit: z.coerce.number().int().min(1).max(12).optional().default(8),
+});
+
+export const editorialCandidateListQuerySchema = z.object({
+  status: z.enum(editorialCandidateStatuses).optional().default("queued"),
+  limit: z.coerce.number().int().min(1).max(30).optional().default(12),
+});
+
+const editorialCandidateMetadataSchema = z
+  .record(
+    z.string().max(48),
+    z.union([
+      z.string().max(240),
+      z.number().finite(),
+      z.boolean(),
+      z.null(),
+    ]),
+  )
+  .optional()
+  .default({});
+
+export const editorialCandidateUpsertSchema = z.object({
+  provider: z.literal("deezer"),
+  provider_id: z.string().trim().min(1, "Missing provider track id."),
+  type: z.literal("track"),
+  title: z.string().trim().min(1, "Track title is required.").max(160, "Track title is too long."),
+  artist_name: optionalTrimmedString(160),
+  cover_url: z.string().trim().url("Cover URL must be valid.").nullable().optional().transform((value) => value ?? null),
+  deezer_url: z.string().trim().url("Deezer URL must be valid.").nullable().optional().transform((value) => value ?? null),
+  source: z.enum(["related-seed", "deep-cut", "manual", "system-signal"]),
+  source_label: z.string().trim().min(2).max(48),
+  seed_label: optionalTrimmedString(120),
+  tier: z.enum(["emerging", "undercovered", "familiar", "deep-cut", "obvious"]),
+  reason: optionalTrimmedString(240),
+  score: z.number().finite().min(-1000).max(1000).optional().default(0),
+  metadata: editorialCandidateMetadataSchema,
+});
+
+export const editorialCandidateDecisionSchema = z.object({
+  id: z.string().uuid("Invalid editorial candidate id."),
+  status: z.enum(editorialCandidateStatuses),
+  decision_note: optionalTrimmedString(240),
+  starter_track_id: z.string().uuid("Invalid starter track id.").nullable().optional().transform((value) => value ?? null),
 });
 
 export const loginSchema = z.object({
@@ -304,6 +347,9 @@ export type StarterTrackArchiveInput = z.infer<typeof starterTrackArchiveSchema>
 export type StarterPreferenceTagInput = z.infer<typeof starterPreferenceTagSchema>;
 export type StarterPreferenceTagUpdateInput = z.infer<typeof starterPreferenceTagUpdateSchema>;
 export type StarterCandidateQueryInput = z.infer<typeof starterCandidateQuerySchema>;
+export type EditorialCandidateListQueryInput = z.infer<typeof editorialCandidateListQuerySchema>;
+export type EditorialCandidateUpsertInput = z.infer<typeof editorialCandidateUpsertSchema>;
+export type EditorialCandidateDecisionInput = z.infer<typeof editorialCandidateDecisionSchema>;
 export type UpdateReviewInput = z.infer<typeof updateReviewSchema>;
 export type CreateCommentInput = z.infer<typeof createCommentSchema>;
 export type ReviewCollectionStateInput = z.infer<typeof reviewCollectionStateSchema>;

--- a/apps/web/queries/starter.ts
+++ b/apps/web/queries/starter.ts
@@ -3,11 +3,13 @@ import type {
   StarterCandidateSource,
   StarterCandidateTrack,
 } from "@/lib/starter/candidates";
+import type { EditorialCandidateStatus as CandidateQueueStatus } from "@/lib/starter/candidate-queue";
 import type { Tables } from "@/lib/supabase/database.types";
 import { fetchJson } from "@/queries/http";
 
 export type StarterTrackRow = Tables<"starter_tracks">;
 export type StarterPreferenceTag = Tables<"preference_tags">;
+export type EditorialCandidateRow = Tables<"editorial_candidates">;
 export type StarterTrackTag = {
   tag_id: string;
   weight: number;
@@ -30,17 +32,46 @@ export type StarterCandidateData = {
   tracks: StarterCandidateTrack[];
 };
 
+export type EditorialCandidateQueueData = {
+  candidates: EditorialCandidateRow[];
+};
+
 export const starterKeys = {
   all: ["starter"] as const,
   curatorTracks: () => ["starter", "curator-tracks"] as const,
   candidates: (mode: StarterCandidateSource, query: string, limit: number) =>
     ["starter", "candidates", mode, query, limit] as const,
+  candidateQueue: (status: CandidateQueueStatus, limit: number) =>
+    ["starter", "candidate-queue", status, limit] as const,
 };
 
 export function starterCuratorTracksQueryOptions() {
   return queryOptions({
     queryKey: starterKeys.curatorTracks(),
     queryFn: () => fetchJson<StarterStudioData>("/api/starter/tracks"),
+    staleTime: 30_000,
+    gcTime: 5 * 60_000,
+  });
+}
+
+export function editorialCandidateQueueQueryOptions({
+  status = "queued",
+  limit = 12,
+}: {
+  status?: CandidateQueueStatus;
+  limit?: number;
+}) {
+  const params = new URLSearchParams({
+    status,
+    limit: String(limit),
+  });
+
+  return queryOptions({
+    queryKey: starterKeys.candidateQueue(status, limit),
+    queryFn: () =>
+      fetchJson<EditorialCandidateQueueData>(
+        `/api/starter/candidate-queue?${params.toString()}`,
+      ),
     staleTime: 30_000,
     gcTime: 5 * 60_000,
   });

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -38,6 +38,7 @@ These items should not be reopened unless a maintainer finds a regression or sta
 | Starter Studio tag editing | done | Curators can create and edit starter signals without leaving Studio. |
 | Starter Studio selected-track inspector | done | The secondary rail focuses on the selected song instead of generic modules while curating. |
 | Starter Studio workflow polish | in review | Catalog filters, readiness labels, editorial notes, and archive confirmation live in `feat/starter-studio-workflow-polish`. |
+| Anti-mainstream candidate finder V0 | done | Deezer can propose related/deep-cut candidates without writing to the database. |
 
 ## Near-Term Priorities
 
@@ -340,7 +341,7 @@ Acceptance criteria:
 
 Suggested issue: `feat(web): add anti-mainstream Deezer candidate finder`
 
-State: `ready`, maintainer-led. This is the next starter curation phase.
+State: `done` for V0. Keep follow-up work focused on queue persistence and measured curation quality.
 
 - Add a curator-only `/api/starter/candidates` route.
 - Use Deezer related artists and artist top tracks as candidate sources.
@@ -385,11 +386,11 @@ Acceptance criteria:
 
 Suggested issue: `feat(web): design editorial candidate queue for starter picks`
 
-State: `blocked` until the anti-mainstream candidate finder proves the curator flow is useful.
+State: `in progress` for V1 persistence.
 
 - Add a maintainer-reviewed design for `editorial_candidates` before implementation.
 - Candidate reasons may include review velocity, bookmark growth, read depth, trusted-user activity, emerging tags, and undercovered taste areas.
-- The first version should support approve to starter, dismiss, and later states.
+- The first version should support saving to queue, selecting into the starter draft, approving after starter save, and dismissing.
 - Keep curator approval required before a candidate becomes official starter content.
 
 Suggested labels: `feature`, `area:web`, `area:supabase`, `area:recommendations`, `needs design review`, `needs maintainer decision`

--- a/docs/discovery-curation.md
+++ b/docs/discovery-curation.md
@@ -46,7 +46,7 @@ This roadmap is intentionally phased. Current shipped or in-review work:
 - Phase 3B starter taxonomy work is in place for `era` and `format` signals.
 - Phase 3C starter Studio workflow polish is in review with catalog filters, readiness labels, editorial notes, and safer archive confirmation.
 
-The active next step is Phase 3D: an anti-mainstream Deezer candidate finder for the curator. It should not write to the database in v0. It proposes candidates, explains why they might fit Kocteau, and lets the curator decide whether to select them into the existing starter pick workflow.
+Phase 3D adds an anti-mainstream Deezer candidate finder for the curator. It does not write to the database in v0. Phase 4 adds the persistent candidate queue so promising suggestions can be saved, revisited, approved into starter picks, or dismissed.
 
 ## Product Model
 
@@ -252,7 +252,7 @@ This phase should prove whether a human curator can use algorithmic suggestions 
 
 Introduce `editorial_candidates` as a queue where the system proposes tracks that might deserve human review.
 
-Status: future persistent version. Do not start with a table until Phase 3D proves the curator flow is useful.
+Status: active V1. The first persistent version stores only curator-facing track candidates and decisions. It does not auto-promote candidates into starter picks.
 
 Candidate reasons can include:
 
@@ -270,6 +270,14 @@ signals -> candidate -> curator decision -> starter pick or dismissal
 ```
 
 The algorithm discovers. Humans validate.
+
+V1 constraints:
+
+- candidates remain curator-only
+- approving still requires saving through the existing starter pick workflow
+- dismissed candidates stay as decision history
+- no public candidate pages
+- no automated ranking changes until recommendation health can measure impact
 
 ### Phase 5: Feed Tuning
 

--- a/supabase/migrations/20260602210000_editorial_candidate_queue.sql
+++ b/supabase/migrations/20260602210000_editorial_candidate_queue.sql
@@ -1,0 +1,335 @@
+-- Editorial candidate queue for human-led starter curation.
+-- Apply after 20260601211257_starter_tag_taxonomy.sql.
+--
+-- Purpose:
+-- - Persist Deezer candidate suggestions after the curator finder proposes them.
+-- - Keep approval human-led before a track becomes a starter pick.
+-- - Preserve curator decisions without exposing raw analytics or private data.
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '90s';
+
+CREATE TABLE IF NOT EXISTS public.editorial_candidates (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  provider text NOT NULL DEFAULT 'deezer',
+  provider_id text NOT NULL,
+  type public.entity_type NOT NULL DEFAULT 'track',
+  title text NOT NULL,
+  artist_name text,
+  cover_url text,
+  deezer_url text,
+  source text NOT NULL,
+  source_label text NOT NULL,
+  seed_label text,
+  tier text NOT NULL,
+  reason text,
+  score numeric NOT NULL DEFAULT 0,
+  status text NOT NULL DEFAULT 'queued',
+  decision_note text,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_by uuid REFERENCES public.profiles(id) ON DELETE SET NULL,
+  decided_by uuid REFERENCES public.profiles(id) ON DELETE SET NULL,
+  starter_track_id uuid REFERENCES public.starter_tracks(id) ON DELETE SET NULL,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  updated_at timestamp with time zone NOT NULL DEFAULT now(),
+  decided_at timestamp with time zone,
+  CONSTRAINT editorial_candidates_pkey PRIMARY KEY (id),
+  CONSTRAINT editorial_candidates_provider_check CHECK (provider = 'deezer'),
+  CONSTRAINT editorial_candidates_type_check CHECK (type = 'track'),
+  CONSTRAINT editorial_candidates_source_check
+    CHECK (source IN ('related-seed', 'deep-cut', 'manual', 'system-signal')),
+  CONSTRAINT editorial_candidates_tier_check
+    CHECK (tier IN ('emerging', 'undercovered', 'familiar', 'deep-cut', 'obvious')),
+  CONSTRAINT editorial_candidates_status_check
+    CHECK (status IN ('queued', 'approved', 'dismissed', 'archived')),
+  CONSTRAINT editorial_candidates_provider_entity_key
+    UNIQUE (provider, provider_id, type)
+);
+
+CREATE INDEX IF NOT EXISTS editorial_candidates_status_score_idx
+  ON public.editorial_candidates (status, score DESC, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS editorial_candidates_created_by_idx
+  ON public.editorial_candidates (created_by, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS editorial_candidates_starter_track_idx
+  ON public.editorial_candidates (starter_track_id)
+  WHERE starter_track_id IS NOT NULL;
+
+ALTER TABLE public.editorial_candidates ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Starter curators can read editorial candidates"
+  ON public.editorial_candidates;
+DROP POLICY IF EXISTS "Starter curators can insert editorial candidates"
+  ON public.editorial_candidates;
+DROP POLICY IF EXISTS "Starter curators can update editorial candidates"
+  ON public.editorial_candidates;
+
+CREATE POLICY "Starter curators can read editorial candidates"
+  ON public.editorial_candidates
+  FOR SELECT
+  TO authenticated
+  USING (public.is_starter_curator());
+
+CREATE POLICY "Starter curators can insert editorial candidates"
+  ON public.editorial_candidates
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (public.is_starter_curator());
+
+CREATE POLICY "Starter curators can update editorial candidates"
+  ON public.editorial_candidates
+  FOR UPDATE
+  TO authenticated
+  USING (public.is_starter_curator())
+  WITH CHECK (public.is_starter_curator());
+
+GRANT SELECT, INSERT, UPDATE ON public.editorial_candidates TO authenticated;
+
+DROP FUNCTION IF EXISTS public.upsert_editorial_candidate(
+  text,
+  text,
+  public.entity_type,
+  text,
+  text,
+  text,
+  text,
+  text,
+  text,
+  text,
+  text,
+  text,
+  numeric,
+  jsonb
+);
+
+CREATE OR REPLACE FUNCTION public.upsert_editorial_candidate(
+  p_provider text,
+  p_provider_id text,
+  p_type public.entity_type,
+  p_title text,
+  p_artist_name text DEFAULT NULL,
+  p_cover_url text DEFAULT NULL,
+  p_deezer_url text DEFAULT NULL,
+  p_source text DEFAULT 'manual',
+  p_source_label text DEFAULT 'Manual',
+  p_seed_label text DEFAULT NULL,
+  p_tier text DEFAULT 'undercovered',
+  p_reason text DEFAULT NULL,
+  p_score numeric DEFAULT 0,
+  p_metadata jsonb DEFAULT '{}'::jsonb
+)
+RETURNS public.editorial_candidates
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_candidate public.editorial_candidates%rowtype;
+BEGIN
+  IF NOT public.is_starter_curator() THEN
+    RAISE EXCEPTION 'Not allowed to curate editorial candidates.'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF p_provider <> 'deezer' OR p_type <> 'track' THEN
+    RAISE EXCEPTION 'Only Deezer tracks can be editorial candidates.'
+      USING ERRCODE = '22023';
+  END IF;
+
+  INSERT INTO public.editorial_candidates (
+    provider,
+    provider_id,
+    type,
+    title,
+    artist_name,
+    cover_url,
+    deezer_url,
+    source,
+    source_label,
+    seed_label,
+    tier,
+    reason,
+    score,
+    status,
+    decision_note,
+    metadata,
+    created_by,
+    decided_by,
+    starter_track_id,
+    decided_at,
+    updated_at
+  )
+  VALUES (
+    p_provider,
+    p_provider_id,
+    p_type,
+    btrim(p_title),
+    nullif(btrim(coalesce(p_artist_name, '')), ''),
+    nullif(btrim(coalesce(p_cover_url, '')), ''),
+    nullif(btrim(coalesce(p_deezer_url, '')), ''),
+    p_source,
+    btrim(p_source_label),
+    nullif(btrim(coalesce(p_seed_label, '')), ''),
+    p_tier,
+    nullif(btrim(coalesce(p_reason, '')), ''),
+    coalesce(p_score, 0),
+    'queued',
+    NULL,
+    coalesce(p_metadata, '{}'::jsonb),
+    auth.uid(),
+    NULL,
+    NULL,
+    NULL,
+    now()
+  )
+  ON CONFLICT (provider, provider_id, type)
+  DO UPDATE SET
+    title = EXCLUDED.title,
+    artist_name = EXCLUDED.artist_name,
+    cover_url = EXCLUDED.cover_url,
+    deezer_url = EXCLUDED.deezer_url,
+    source = EXCLUDED.source,
+    source_label = EXCLUDED.source_label,
+    seed_label = EXCLUDED.seed_label,
+    tier = EXCLUDED.tier,
+    reason = EXCLUDED.reason,
+    score = greatest(public.editorial_candidates.score, EXCLUDED.score),
+    status = CASE
+      WHEN public.editorial_candidates.status = 'approved' THEN 'approved'
+      ELSE 'queued'
+    END,
+    decision_note = CASE
+      WHEN public.editorial_candidates.status = 'approved' THEN public.editorial_candidates.decision_note
+      ELSE NULL
+    END,
+    metadata = public.editorial_candidates.metadata || EXCLUDED.metadata,
+    updated_at = now(),
+    decided_by = CASE
+      WHEN public.editorial_candidates.status = 'approved' THEN public.editorial_candidates.decided_by
+      ELSE NULL
+    END,
+    decided_at = CASE
+      WHEN public.editorial_candidates.status = 'approved' THEN public.editorial_candidates.decided_at
+      ELSE NULL
+    END
+  RETURNING * INTO v_candidate;
+
+  RETURN v_candidate;
+END;
+$$;
+
+DROP FUNCTION IF EXISTS public.update_editorial_candidate_status(
+  uuid,
+  text,
+  text,
+  uuid
+);
+
+CREATE OR REPLACE FUNCTION public.update_editorial_candidate_status(
+  p_candidate_id uuid,
+  p_status text,
+  p_decision_note text DEFAULT NULL,
+  p_starter_track_id uuid DEFAULT NULL
+)
+RETURNS public.editorial_candidates
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_candidate public.editorial_candidates%rowtype;
+BEGIN
+  IF NOT public.is_starter_curator() THEN
+    RAISE EXCEPTION 'Not allowed to update editorial candidates.'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF p_status NOT IN ('queued', 'approved', 'dismissed', 'archived') THEN
+    RAISE EXCEPTION 'Editorial candidate status is invalid.'
+      USING ERRCODE = '22023';
+  END IF;
+
+  UPDATE public.editorial_candidates
+  SET
+    status = p_status,
+    decision_note = CASE
+      WHEN p_status = 'queued' THEN NULL
+      ELSE nullif(btrim(coalesce(p_decision_note, '')), '')
+    END,
+    starter_track_id = CASE
+      WHEN p_status = 'approved' THEN p_starter_track_id
+      ELSE NULL
+    END,
+    decided_by = CASE
+      WHEN p_status = 'queued' THEN NULL
+      ELSE auth.uid()
+    END,
+    decided_at = CASE
+      WHEN p_status = 'queued' THEN NULL
+      ELSE now()
+    END,
+    updated_at = now()
+  WHERE id = p_candidate_id
+  RETURNING * INTO v_candidate;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Editorial candidate not found.'
+      USING ERRCODE = '02000';
+  END IF;
+
+  RETURN v_candidate;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.upsert_editorial_candidate(
+  text,
+  text,
+  public.entity_type,
+  text,
+  text,
+  text,
+  text,
+  text,
+  text,
+  text,
+  text,
+  text,
+  numeric,
+  jsonb
+) FROM PUBLIC;
+
+REVOKE ALL ON FUNCTION public.update_editorial_candidate_status(
+  uuid,
+  text,
+  text,
+  uuid
+) FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION public.upsert_editorial_candidate(
+  text,
+  text,
+  public.entity_type,
+  text,
+  text,
+  text,
+  text,
+  text,
+  text,
+  text,
+  text,
+  text,
+  numeric,
+  jsonb
+) TO authenticated;
+
+GRANT EXECUTE ON FUNCTION public.update_editorial_candidate_status(
+  uuid,
+  text,
+  text,
+  uuid
+) TO authenticated;
+
+COMMIT;


### PR DESCRIPTION
## What changed

- Adds persistent editorial candidate queue support.
- Adds `editorial_candidates` migration with RLS, grants, and curator-only RPCs.
- Adds `/api/starter/candidate-queue`, queue helpers, validation, database types, and tests.
- Extends Starter Studio so candidates can be saved, reviewed, selected, or dismissed.
- Updates backlog and discovery docs for the completed queue phase.

## Why

The candidate finder needs memory. This queue lets Kocteau keep curator decisions over time instead of losing good candidates between sessions, making the discovery workflow more scalable and easier to continue later.

## Testing

- [ ] Ran `pnpm check`
- [ ] Added screenshots or a short recording for visible web UI changes
- [ ] Confirmed this does not touch auth, Supabase, recommendations, analytics, CI, or release behavior

Additional checks run:

- [x] Ran `node --test apps\web\lib\starter\candidate-queue.test.ts apps\web\lib\starter\candidates.test.ts apps\web\lib\starter\surface.test.ts`
- [x] Ran `pnpm --filter web lint`
- [x] Ran `pnpm --filter web build`
- [x] Ran `git diff --check`

## Changelog impact

No manual `CHANGELOG.md` edit is required. Release Please generates release notes from PR titles and squash commits.

- [x] User-facing web change
- [x] Developer experience or documentation change
- [x] Internal-only change