### PR TITLE
docs: prepare phase 5 feed tuning

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -37,8 +37,9 @@ These items should not be reopened unless a maintainer finds a regression or sta
 | Starter tag taxonomy | done | `era` and `format` are first-class starter signals alongside genre, mood, scene, and style. |
 | Starter Studio tag editing | done | Curators can create and edit starter signals without leaving Studio. |
 | Starter Studio selected-track inspector | done | The secondary rail focuses on the selected song instead of generic modules while curating. |
-| Starter Studio workflow polish | in review | Catalog filters, readiness labels, editorial notes, and archive confirmation live in `feat/starter-studio-workflow-polish`. |
+| Starter Studio workflow polish | done | Catalog filters, readiness labels, editorial notes, and archive confirmation are merged. |
 | Anti-mainstream candidate finder V0 | done | Deezer can propose related/deep-cut candidates without writing to the database. |
+| Editorial candidate queue V1 | done | Curators can persist, revisit, approve, and dismiss candidate suggestions before promoting starter picks. |
 
 ## Near-Term Priorities
 
@@ -386,7 +387,7 @@ Acceptance criteria:
 
 Suggested issue: `feat(web): design editorial candidate queue for starter picks`
 
-State: `in progress` for V1 persistence.
+State: `done` for V1 persistence. Future work should focus on measured curation quality and candidate generation sources, not automatic promotion.
 
 - Add a maintainer-reviewed design for `editorial_candidates` before implementation.
 - Candidate reasons may include review velocity, bookmark growth, read depth, trusted-user activity, emerging tags, and undercovered taste areas.
@@ -406,9 +407,18 @@ Acceptance criteria:
 
 Suggested issue: `feat(web): tune For You ranking with measured signals`
 
+State: `next maintainer phase`. Do not change the recommendation RPC until a baseline snapshot is captured.
+
 - Tune `get_recommended_review_ids` only after analytics events can report feed health.
 - Consider written-review quality, author diversity, entity diversity, exploration, and editorial fallback.
 - Keep the scoring inspectable and reversible.
+
+Implementation path:
+
+1. Run `supabase/scripts/maintenance/feed-tuning-baseline-snapshot.sql` in the Supabase SQL editor and save aggregate results in the PR notes.
+2. Identify one or two ranking hypotheses, such as written-review lift, author/entity diversity, or editorial fallback quality.
+3. Change only `get_recommended_review_ids()` and any directly related indexes/types in one focused PR.
+4. Re-run the same snapshot 7-14 days after deployment before tuning again.
 
 Suggested labels: `feature`, `area:supabase`, `area:recommendations`, `area:analytics`, `needs maintainer decision`
 

--- a/docs/discovery-curation.md
+++ b/docs/discovery-curation.md
@@ -44,9 +44,11 @@ This roadmap is intentionally phased. Current shipped or in-review work:
 - Phase 2 recommendation health has a maintainer Studio surface and aggregate checks.
 - Phase 3A contextual starter rails are in place through a surface/context contract.
 - Phase 3B starter taxonomy work is in place for `era` and `format` signals.
-- Phase 3C starter Studio workflow polish is in review with catalog filters, readiness labels, editorial notes, and safer archive confirmation.
+- Phase 3C starter Studio workflow polish is in place with catalog filters, readiness labels, editorial notes, and safer archive confirmation.
+- Phase 3D anti-mainstream Deezer candidate finder V0 is in place for related and deep-cut suggestions.
+- Phase 4 editorial candidate queue V1 is in place for persisting curator decisions.
 
-Phase 3D adds an anti-mainstream Deezer candidate finder for the curator. It does not write to the database in v0. Phase 4 adds the persistent candidate queue so promising suggestions can be saved, revisited, approved into starter picks, or dismissed.
+Phase 5 is the next maintainer phase. Feed tuning should start with a baseline snapshot before changing the recommendation RPC.
 
 ## Product Model
 
@@ -192,7 +194,7 @@ Useful checks:
 
 Improve `/studio/starter` as a quiet editorial tool for the official curator.
 
