### PR TITLE
feat(web): show public starter picks

### DIFF
--- a/apps/web/app/(main)/page.tsx
+++ b/apps/web/app/(main)/page.tsx
@@ -10,7 +10,10 @@ import {
   getFeedPage,
   getFeedViewerState,
 } from "@/lib/queries/feed";
-import { getStarterTracksForSurface } from "@/lib/queries/starter";
+import {
+  getPublicStarterTracks,
+  getStarterTracksForSurface,
+} from "@/lib/queries/starter";
 import { createServerQueryClient } from "@/lib/react-query/server";
 import { buildFeedPageJsonLd } from "@/lib/structured-data";
 import { feedKeys, type FeedInfiniteQueryData } from "@/queries/feed";
@@ -35,12 +38,7 @@ export default async function HomePage({
   const user = await userPromise;
   const activeView = requestedView ?? (user ? "for-you" : "latest");
   const tabActiveView = activeView === "latest" ? "for-you" : activeView;
-  const [publicBundle, starterTracks] = await Promise.all([
-    getFeedPage({
-      view: activeView,
-      viewerId: user?.id,
-      includeActiveUsers: false,
-    }),
+  const starterTracksPromise =
     activeView === "for-you" && user?.id
       ? getStarterTracksForSurface({
           viewerId: user.id,
@@ -48,7 +46,16 @@ export default async function HomePage({
           surface: "home",
           contextKey: "home",
         })
-      : Promise.resolve([]),
+      : !user
+        ? getPublicStarterTracks({ limit: 6, contextKey: "home" })
+        : Promise.resolve([]);
+  const [publicBundle, starterTracks] = await Promise.all([
+    getFeedPage({
+      view: activeView,
+      viewerId: user?.id,
+      includeActiveUsers: false,
+    }),
+    starterTracksPromise,
   ]);
   const viewerStatePromise =
     user?.id && publicBundle.feed.length > 0

--- a/apps/web/app/api/starter/rail/route.ts
+++ b/apps/web/app/api/starter/rail/route.ts
@@ -1,6 +1,9 @@
 import { NextResponse } from "next/server";
 import { getCurrentUser } from "@/lib/auth/server";
-import { getStarterTracksForSurface } from "@/lib/queries/starter";
+import {
+  getPublicStarterTracks,
+  getStarterTracksForSurface,
+} from "@/lib/queries/starter";
 import {
   getStarterContextKey,
   isStarterSurface,
@@ -38,17 +41,24 @@ function getRailContextKey(req: Request, surface: StarterSurface) {
 
 export async function GET(req: Request) {
   const user = await getCurrentUser();
+  const surface = getRailSurface(req);
+  const limit = getRailLimit(req);
+  const contextKey = getRailContextKey(req, surface);
 
   if (!user) {
-    return NextResponse.json({ tracks: [] });
+    const tracks = await getPublicStarterTracks({
+      limit,
+      contextKey,
+    });
+
+    return NextResponse.json({ tracks });
   }
 
-  const surface = getRailSurface(req);
   const tracks = await getStarterTracksForSurface({
     viewerId: user.id,
-    limit: getRailLimit(req),
+    limit,
     surface,
-    contextKey: getRailContextKey(req, surface),
+    contextKey,
   });
 
   return NextResponse.json({ tracks });

--- a/apps/web/components/feed-review-list.tsx
+++ b/apps/web/components/feed-review-list.tsx
@@ -310,7 +310,7 @@ export default function FeedReviewList({
           tracks={visibleStarterTracks}
           isAuthenticated={isAuthenticated}
           variant={isAuthenticated ? "personalized" : "editorial"}
-          className={isAuthenticated ? "lg:hidden" : undefined}
+          className="lg:hidden"
         />
       ) : null}
 

--- a/apps/web/components/feed-review-list.tsx
+++ b/apps/web/components/feed-review-list.tsx
@@ -277,11 +277,13 @@ export default function FeedReviewList({
     isAuthenticated &&
     visibleStarterTracks.length > 0 &&
     reviews.length < 4;
-  const showMobileStarterShelf =
-    view === "for-you" &&
-    isAuthenticated &&
+  const showStarterShelf =
     visibleStarterTracks.length > 0 &&
-    reviews.length > 0;
+    reviews.length > 0 &&
+    (
+      (isAuthenticated && view === "for-you") ||
+      (!isAuthenticated && view === "latest")
+    );
   const showReviewCta = view === "for-you" || view === "latest";
 
   if (reviews.length === 0) {
@@ -303,11 +305,12 @@ export default function FeedReviewList({
         <FeedReviewCta isAuthenticated={isAuthenticated} />
       ) : null}
 
-      {showMobileStarterShelf ? (
+      {showStarterShelf ? (
         <FeedStarterShelf
           tracks={visibleStarterTracks}
           isAuthenticated={isAuthenticated}
-          className="lg:hidden"
+          variant={isAuthenticated ? "personalized" : "editorial"}
+          className={isAuthenticated ? "lg:hidden" : undefined}
         />
       ) : null}
 
@@ -333,7 +336,7 @@ export default function FeedReviewList({
       })}
 
       {showStarterLayer ? (
-        <div className={showMobileStarterShelf ? "hidden lg:block" : undefined}>
+        <div className={showStarterShelf ? "hidden lg:block" : undefined}>
           <FeedStarterLayer
             tracks={visibleStarterTracks}
             isAuthenticated={isAuthenticated}

--- a/apps/web/components/feed-starter-shelf.tsx
+++ b/apps/web/components/feed-starter-shelf.tsx
@@ -107,12 +107,10 @@ export default function FeedStarterShelf({
     ? {
         label: "Starter picks",
         description: "Start with something worth reviewing.",
-        countLabel: "Editorial",
       }
     : {
         label: "Starter picks",
         description: "Find your next review.",
-        countLabel: `${visibleTracks.length} picks`,
       };
 
   useEffect(() => {
@@ -151,7 +149,7 @@ export default function FeedStarterShelf({
       )}
       aria-label="Starter picks"
     >
-      <div className="flex items-end justify-between gap-3 px-0.5">
+      <div className="flex items-start gap-3 px-0.5">
         <div className="min-w-0">
           <div className="flex items-center gap-2 text-[12px] font-medium leading-none text-muted-foreground/74">
             <Sparkles className="size-3.5" />
@@ -161,9 +159,6 @@ export default function FeedStarterShelf({
             {shelfCopy.description}
           </p>
         </div>
-        <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground/58">
-          {shelfCopy.countLabel}
-        </span>
       </div>
 
       <TrackCarousel

--- a/apps/web/components/feed-starter-shelf.tsx
+++ b/apps/web/components/feed-starter-shelf.tsx
@@ -13,6 +13,7 @@ import { cn } from "@/lib/utils";
 type FeedStarterShelfProps = {
   tracks: StarterTrack[];
   isAuthenticated: boolean;
+  variant?: "editorial" | "personalized";
   className?: string;
 };
 
@@ -97,10 +98,22 @@ function StarterShelfTrigger({
 export default function FeedStarterShelf({
   tracks,
   isAuthenticated,
+  variant = "personalized",
   className,
 }: FeedStarterShelfProps) {
   const trackedImpressionIdsRef = useRef(new Set<string>());
   const visibleTracks = useMemo(() => tracks.slice(0, 6), [tracks]);
+  const shelfCopy = variant === "editorial"
+    ? {
+        label: "Starter picks",
+        description: "Start with something worth reviewing.",
+        countLabel: "Editorial",
+      }
+    : {
+        label: "Starter picks",
+        description: "Find your next review.",
+        countLabel: `${visibleTracks.length} picks`,
+      };
 
   useEffect(() => {
     if (!isAuthenticated || visibleTracks.length === 0) {
@@ -142,14 +155,14 @@ export default function FeedStarterShelf({
         <div className="min-w-0">
           <div className="flex items-center gap-2 text-[12px] font-medium leading-none text-muted-foreground/74">
             <Sparkles className="size-3.5" />
-            Starter picks
+            {shelfCopy.label}
           </div>
           <p className="mt-1 text-[13px] leading-5 text-muted-foreground/82">
-            Find your next review.
+            {shelfCopy.description}
           </p>
         </div>
         <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground/58">
-          {visibleTracks.length} picks
+          {shelfCopy.countLabel}
         </span>
       </div>
 

--- a/apps/web/components/feed-view-tabs.tsx
+++ b/apps/web/components/feed-view-tabs.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import Link from "next/link";
-import { motion, useReducedMotion } from "motion/react";
 import type { FeedView } from "@/lib/feed-view";
 import { cn } from "@/lib/utils";
 
@@ -42,12 +41,10 @@ export default function FeedViewTabs({
   fullWidth = false,
   className,
 }: FeedViewTabsProps) {
-  const prefersReducedMotion = useReducedMotion();
-
   return (
     <div
       className={cn(
-        "kocteau-feed-tabs relative grid min-w-0 grid-cols-3 gap-1 overflow-visible rounded-[var(--kocteau-radius-control)] p-0.5",
+        "kocteau-feed-tabs relative grid min-w-0 grid-cols-3 gap-1 overflow-visible rounded-full p-0.5",
         fullWidth ? "w-full" : "w-full max-w-[17.25rem] lg:w-[17.25rem]",
         className,
       )}
@@ -61,27 +58,11 @@ export default function FeedViewTabs({
             href={getFeedViewHref(view.value)}
             aria-current={isActive ? "page" : undefined}
             className={cn(
-              "relative z-10 inline-flex h-8 items-center justify-center rounded-[0.52rem] px-2.5 text-[13px] font-medium text-muted-foreground/78 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/70 focus-visible:ring-offset-0",
+              "relative z-10 inline-flex h-8 items-center justify-center rounded-full px-2.5 text-[13px] font-medium text-muted-foreground/78 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/70 focus-visible:ring-offset-0",
               fullWidth ? "min-w-0 px-2" : "min-w-[5.1rem]",
-              isActive ? "text-foreground" : "hover:text-foreground",
+              isActive ? "kocteau-feed-tab-active text-foreground" : "hover:text-foreground",
             )}
           >
-            {isActive ? (
-              <motion.span
-                layoutId="feed-tab-active"
-                className="kocteau-feed-tab-active absolute inset-x-1 inset-y-1 rounded-[0.44rem]"
-                transition={
-                  prefersReducedMotion
-                    ? {
-                        duration: 0,
-                      }
-                    : {
-                        duration: 0.18,
-                        ease: "easeOut",
-                      }
-                }
-              />
-            ) : null}
             <span className={cn("relative z-10", fullWidth && "truncate")}>{view.label}</span>
           </Link>
         );

--- a/apps/web/components/guest-header.tsx
+++ b/apps/web/components/guest-header.tsx
@@ -29,7 +29,7 @@ export default function GuestHeader() {
             href="/login"
             className={cn(
               buttonVariants({ variant: "outline", size: "sm" }),
-              "rounded-full border-border/30 px-4 text-foreground",
+              "h-10 rounded-full border-foreground bg-foreground px-4 text-background shadow-[0_10px_28px_rgba(0,0,0,0.28)] hover:border-foreground/90 hover:bg-foreground/90 hover:text-background",
             )}
           >
             Log in

--- a/apps/web/components/header.tsx
+++ b/apps/web/components/header.tsx
@@ -197,7 +197,7 @@ export default function Header({
               <Button
                 variant="outline"
                 size="sm"
-                className="mobile-liquid-button pointer-events-auto h-10 rounded-full px-4 text-foreground md:h-8 md:rounded-[0.62rem] md:border-border/30 md:px-3 md:text-xs"
+                className="pointer-events-auto h-10 rounded-full border-foreground bg-foreground px-4 text-background shadow-[0_10px_28px_rgba(0,0,0,0.28)] transition-[background-color,border-color,color,transform,box-shadow] duration-150 ease-out hover:border-foreground/90 hover:bg-foreground/90 hover:text-background active:scale-[0.96] md:h-8 md:rounded-[0.62rem] md:px-3 md:text-xs"
               >
                 Log in
               </Button>

--- a/apps/web/components/mobile-bottom-bar.tsx
+++ b/apps/web/components/mobile-bottom-bar.tsx
@@ -142,7 +142,7 @@ export default function MobileBottomBar({ profile }: MobileBottomBarProps) {
               <button
                 type="button"
                 aria-label={reviewEntryLabel}
-                className="flex size-10 items-center justify-center rounded-full border border-sidebar-border/70 bg-[var(--kocteau-surface-control)] text-foreground shadow-none transition-[transform,background-color,border-color] duration-150 ease-out hover:bg-[var(--kocteau-surface-control-hover)] active:scale-[0.96]"
+                className="flex size-10 items-center justify-center rounded-full border border-foreground bg-foreground text-background shadow-[0_10px_28px_rgba(0,0,0,0.32)] transition-[transform,background-color,border-color,color] duration-150 ease-out hover:border-foreground/90 hover:bg-foreground/90 hover:text-background active:scale-[0.96]"
               >
                 <ReviewGlyphIcon className="size-[1.05rem]" />
                 <span className="sr-only">{reviewEntryLabel}</span>

--- a/apps/web/components/nav-main.tsx
+++ b/apps/web/components/nav-main.tsx
@@ -56,7 +56,11 @@ export function NavMain({
                 )}
               </SidebarMenuButton>
               {item.badge && item.badge > 0 ? (
-                <SidebarMenuBadge>{item.badge > 99 ? "99+" : item.badge}</SidebarMenuBadge>
+                <SidebarMenuBadge
+                  role="status"
+                  aria-label={`${item.badge} unread`}
+                  className="right-2 !h-1.5 !w-1.5 !min-w-[0.375rem] rounded-full bg-sidebar-foreground/72 !p-0 text-transparent shadow-[0_0_0_2px_var(--sidebar)] peer-data-active/menu-button:bg-sidebar-foreground"
+                />
               ) : null}
             </SidebarMenuItem>
           ))}

--- a/apps/web/components/nav-secondary.tsx
+++ b/apps/web/components/nav-secondary.tsx
@@ -49,7 +49,11 @@ export function NavSecondary({
                 </Link>
               </SidebarMenuButton>
               {item.badge && item.badge > 0 ? (
-                <SidebarMenuBadge>{item.badge > 99 ? "99+" : item.badge}</SidebarMenuBadge>
+                <SidebarMenuBadge
+                  role="status"
+                  aria-label={`${item.badge} unread`}
+                  className="right-2 !h-1.5 !w-1.5 !min-w-[0.375rem] rounded-full bg-sidebar-foreground/72 !p-0 text-transparent shadow-[0_0_0_2px_var(--sidebar)] peer-data-active/menu-button:bg-sidebar-foreground"
+                />
               ) : null}
             </SidebarMenuItem>
           ))}

--- a/apps/web/components/notifications-button.tsx
+++ b/apps/web/components/notifications-button.tsx
@@ -112,9 +112,10 @@ export default function NotificationsButton({
         >
           <BellSimpleIcon className="size-4" weight={unreadCount > 0 ? "fill" : "regular"} />
           {unreadCount > 0 ? (
-            <span className="absolute -right-1 -top-1 inline-flex min-w-5 items-center justify-center rounded-[0.45rem] bg-foreground px-1.5 py-0.5 text-[10px] font-semibold leading-none text-background shadow-sm">
-              {unreadCount > 99 ? "99+" : unreadCount}
-            </span>
+            <span
+              className="absolute right-1.5 top-1.5 size-1.5 rounded-full bg-foreground shadow-[0_0_0_2px_var(--sidebar)]"
+              aria-hidden="true"
+            />
           ) : null}
         </Button>
       </PopoverTrigger>

--- a/apps/web/components/ui/drawer.tsx
+++ b/apps/web/components/ui/drawer.tsx
@@ -61,7 +61,7 @@ function DrawerContent({
         )}
         {...props}
       >
-        <div className="mx-auto mt-4 hidden h-1.5 w-[100px] shrink-0 rounded-full bg-muted group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
+        <div className="mx-auto mt-2.5 hidden h-[3px] w-20 shrink-0 rounded-full bg-foreground/20 shadow-[0_0_0_1px_rgba(255,255,255,0.025)] group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
         {children}
       </DrawerPrimitive.Content>
     </DrawerPortal>

--- a/apps/web/components/who-to-follow-rail.tsx
+++ b/apps/web/components/who-to-follow-rail.tsx
@@ -27,6 +27,17 @@ type StarterRailResponse = {
 };
 
 const stableStarterRailQueryPath = "/api/starter/rail?surface=app&context=global";
+const railFooterLinks = [
+  ...helpFooterLinks,
+  {
+    href: "https://github.com/francozeta/kocteau",
+    label: "GitHub",
+  },
+  {
+    href: "https://discord.gg/FgrNjkPa8",
+    label: "Discord",
+  },
+] as const;
 
 function useDesktopRail() {
   const [isDesktop, setIsDesktop] = useState(false);
@@ -246,15 +257,22 @@ export default function WhoToFollowRail({ isAuthenticated }: WhoToFollowRailProp
 
         <footer className="mt-5 px-1 pb-8 pt-1 text-[11px] leading-5 text-muted-foreground/52">
           <div className="flex flex-wrap gap-x-2 gap-y-0.5">
-            {helpFooterLinks.map((link) => (
-              <PrefetchLink
-                key={link.href}
-                href={link.href}
-                className="transition-colors hover:text-muted-foreground"
-              >
-                {link.label}
-              </PrefetchLink>
-            ))}
+            {railFooterLinks.map((link) => {
+              const isExternal = link.href.startsWith("http");
+
+              return (
+                <PrefetchLink
+                  key={link.href}
+                  href={link.href}
+                  prefetch={!isExternal}
+                  target={isExternal ? "_blank" : undefined}
+                  rel={isExternal ? "noreferrer" : undefined}
+                  className="transition-colors hover:text-muted-foreground"
+                >
+                  {link.label}
+                </PrefetchLink>
+              );
+            })}
           </div>
           <p>© 2026 Kocteau</p>
         </footer>

--- a/apps/web/components/who-to-follow-rail.tsx
+++ b/apps/web/components/who-to-follow-rail.tsx
@@ -26,6 +26,8 @@ type StarterRailResponse = {
   tracks: StarterTrack[];
 };
 
+const stableStarterRailQueryPath = "/api/starter/rail?surface=app&context=global";
+
 function useDesktopRail() {
   const [isDesktop, setIsDesktop] = useState(false);
 
@@ -107,18 +109,25 @@ export default function WhoToFollowRail({ isAuthenticated }: WhoToFollowRailProp
   const isStudioRoute = pathname?.startsWith("/studio") ?? false;
   const customRailContent = useSecondaryRailContent();
   const hasCustomRailContent = customRailContent !== null;
-  const starterRailQueryPath = useMemo(
+  const publicStarterRailQueryPath = useMemo(
     () => getStarterRailQueryPath(pathname),
     [pathname],
   );
+  const starterRailQueryPath = isAuthenticated
+    ? stableStarterRailQueryPath
+    : publicStarterRailQueryPath;
   const { data, isLoading } = useQuery({
     ...activeProfilesQueryOptions(3),
     enabled: isDesktop && !isStudioRoute,
   });
   const { data: starterRail, isLoading: isStarterRailLoading } = useQuery({
-    queryKey: ["starter", "rail", starterRailQueryPath],
+    queryKey: [
+      "starter",
+      "rail",
+      isAuthenticated ? "global" : starterRailQueryPath,
+    ],
     queryFn: () => fetchJson<StarterRailResponse>(starterRailQueryPath),
-    enabled: isDesktop && isAuthenticated && !isStudioRoute,
+    enabled: isDesktop && !isStudioRoute,
     staleTime: 5 * 60 * 1000,
     gcTime: 30 * 60 * 1000,
   });
@@ -127,7 +136,6 @@ export default function WhoToFollowRail({ isAuthenticated }: WhoToFollowRailProp
   const showStarterRail =
     !hasCustomRailContent &&
     !isStudioRoute &&
-    isAuthenticated &&
     (isStarterRailLoading || visibleStarterTracks.length > 0);
 
   return (

--- a/apps/web/lib/queries/starter.ts
+++ b/apps/web/lib/queries/starter.ts
@@ -2,8 +2,30 @@ import "server-only";
 
 import { measureServerTask } from "@/lib/perf";
 import type { StarterSurface } from "@/lib/starter/surface";
+import {
+  createStarterRotationSeed,
+  rotateStarterTracks,
+} from "@/lib/starter/rotation";
 import { supabaseServer } from "@/lib/supabase/server";
 import type { StarterTrack } from "@/lib/starter";
+
+type PublicStarterTrackRow = Pick<
+  StarterTrack,
+  | "id"
+  | "provider"
+  | "provider_id"
+  | "type"
+  | "title"
+  | "artist_name"
+  | "cover_url"
+  | "deezer_url"
+  | "prompt"
+  | "editorial_note"
+> & {
+  is_featured: boolean;
+  sort_order: number;
+  created_at: string;
+};
 
 type StarterEntityLookup = {
   id: string;
@@ -29,6 +51,85 @@ function isMissingSurfaceRpc(error: { code?: string | null; message?: string | n
     error.code === "PGRST202" ||
     error.code === "42883" ||
     Boolean(error.message?.includes("get_starter_tracks_for_surface"))
+  );
+}
+
+function mapPublicStarterTrack(track: PublicStarterTrackRow): StarterTrack {
+  return {
+    id: track.id,
+    provider: track.provider,
+    provider_id: track.provider_id,
+    type: track.type,
+    title: track.title,
+    artist_name: track.artist_name,
+    cover_url: track.cover_url,
+    deezer_url: track.deezer_url,
+    prompt: track.prompt,
+    editorial_note: track.editorial_note,
+    collection_slug: "starter-picks",
+    collection_title: "Starter picks",
+    matched_tag_count: 0,
+    score: track.is_featured ? 0.35 : 0,
+  };
+}
+
+export async function getPublicStarterTracks({
+  limit = 6,
+  seed,
+  contextKey = "public",
+}: {
+  limit?: number;
+  seed?: string;
+  contextKey?: string | null;
+} = {}): Promise<StarterTrack[]> {
+  return measureServerTask(
+    "getPublicStarterTracks",
+    async () => {
+      const supabase = await supabaseServer();
+      const requestedLimit = Math.max(1, Math.min(limit, 12));
+      const lookupLimit = Math.max(12, Math.min(requestedLimit * 4, 36));
+      const { data, error } = await supabase
+        .from("starter_tracks")
+        .select(`
+          id,
+          provider,
+          provider_id,
+          type,
+          title,
+          artist_name,
+          cover_url,
+          deezer_url,
+          prompt,
+          editorial_note,
+          is_featured,
+          sort_order,
+          created_at
+        `)
+        .eq("is_active", true)
+        .order("is_featured", { ascending: false })
+        .order("sort_order", { ascending: true })
+        .order("created_at", { ascending: false })
+        .limit(lookupLimit)
+        .returns<PublicStarterTrackRow[]>();
+
+      if (error) {
+        console.error("[starter.getPublicStarterTracks] failed", {
+          code: error.code ?? null,
+          message: error.message ?? null,
+        });
+
+        return [];
+      }
+
+      const rotationSeed = `${seed ?? createStarterRotationSeed()}:${contextKey ?? "public"}`;
+
+      return rotateStarterTracks((data ?? []).map(mapPublicStarterTrack), rotationSeed)
+        .slice(0, requestedLimit);
+    },
+    {
+      limit,
+      contextKey,
+    },
   );
 }
 

--- a/apps/web/lib/starter/rotation.test.ts
+++ b/apps/web/lib/starter/rotation.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createStarterRotationSeed,
+  rotateStarterTracks,
+} from "./rotation.ts";
+
+const tracks = [
+  { id: "starter-1", provider_id: "1001", title: "One" },
+  { id: "starter-2", provider_id: "1002", title: "Two" },
+  { id: "starter-3", provider_id: "1003", title: "Three" },
+  { id: "starter-4", provider_id: "1004", title: "Four" },
+  { id: "starter-5", provider_id: "1005", title: "Five" },
+  { id: "starter-6", provider_id: "1006", title: "Six" },
+];
+
+test("starter track rotation is stable for the same seed", () => {
+  const first = rotateStarterTracks(tracks, "2026-06-03:4");
+  const second = rotateStarterTracks(tracks, "2026-06-03:4");
+
+  assert.deepEqual(first.map((track) => track.id), second.map((track) => track.id));
+});
+
+test("starter track rotation does not mutate the source list", () => {
+  const source = [...tracks];
+
+  rotateStarterTracks(source, "2026-06-03:4");
+
+  assert.deepEqual(source.map((track) => track.id), tracks.map((track) => track.id));
+});
+
+test("starter rotation seed changes every three UTC hours", () => {
+  assert.equal(
+    createStarterRotationSeed(new Date("2026-06-03T05:59:00Z")),
+    "2026-06-03:1",
+  );
+  assert.equal(
+    createStarterRotationSeed(new Date("2026-06-03T06:00:00Z")),
+    "2026-06-03:2",
+  );
+});

--- a/apps/web/lib/starter/rotation.ts
+++ b/apps/web/lib/starter/rotation.ts
@@ -1,0 +1,31 @@
+export function createStarterRotationSeed(now = new Date()) {
+  const day = now.toISOString().slice(0, 10);
+  const hourSlot = Math.floor(now.getUTCHours() / 3);
+
+  return `${day}:${hourSlot}`;
+}
+
+function hashString(value: string) {
+  let hash = 2166136261;
+
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+
+  return hash >>> 0;
+}
+
+export function rotateStarterTracks<T extends { id: string; provider_id?: string | null }>(
+  tracks: readonly T[],
+  seed: string,
+) {
+  return tracks
+    .map((track, index) => ({
+      index,
+      score: hashString(`${seed}:${track.id}:${track.provider_id ?? ""}`),
+      track,
+    }))
+    .sort((left, right) => left.score - right.score || left.index - right.index)
+    .map(({ track }) => track);
+}


### PR DESCRIPTION
## What changed

- Shows public Starter picks as a signed-out discovery demo while keeping desktop from showing duplicate Starter picks in both the main feed and the right rail.
- Polishes public CTAs: white login button, white mobile review action, cleaner feed tabs, and calmer Starter picks shelf metadata.
- Refines sidebar and rail details: unread notifications now use minimal dots, rail footer includes GitHub and Discord, and review drawers have a clearer drag handle.

## Why

Signed-out users should immediately understand that Kocteau can help them find something worth reviewing, without the interface feeling duplicated or noisy. These changes make the public experience more intentional on mobile and desktop while preserving Kocteau’s quiet editorial tone.

## Testing

- [ ] Ran `pnpm check`
- [ ] Added screenshots or a short recording for visible web UI changes
- [ ] Confirmed this does not touch auth, Supabase, recommendations, analytics, CI, or release behavior

Additional verification run:

- `pnpm --filter web lint`
- `pnpm --filter web build`
- `git diff --check`
- Playwright/browser checks for desktop and mobile layout, Starter picks visibility, footer links, drawer handle, and horizontal overflow.

## Changelog impact

No manual `CHANGELOG.md` edit is required. Release Please generates release notes from PR titles and squash commits.

- [x] User-facing web change
- [ ] Developer experience or documentation change
- [ ] Internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Guest users can now view public starter content on the home feed and in the starter rail
  * Starter tracks display with personalized or editorial variants based on authentication status

* **Style**
  * Simplified navigation tab styling with cleaner active indicators
  * Refreshed login and action button styling across the app
  * Updated notification badge indicators to use visual dots instead of numeric counters
  * Redesigned drawer divider elements

* **Tests**
  * Added test coverage for starter track rotation logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->