### PR TITLE
fix(web): tune toast placement and contrast

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -577,9 +577,9 @@
   .kocteau-toast {
     --kocteau-toast-accent: color-mix(in oklch, var(--foreground) 56%, transparent);
     --kocteau-toast-bg: color-mix(in oklch, var(--kocteau-surface) 82%, black);
-    --kocteau-toast-border: color-mix(in oklch, var(--kocteau-toast-accent) 42%, var(--kocteau-line));
+    --kocteau-toast-border: color-mix(in oklch, var(--kocteau-toast-accent) 28%, var(--kocteau-line-soft));
     --kocteau-toast-fg: var(--foreground);
-    width: min(20rem, calc(100vw - 2rem)) !important;
+    width: min(17.5rem, calc(100vw - 3rem)) !important;
     border: 1px solid var(--kocteau-toast-border) !important;
     border-radius: 999px !important;
     background: var(--kocteau-toast-bg) !important;
@@ -605,17 +605,17 @@
 
   .kocteau-toast-success {
     --kocteau-toast-accent: oklch(0.84 0.12 152);
-    --kocteau-toast-bg: color-mix(in oklch, oklch(0.84 0.12 152) 9%, var(--kocteau-canvas));
+    --kocteau-toast-bg: color-mix(in oklch, oklch(0.84 0.12 152) 7%, var(--kocteau-canvas));
   }
 
   .kocteau-toast-warning {
     --kocteau-toast-accent: oklch(0.84 0.14 78);
-    --kocteau-toast-bg: color-mix(in oklch, oklch(0.84 0.14 78) 11%, var(--kocteau-canvas));
+    --kocteau-toast-bg: color-mix(in oklch, oklch(0.84 0.14 78) 8%, var(--kocteau-canvas));
   }
 
   .kocteau-toast-error {
     --kocteau-toast-accent: oklch(0.72 0.2 22);
-    --kocteau-toast-bg: color-mix(in oklch, oklch(0.72 0.2 22) 13%, var(--kocteau-canvas));
+    --kocteau-toast-bg: color-mix(in oklch, oklch(0.72 0.2 22) 9%, var(--kocteau-canvas));
   }
 
   .kocteau-toast-icon {
@@ -797,7 +797,7 @@
     }
 
     .kocteau-toast {
-      width: min(20rem, calc(100vw - 2rem)) !important;
+      width: min(17.5rem, calc(100vw - 3rem)) !important;
       min-height: 2.35rem;
       padding: 0.42rem 0.55rem !important;
     }

--- a/apps/web/components/ui/sonner.tsx
+++ b/apps/web/components/ui/sonner.tsx
@@ -7,9 +7,9 @@ import { IconCircleCheck, IconInfoCircle, IconAlertTriangle, IconAlertOctagon } 
 import { Spinner } from "@/components/ui/spinner"
 
 const Toaster = ({
-  position = "bottom-center",
-  offset = { bottom: "1.25rem" },
-  mobileOffset = { bottom: "calc(env(safe-area-inset-bottom) + 6.35rem)" },
+  position = "bottom-right",
+  offset = { bottom: "1.25rem", right: "1.25rem" },
+  mobileOffset = { bottom: "calc(env(safe-area-inset-bottom) + 4.8rem)" },
   ...props
 }: ToasterProps) => {
   const { theme = "system" } = useTheme()
@@ -42,7 +42,7 @@ const Toaster = ({
       }}
       style={
         {
-          "--width": "20rem",
+          "--width": "17.5rem",
           "--normal-bg": "color-mix(in oklch, var(--kocteau-surface) 88%, black)",
           "--normal-text": "var(--foreground)",
           "--normal-border": "var(--kocteau-line)",


### PR DESCRIPTION
## What changed

- Added a temporary `/toast-preview` route to review Kocteau toast states.
- Redesigned global Sonner toasts with a thinner rounded style, classic Kocteau loading spinner, smaller width, and mobile offset above the bottom bar.
- Restored desktop toast placement to bottom-right.
- Removed onboarding success toast after profile creation.
- Added motion guidance to `docs/ai/motion-rules.md` for contextual icon motion, toast state changes, panel transitions, and subtle exits.

## Why

To make feedback feel more polished, quieter, and consistent with Kocteau’s dark editorial interface while keeping a preview route available for visual QA.

## Testing

- [ ] Ran `pnpm check`
- [x] Added screenshots or a short recording for visible web UI changes
- [ ] Confirmed this does not touch auth, Supabase, recommendations, analytics, CI, or release behavior

Ran instead:

- [x] `pnpm --filter web lint`
- [x] `pnpm --filter web build`
- [x] `git diff --check`

Note: this touches profile onboarding toast behavior, but does not change Supabase/Auth/RLS logic.

## Changelog impact

No manual `CHANGELOG.md` edit is required. Release Please generates release notes from PR titles and squash commits.

- [x] User-facing web change
- [x] Developer experience or documentation change
- [ ] Internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
- Repositioned toast notifications from bottom-center to bottom-right
- Adjusted toast notification width and refined visual styling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->