-Status: active. The rail, taxonomy, tag editing, selected-song rail inspector, and workflow polish are in place or in review.
+Status: shipped enough for the current starter curation loop. Future work should be narrow visual QA, candidate quality measurement, or measured rail diversity.
 
 Phase 3A starts with the secondary starter rail: starter picks should not feel identical on every screen, and they should not block the main layout render. The rail can use a lightweight surface/context contract, such as `home`, `profile:{username}`, `track:{id}`, `review:{id}`, or `studio:health`, to request a stable daily editorial rotation from `get_starter_tracks_for_surface()`.
 
@@ -215,6 +217,8 @@ Keep it editorial and focused. Do not turn it into a generic admin dashboard.
 ### Phase 3D: Anti-Mainstream Candidate Finder V0
 
 Add a curator-only finder inside `/studio/starter` where Deezer proposes possible starter picks and Kocteau filters them through editorial rules.
+
+Status: shipped for V0. The finder can suggest related and deep-cut candidates, while persistence is handled by the Phase 4 queue.
 
 Principle:
 
@@ -252,7 +256,7 @@ This phase should prove whether a human curator can use algorithmic suggestions 
 
 Introduce `editorial_candidates` as a queue where the system proposes tracks that might deserve human review.
 
-Status: active V1. The first persistent version stores only curator-facing track candidates and decisions. It does not auto-promote candidates into starter picks.
+Status: shipped for V1 persistence. The first persistent version stores only curator-facing track candidates and decisions. It does not auto-promote candidates into starter picks.
 
 Candidate reasons can include:
 
@@ -283,6 +287,8 @@ V1 constraints:
 
 Tune `get_recommended_review_ids` only after Phase 1 and Phase 2 produce enough signal.
 
+Status: next maintainer phase. Capture the baseline with `supabase/scripts/maintenance/feed-tuning-baseline-snapshot.sql` before changing the RPC.
+
 Potential tuning areas:
 
 - written reviews above rating-only entries
@@ -290,6 +296,13 @@ Potential tuning areas:
 - better exploration controls
 - clearer recommendation reason labels
 - stronger editorial fallback when activity is sparse
+
+First pass constraints:
+
+- change one or two scoring hypotheses at a time
+- preserve existing reason labels unless the UI and analytics contract are updated together
+- keep sparse-data fallback useful for new users
+- compare before/after snapshots rather than tuning from intuition
 
 ### Phase 6: Taste Graph
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -194,6 +194,8 @@ The feed presents these picks as a lightweight taste queue. Impressions, passes,
 
 Use `supabase/scripts/maintenance/recommendation-health-checks.sql` to inspect aggregate For You and starter health from the Supabase SQL editor.
 
