### PR TITLE
feat(web): add toast preview system

### DIFF
--- a/apps/web/app/(main)/toast-preview/page.tsx
+++ b/apps/web/app/(main)/toast-preview/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next"
+
+import { ToastPreviewClient } from "@/components/toast-preview-client"
+
+export const metadata: Metadata = {
+  title: "Toast Preview",
+  robots: {
+    index: false,
+    follow: false,
+  },
+}
+
+export default function ToastPreviewPage() {
+  return <ToastPreviewClient />
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -574,6 +574,135 @@
     background: var(--kocteau-surface-featured-hover);
   }
 
+  .kocteau-toast {
+    --kocteau-toast-accent: color-mix(in oklch, var(--foreground) 56%, transparent);
+    --kocteau-toast-bg: color-mix(in oklch, var(--kocteau-surface) 82%, black);
+    --kocteau-toast-border: color-mix(in oklch, var(--kocteau-toast-accent) 42%, var(--kocteau-line));
+    --kocteau-toast-fg: var(--foreground);
+    width: min(20rem, calc(100vw - 2rem)) !important;
+    border: 1px solid var(--kocteau-toast-border) !important;
+    border-radius: 999px !important;
+    background: var(--kocteau-toast-bg) !important;
+    color: var(--kocteau-toast-fg) !important;
+    box-shadow:
+      0 18px 55px rgba(0, 0, 0, 0.34),
+      inset 0 1px 0 color-mix(in oklch, var(--foreground) 6%, transparent) !important;
+    min-height: 2.35rem;
+    align-items: center !important;
+    gap: 0.45rem !important;
+    margin-inline: auto !important;
+    padding: 0.42rem 0.55rem !important;
+    backdrop-filter: blur(18px) saturate(112%);
+    -webkit-backdrop-filter: blur(18px) saturate(112%);
+  }
+
+  .kocteau-toast-default,
+  .kocteau-toast-info,
+  .kocteau-toast-loading {
+    --kocteau-toast-accent: color-mix(in oklch, var(--foreground) 52%, transparent);
+    --kocteau-toast-bg: color-mix(in oklch, var(--kocteau-surface) 84%, black);
+  }
+
+  .kocteau-toast-success {
+    --kocteau-toast-accent: oklch(0.84 0.12 152);
+    --kocteau-toast-bg: color-mix(in oklch, oklch(0.84 0.12 152) 9%, var(--kocteau-canvas));
+  }
+
+  .kocteau-toast-warning {
+    --kocteau-toast-accent: oklch(0.84 0.14 78);
+    --kocteau-toast-bg: color-mix(in oklch, oklch(0.84 0.14 78) 11%, var(--kocteau-canvas));
+  }
+
+  .kocteau-toast-error {
+    --kocteau-toast-accent: oklch(0.72 0.2 22);
+    --kocteau-toast-bg: color-mix(in oklch, oklch(0.72 0.2 22) 13%, var(--kocteau-canvas));
+  }
+
+  .kocteau-toast-icon {
+    display: grid !important;
+    place-items: center;
+    flex: 0 0 1rem;
+    align-items: center;
+    justify-content: center;
+    width: 1rem !important;
+    height: 1rem !important;
+    border-radius: 999px;
+    margin: 0 !important;
+    color: var(--kocteau-toast-accent);
+    background: transparent;
+    line-height: 0 !important;
+  }
+
+  .kocteau-toast [data-content] {
+    display: flex !important;
+    justify-content: center !important;
+    min-width: 0;
+    min-height: 1rem;
+    gap: 0 !important;
+  }
+
+  .kocteau-toast [data-icon] > svg,
+  .kocteau-toast [data-icon] > span,
+  .kocteau-toast-icon svg {
+    margin: 0 !important;
+  }
+
+  .kocteau-toast-icon svg {
+    width: 0.9rem !important;
+    height: 0.9rem !important;
+  }
+
+  .kocteau-toast-title {
+    color: var(--kocteau-toast-fg) !important;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 0.78rem !important;
+    font-weight: 600 !important;
+    line-height: 1.05 !important;
+    letter-spacing: 0;
+  }
+
+  .kocteau-toast [data-title] {
+    display: block;
+    line-height: 1rem !important;
+  }
+
+  .kocteau-toast-description {
+    display: none !important;
+    color: color-mix(in oklch, var(--foreground) 70%, transparent) !important;
+    font-size: 0.75rem !important;
+    line-height: 1.25 !important;
+  }
+
+  .kocteau-toast-action,
+  .kocteau-toast-cancel {
+    height: 1.75rem !important;
+    border-radius: 999px !important;
+    padding-inline: 0.75rem !important;
+    font-size: 0.72rem !important;
+    font-weight: 650 !important;
+  }
+
+  .kocteau-toast-action {
+    border: 1px solid color-mix(in oklch, var(--foreground) 28%, transparent) !important;
+    background: var(--foreground) !important;
+    color: var(--background) !important;
+  }
+
+  .kocteau-toast-cancel {
+    border: 1px solid var(--kocteau-line) !important;
+    background: color-mix(in oklch, var(--foreground) 7%, transparent) !important;
+    color: var(--foreground) !important;
+  }
+
+  .kocteau-toast-close {
+    border-radius: 999px !important;
+    border-color: var(--kocteau-line) !important;
+    background: color-mix(in oklch, var(--kocteau-canvas) 82%, black) !important;
+    color: color-mix(in oklch, var(--foreground) 72%, transparent) !important;
+  }
+
   @media (min-width: 1024px) {
     .kocteau-app-frame {
       background: var(--kocteau-shell);
@@ -665,6 +794,12 @@
       box-shadow: none !important;
       backdrop-filter: blur(14px) saturate(108%) !important;
       -webkit-backdrop-filter: blur(14px) saturate(108%) !important;
+    }
+
+    .kocteau-toast {
+      width: min(20rem, calc(100vw - 2rem)) !important;
+      min-height: 2.35rem;
+      padding: 0.42rem 0.55rem !important;
     }
 
     .dark .mobile-liquid-button {

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -66,7 +66,7 @@ export default function RootLayout({
         {children}
         <Analytics />
         <SpeedInsights />
-        <Toaster position="bottom-right" richColors />
+        <Toaster />
       </body>
     </html>
   );

--- a/apps/web/components/profile-editor-form.tsx
+++ b/apps/web/components/profile-editor-form.tsx
@@ -339,7 +339,9 @@ export default function ProfileEditorForm({
         });
       }
 
-      toastActionSuccess("Profile updated.");
+      if (mode === "settings") {
+        toastActionSuccess("Profile updated.");
+      }
     } catch (error) {
       const profileError = error as Error & { code?: string };
 

--- a/apps/web/components/toast-preview-client.tsx
+++ b/apps/web/components/toast-preview-client.tsx
@@ -1,0 +1,168 @@
+"use client"
+
+import { useState, type ReactNode } from "react"
+import { toast } from "sonner"
+
+import { Button } from "@/components/ui/button"
+import {
+  IconAlertOctagon,
+  IconAlertTriangle,
+  IconCircleCheck,
+  IconInfoCircle,
+} from "@/components/ui/icons"
+import { Spinner } from "@/components/ui/spinner"
+import { cn } from "@/lib/utils"
+
+type ToastSample = {
+  title: string
+  description: string
+  icon: ReactNode
+  action: () => void
+}
+
+const samples: ToastSample[] = [
+  {
+    title: "Neutral",
+    description: "Saved as a quiet app note.",
+    icon: <IconInfoCircle className="size-3.5" />,
+    action: () => {
+      toast("Track note saved")
+    },
+  },
+  {
+    title: "Success",
+    description: "Review and curation actions.",
+    icon: <IconCircleCheck className="size-3.5" />,
+    action: () => {
+      toast.success("Review published")
+    },
+  },
+  {
+    title: "Warning",
+    description: "Soft validation before a save.",
+    icon: <IconAlertTriangle className="size-3.5" />,
+    action: () => {
+      toast.warning("Taste signal is thin")
+    },
+  },
+  {
+    title: "Destructive",
+    description: "Errors without loud UI.",
+    icon: <IconAlertOctagon className="size-3.5" />,
+    action: () => {
+      toast.error("Could not save review")
+    },
+  },
+]
+
+export function ToastPreviewClient() {
+  const [isLoadingPreview, setIsLoadingPreview] = useState(false)
+
+  const showLoadingPreview = () => {
+    if (isLoadingPreview) return
+
+    setIsLoadingPreview(true)
+    const id = toast.loading("Saving taste")
+
+    window.setTimeout(() => {
+      toast.success("Taste updated", {
+        id,
+      })
+      setIsLoadingPreview(false)
+    }, 1600)
+  }
+
+  const showActionPreview = () => {
+    toast("Log in to save reviews", {
+      action: {
+        label: "Log in",
+        onClick: () => toast.success("Action clicked"),
+      },
+    })
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-3xl flex-col gap-5 py-5 sm:py-6 lg:pb-10">
+      <section className="border-b border-[var(--kocteau-line-soft)] pb-5">
+        <p className="text-[0.68rem] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+          Studio
+        </p>
+        <h1 className="mt-2 text-xl font-semibold tracking-normal text-foreground">
+          Toast preview
+        </h1>
+        <p className="mt-2 max-w-xl text-sm leading-6 text-muted-foreground">
+          A small feedback surface for review, taste, and curation actions.
+        </p>
+      </section>
+
+      <section className="grid gap-2 sm:grid-cols-2">
+        {samples.map((sample) => (
+          <button
+            key={sample.title}
+            type="button"
+            onClick={sample.action}
+            className="group flex min-h-24 items-start gap-3 rounded-[var(--kocteau-radius-card)] border border-[var(--kocteau-line-soft)] bg-[var(--kocteau-surface)] p-4 text-left transition-colors hover:border-[var(--kocteau-line)] hover:bg-[var(--kocteau-surface-raised)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30"
+          >
+            <span
+              className={cn(
+                "mt-0.5 inline-flex size-7 shrink-0 items-center justify-center rounded-full border border-[var(--kocteau-line-soft)] bg-[var(--kocteau-surface-control)] text-muted-foreground",
+                sample.title === "Destructive" && "text-destructive",
+              )}
+            >
+              {sample.icon}
+            </span>
+            <span className="min-w-0">
+              <span className="block text-sm font-semibold text-foreground">
+                {sample.title}
+              </span>
+              <span className="mt-1 block text-xs leading-5 text-muted-foreground">
+                {sample.description}
+              </span>
+            </span>
+          </button>
+        ))}
+      </section>
+
+      <section className="flex flex-col gap-3 rounded-[var(--kocteau-radius-card)] border border-[var(--kocteau-line-soft)] bg-[var(--kocteau-surface)] p-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="min-w-0">
+          <p className="text-sm font-semibold text-foreground">Loading transition</p>
+          <p className="mt-1 text-xs leading-5 text-muted-foreground">
+            Uses the same classic loading mark as Notifications.
+          </p>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          {isLoadingPreview ? (
+            <Spinner className="size-4 text-muted-foreground" />
+          ) : null}
+          <Button
+            type="button"
+            size="lg"
+            className="rounded-full"
+            onClick={showLoadingPreview}
+            disabled={isLoadingPreview}
+          >
+            {isLoadingPreview ? "Saving" : "Show loading"}
+          </Button>
+        </div>
+      </section>
+
+      <section className="flex flex-col gap-3 rounded-[var(--kocteau-radius-card)] border border-[var(--kocteau-line-soft)] bg-transparent p-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="min-w-0">
+          <p className="text-sm font-semibold text-foreground">Action toast</p>
+          <p className="mt-1 text-xs leading-5 text-muted-foreground">
+            Mirrors the login prompt used from signed-out interactions.
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="lg"
+          className="rounded-full"
+          onClick={showActionPreview}
+        >
+          Show action
+        </Button>
+      </section>
+    </div>
+  )
+}

--- a/apps/web/components/ui/sonner.tsx
+++ b/apps/web/components/ui/sonner.tsx
@@ -1,16 +1,28 @@
 "use client"
 
+import type { CSSProperties } from "react"
 import { useTheme } from "next-themes"
 import { Toaster as Sonner, type ToasterProps } from "sonner"
-import { IconCircleCheck, IconInfoCircle, IconAlertTriangle, IconAlertOctagon, IconLoader } from "@/components/ui/icons"
+import { IconCircleCheck, IconInfoCircle, IconAlertTriangle, IconAlertOctagon } from "@/components/ui/icons"
+import { Spinner } from "@/components/ui/spinner"
 
-const Toaster = ({ ...props }: ToasterProps) => {
+const Toaster = ({
+  position = "bottom-center",
+  offset = { bottom: "1.25rem" },
+  mobileOffset = { bottom: "calc(env(safe-area-inset-bottom) + 6.35rem)" },
+  ...props
+}: ToasterProps) => {
   const { theme = "system" } = useTheme()
 
   return (
     <Sonner
       theme={theme as ToasterProps["theme"]}
-      className="toaster group"
+      className="kocteau-toaster group"
+      position={position}
+      offset={offset}
+      mobileOffset={mobileOffset}
+      gap={8}
+      visibleToasts={3}
       icons={{
         success: (
           <IconCircleCheck className="size-4" />
@@ -25,20 +37,33 @@ const Toaster = ({ ...props }: ToasterProps) => {
           <IconAlertOctagon className="size-4" />
         ),
         loading: (
-          <IconLoader className="size-4 animate-spin" />
+          <Spinner className="size-4" />
         ),
       }}
       style={
         {
-          "--normal-bg": "var(--popover)",
-          "--normal-text": "var(--popover-foreground)",
-          "--normal-border": "var(--border)",
-          "--border-radius": "var(--radius)",
-        } as React.CSSProperties
+          "--width": "20rem",
+          "--normal-bg": "color-mix(in oklch, var(--kocteau-surface) 88%, black)",
+          "--normal-text": "var(--foreground)",
+          "--normal-border": "var(--kocteau-line)",
+          "--border-radius": "999px",
+        } as CSSProperties
       }
       toastOptions={{
         classNames: {
-          toast: "cn-toast",
+          toast: "kocteau-toast",
+          title: "kocteau-toast-title",
+          description: "kocteau-toast-description",
+          icon: "kocteau-toast-icon",
+          actionButton: "kocteau-toast-action",
+          cancelButton: "kocteau-toast-cancel",
+          closeButton: "kocteau-toast-close",
+          default: "kocteau-toast-default",
+          success: "kocteau-toast-success",
+          info: "kocteau-toast-info",
+          warning: "kocteau-toast-warning",
+          error: "kocteau-toast-error",
+          loading: "kocteau-toast-loading",
         },
       }}
       {...props}

--- a/docs/ai/motion-rules.md
+++ b/docs/ai/motion-rules.md
@@ -6,6 +6,13 @@ These rules define how to use `motion/react` in Kocteau.
 
 Motion is optional by default. Do not animate a surface just because animation is available.
 
+Reference inspiration:
+
+- [Transitions.dev](https://transitions.dev/) for reusable interaction patterns such as icon swaps, success checks, notification badges, tab indicators, panel reveals, tooltip entrances, and text-state swaps.
+- [Details that make interfaces feel better](https://interfaces.dev/magazine/issues/details-that-make-interfaces-feel-better#animate-icons-contextually) for contextual icon motion, interruptibility, staggered entrances, subtle exits, optical alignment, tabular numbers, and text polish.
+
+Use these references as craft direction, not as a visual theme. Kocteau should still feel dark, editorial, restrained, and review-led.
+
 ## Purpose
 
 Use motion only when it improves:
@@ -23,6 +30,19 @@ Kocteau motion should feel:
 - contextual
 - physically believable
 - faster than decorative product marketing motion
+
+## Motion Contract
+
+Default interaction values:
+
+- CSS transitions: `160ms` to `220ms`, `var(--kocteau-ease)` or `cubic-bezier(0.2, 0, 0, 1)`
+- Motion springs: `type: "spring"`, `duration: 0.3`, `bounce: 0`
+- Press feedback: `scale(0.96)` only when it helps the control feel tactile
+- Enter offsets: `y: 6` to `12`, `opacity: 0`, optional `filter: "blur(4px)"`
+- Exit offsets: smaller than entry, usually `y: -8` to `-12`
+- Icon swap scale: `0.25` to `1`, with `opacity` and `blur(4px)` to `blur(0px)`
+
+Use CSS transitions for interactive state changes because they retarget when the user changes intent. Use keyframes only for staged one-shot sequences such as a success check or a temporary badge pop.
 
 ## Prefer
 
@@ -48,6 +68,8 @@ Kocteau motion should feel:
 - long staged sequences for routine product actions
 - blur-heavy entrances when a simpler transition communicates the same thing
 - `transition-all`
+- bounce on routine UI; Kocteau motion should feel composed, not playful
+- first-load animations for default state controls
 
 ## Interaction Guidance
 
@@ -56,6 +78,68 @@ Kocteau motion should feel:
 - routine product interactions should feel immediate
 - the user should never wait for an animation to finish before understanding state
 - shared-layout transitions should stay readable even if interrupted halfway
+- keep controls usable while motion is running
+- use `AnimatePresence initial={false}` for toggles, icon swaps, tabs, and segmented controls that already have a default page-load state
+
+## Contextual Icons
+
+Animate icons only when the icon represents a state change or appears contextually.
+
+Good examples:
+
+- like to liked
+- save to saved
+- review action to success
+- play to pause
+- search clear icon appearing after input
+- overflow actions appearing on hover or focus
+
+Do not animate static navigation icons, decorative icons, or icons that are always visible and not changing state.
+
+Use this `motion/react` shape when possible:
+
+```tsx
+<AnimatePresence initial={false} mode="popLayout">
+  <motion.span
+    key={isActive ? "active" : "inactive"}
+    initial={{ opacity: 0, scale: 0.25, filter: "blur(4px)" }}
+    animate={{ opacity: 1, scale: 1, filter: "blur(0px)" }}
+    exit={{ opacity: 0, scale: 0.25, filter: "blur(4px)" }}
+    transition={{ type: "spring", duration: 0.3, bounce: 0 }}
+  >
+    <Icon />
+  </motion.span>
+</AnimatePresence>
+```
+
+If CSS is enough, keep both icons mounted and cross-fade with exact transition properties. Do not add another dependency for icon motion.
+
+## Entrances And Exits
+
+When a surface appears, split the motion by semantic chunks instead of animating a large block:
+
+- title or track identity first
+- supporting copy second
+- actions last
+
+Stagger small groups by roughly `80ms` to `100ms`. Keep blur subtle and remove it if text feels soft or slow.
+
+Exit animations should be quieter than entrances. Use smaller movement, shorter duration, and never make the outgoing element demand more attention than the incoming state.
+
+## Pattern Guidance
+
+Adapt these patterns when they serve the review/discovery loop:
+
+- card resize: only when a selected track, composer, or contextual rail panel expands from an existing surface
+- number pop-in: ratings, counts, unread dots, and small counters with `tabular-nums`
+- notification badge: unread indicators and success badges, not decorative attention grabs
+- text-state swap: saving to saved, publish to published, loading to ready
+- origin-aware menu: dropdowns, context menus, and overflow actions should open from their trigger
+- panel reveal: drawers, review composer, secondary rail details, and starter studio panels
+- tab sliding: active feed/studio tabs may use a shared indicator
+- success check: one-shot publish/save confirmation, kept quick and quiet
+- error shake: only for direct form validation, never for whole pages or review cards
+- tooltip open: appear with a slight delay, exit immediately or almost immediately
 
 ## Review Guidance
 
@@ -64,6 +148,8 @@ Kocteau motion should feel:
 - Fix issues visible at slow speed; the full-speed interaction will feel more polished.
 - Prefer contextual icon swaps that animate opacity, scale, and subtle blur instead of hard toggles.
 - Keep exit animations softer than entrance animations.
+- Check optical alignment after motion settles. If an icon looks off even when geometrically centered, adjust the icon or its local padding.
+- Confirm dynamic numbers use `tabular-nums` before animating them.
 
 ## Good Places to Use Motion in Kocteau
 
@@ -73,6 +159,9 @@ Kocteau motion should feel:
 - like/save/bookmark feedback
 - contextual icon swaps
 - cards entering a newly filtered or reordered state
+- selected song preview appearing in the studio rail
+- toast status changes such as loading to success
+- review composer drawer handle, sheet, and publish-state transitions
 
 ## Bad Places to Use Motion in Kocteau
 


### PR DESCRIPTION
## What changed

- Redesigned the global Sonner toast styling for a thinner, centered, rounded Kocteau feedback surface.
- Moved global toasts to bottom-center and adjusted mobile offset above the bottom bar.
- Reused the classic Kocteau loading spinner for toast loading states.
- Added temporary `/toast-preview` route to test neutral, success, warning, destructive, action, and loading toasts.
- Prevented profile onboarding from showing a success toast after profile creation.
- Updated `docs/ai/motion-rules.md` with concrete animation guidance for contextual icon motion, toast state changes, panel transitions, and subtle exits.

## Why

To make app feedback feel more editorial, minimal, and consistent with Kocteau’s dark interface while giving us a preview route to polish toast behavior before applying it broadly.

## Testing

- [ ] Ran `pnpm check`
- [x] Added screenshots or a short recording for visible web UI changes
- [ ] Confirmed this does not touch auth, Supabase, recommendations, analytics, CI, or release behavior

Ran instead:
- [x] `pnpm --filter web lint`
- [x] `pnpm --filter web build`
- [x] `git diff --check`

Note: this touches profile onboarding toast behavior, but does not change Supabase/Auth/RLS logic.

## Changelog impact

No manual `CHANGELOG.md` edit is required. Release Please generates release notes from PR titles and squash commits.

- [x] User-facing web change
- [x] Developer experience or documentation change
- [ ] Internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Toast Preview page to showcase notification styles and variants (success, warning, error, loading states)
  * Notifications now support action buttons with callback handling

* **Improvements**
  * Updated toast notification styling and visual appearance
  * Enhanced loading state animations with improved visual feedback
  * Optimized mobile toast display with better spacing and positioning
  * Toast notifications now display up to 3 simultaneously with improved layout

<!-- end of auto-generated comment: release notes by coderabbit.ai -->