+Before changing `get_recommended_review_ids()`, run `supabase/scripts/maintenance/feed-tuning-baseline-snapshot.sql` and keep the aggregate output in the PR notes. Run the same script again 7-14 days after deployment before making another ranking change.
+
 Curators can use the internal route:
 
 ```text

--- a/supabase/scripts/maintenance/feed-tuning-baseline-snapshot.sql
+++ b/supabase/scripts/maintenance/feed-tuning-baseline-snapshot.sql
@@ -1,0 +1,202 @@
+-- Kocteau feed tuning baseline snapshot.
+-- Read-only aggregate queries for maintainers before changing
+-- get_recommended_review_ids().
+--
+-- Run in the Supabase SQL editor before a Phase 5 ranking change, then run
+-- again 7-14 days after deployment. Do not export raw analytics rows.
+
+-- 1. Daily For You health.
+SELECT
+  date_trunc('day', created_at) AS day,
+  count(*) FILTER (WHERE event_type = 'feed_loaded') AS feed_loads,
+  count(*) FILTER (WHERE event_type = 'recommendation_fallback') AS fallbacks,
+  count(*) FILTER (WHERE event_type = 'review_impression') AS review_impressions,
+  count(*) FILTER (WHERE event_type = 'review_open') AS review_opens,
+  count(*) FILTER (WHERE event_type IN ('review_read_50', 'review_read_90')) AS review_reads,
+  count(*) FILTER (WHERE event_type = 'for_you_review_action') AS review_actions,
+  round(
+    count(*) FILTER (WHERE event_type = 'recommendation_fallback')::numeric
+    / nullif(count(*) FILTER (WHERE event_type = 'feed_loaded'), 0),
+    4
+  ) AS fallback_rate,
+  round(
+    count(*) FILTER (WHERE event_type = 'review_open')::numeric
+    / nullif(count(*) FILTER (WHERE event_type = 'review_impression'), 0),
+    4
+  ) AS open_rate
+FROM public.analytics_events
+WHERE created_at >= now() - interval '28 days'
+  AND event_type IN (
+    'feed_loaded',
+    'recommendation_fallback',
+    'review_impression',
+    'review_open',
+    'review_read_50',
+    'review_read_90',
+    'for_you_review_action'
+  )
+GROUP BY 1
+ORDER BY 1 DESC;
+
+-- 2. Recommendation reason funnel.
+WITH reason_impressions AS (
+  SELECT
+    metadata->>'review_id' AS review_id,
+    coalesce(metadata->>'reason', 'unknown') AS reason,
+    count(*) AS impressions
+  FROM public.analytics_events
+  WHERE created_at >= now() - interval '28 days'
+    AND event_type = 'review_impression'
+  GROUP BY 1, 2
+),
+reason_opens AS (
+  SELECT
+    metadata->>'review_id' AS review_id,
+    count(*) AS opens
+  FROM public.analytics_events
+  WHERE created_at >= now() - interval '28 days'
+    AND event_type = 'review_open'
+  GROUP BY 1
+),
+reason_reads AS (
+  SELECT
+    metadata->>'review_id' AS review_id,
+    count(*) FILTER (WHERE event_type = 'review_read_50') AS read_50,
+    count(*) FILTER (WHERE event_type = 'review_read_90') AS read_90
+  FROM public.analytics_events
+  WHERE created_at >= now() - interval '28 days'
+    AND event_type IN ('review_read_50', 'review_read_90')
+  GROUP BY 1
+),
+reason_actions AS (
+  SELECT
+    metadata->>'review_id' AS review_id,
+    count(*) FILTER (WHERE metadata->>'action' = 'like') AS likes,
+    count(*) FILTER (WHERE metadata->>'action' = 'bookmark') AS bookmarks,
+    count(*) FILTER (WHERE metadata->>'action' IN ('open_comments', 'comment')) AS comment_opens
+  FROM public.analytics_events
+  WHERE created_at >= now() - interval '28 days'
+    AND event_type = 'for_you_review_action'
+  GROUP BY 1
+)
+SELECT
+  reason_impressions.reason,
+  sum(reason_impressions.impressions) AS impressions,
+  coalesce(sum(reason_opens.opens), 0) AS opens,
+  coalesce(sum(reason_reads.read_50), 0) AS read_50,
+  coalesce(sum(reason_reads.read_90), 0) AS read_90,
+  coalesce(sum(reason_actions.likes), 0) AS likes,
+  coalesce(sum(reason_actions.bookmarks), 0) AS bookmarks,
+  coalesce(sum(reason_actions.comment_opens), 0) AS comment_opens,
+  round(
+    coalesce(sum(reason_opens.opens), 0)::numeric
+    / nullif(sum(reason_impressions.impressions), 0),
+    4
+  ) AS open_rate,
+  round(
+    coalesce(sum(reason_reads.read_90), 0)::numeric
+    / nullif(sum(reason_impressions.impressions), 0),
+    4
+  ) AS deep_read_rate,
+  round(
+    (
+      coalesce(sum(reason_actions.likes), 0)
+      + coalesce(sum(reason_actions.bookmarks), 0)
+      + coalesce(sum(reason_actions.comment_opens), 0)
+    )::numeric
+    / nullif(sum(reason_impressions.impressions), 0),
+    4
+  ) AS action_rate
+FROM reason_impressions
+LEFT JOIN reason_opens
+  ON reason_opens.review_id = reason_impressions.review_id
+LEFT JOIN reason_reads
+  ON reason_reads.review_id = reason_impressions.review_id
+LEFT JOIN reason_actions
+  ON reason_actions.review_id = reason_impressions.review_id
+GROUP BY 1
+ORDER BY impressions DESC;
+
+-- 3. Recent review inventory quality.
+SELECT
+  count(*) AS reviews,
+  count(*) FILTER (WHERE nullif(trim(coalesce(body, '')), '') IS NOT NULL) AS written_reviews,
+  count(*) FILTER (WHERE nullif(trim(coalesce(body, '')), '') IS NULL) AS rating_only_reviews,
+  round(avg(rating)::numeric, 2) AS average_rating,
+  count(DISTINCT author_id) AS authors,
+  count(DISTINCT entity_id) AS entities,
+  sum(greatest(likes_count, 0)) AS likes,
+  sum(greatest(comments_count, 0)) AS comments
+FROM public.reviews
+WHERE created_at >= now() - interval '90 days';
+
+-- 4. Author and entity concentration in recent inventory.
+WITH recent_reviews AS (
+  SELECT id, author_id, entity_id
+  FROM public.reviews
+  WHERE created_at >= now() - interval '90 days'
+),
+author_counts AS (
+  SELECT author_id, count(*) AS review_count
+  FROM recent_reviews
+  GROUP BY 1
+),
+entity_counts AS (
+  SELECT entity_id, count(*) AS review_count
+  FROM recent_reviews
+  GROUP BY 1
+)
+SELECT
+  'authors' AS dimension,
+  count(*) AS distinct_count,
+  max(review_count) AS max_reviews_for_one_value,
+  round(avg(review_count)::numeric, 2) AS average_reviews_per_value
+FROM author_counts
+UNION ALL
+SELECT
+  'entities' AS dimension,
+  count(*) AS distinct_count,
+  max(review_count) AS max_reviews_for_one_value,
+  round(avg(review_count)::numeric, 2) AS average_reviews_per_value
+FROM entity_counts;
+
+-- 5. Reviews with strong engagement but low written context.
+SELECT
+  reviews.id AS review_id,
+  reviews.entity_id,
+  entities.title,
+  entities.artist_name,
+  reviews.rating,
+  reviews.likes_count,
+  reviews.comments_count,
+  reviews.created_at,
+  CASE
+    WHEN nullif(trim(coalesce(reviews.body, '')), '') IS NULL THEN 'rating_only'
+    ELSE 'written'
+  END AS content_state
+FROM public.reviews
+JOIN public.entities
+  ON entities.id = reviews.entity_id
+WHERE reviews.created_at >= now() - interval '180 days'
+ORDER BY
+  (greatest(reviews.likes_count, 0) + greatest(reviews.comments_count, 0)) DESC,
+  reviews.created_at DESC
+LIMIT 25;
+
+-- 6. Editorial fallback inventory.
+SELECT
+  count(*) FILTER (WHERE is_active = true) AS active_starter_tracks,
+  count(*) FILTER (WHERE is_active = false) AS inactive_starter_tracks,
+  count(*) FILTER (WHERE is_active = true AND nullif(trim(coalesce(editorial_note, '')), '') IS NOT NULL) AS active_with_notes,
+  count(*) FILTER (WHERE is_active = true AND nullif(trim(coalesce(editorial_note, '')), '') IS NULL) AS active_without_notes
+FROM public.starter_tracks;
+
+-- 7. Persistent candidate queue state.
+SELECT
+  status,
+  count(*) AS candidates,
+  min(created_at) AS oldest_created_at,
+  max(updated_at) AS newest_updated_at
+FROM public.editorial_candidates
+GROUP BY 1
+ORDER BY candidates DESC, status ASC;


### PR DESCRIPTION
## What changed

- Updates backlog and discovery docs to reflect merged discovery work.
- Marks Starter Studio workflow polish and Editorial Candidate Queue V1 as done.
- Defines Phase 5 Feed Tuning as the next maintainer phase.
- Adds `supabase/scripts/maintenance/feed-tuning-baseline-snapshot.sql` as a read-only aggregate SQL snapshot before recommendation RPC changes.
- Updates operations docs to require baseline and post-deploy snapshots around `get_recommended_review_ids()` changes.

## Why

The discovery/starter phases are now merged, so the next ranking work needs a clean before/after measurement path. This keeps For You tuning inspectable and avoids changing recommendation SQL from intuition alone.

## Testing

- [ ] Ran `pnpm check`
- [ ] Added screenshots or a short recording for visible web UI changes
- [ ] Confirmed this does not touch auth, Supabase, recommendations, analytics, CI, or release behavior

Additional checks run:

- [x] Ran `git diff --cached --check`
- [x] Reviewed snapshot query fields against local migration definitions
- [x] Confirmed the SQL is read-only aggregate maintenance guidance

## Changelog impact

No manual `CHANGELOG.md` edit is required. Release Please generates release notes from PR titles and squash commits.

- [ ] User-facing web change
- [x] Developer experience or documentation change
- [x] Internal-only change