### PR TITLE
feat(web): improve starter signals and rail variety

### DIFF
--- a/apps/web/app/api/starter/rail/route.ts
+++ b/apps/web/app/api/starter/rail/route.ts
@@ -18,7 +18,7 @@ function getRailLimit(req: Request) {
     return 6;
   }
 
-  return Math.max(1, Math.min(Math.trunc(parsedLimit), 8));
+  return Math.max(1, Math.min(Math.trunc(parsedLimit), 12));
 }
 
 function getRailSurface(req: Request): StarterSurface {

--- a/apps/web/components/starter-studio-client.tsx
+++ b/apps/web/components/starter-studio-client.tsx
@@ -70,7 +70,8 @@ type StarterDraftTrack = Pick<
 >;
 
 const defaultPrompt = "What should people pay attention to here?";
-const starterTagLimit = 6;
+const starterSignalTarget = 6;
+const starterTagLimit = 12;
 const starterTagKinds = preferenceKindOrder;
 const starterTagKindSet = new Set<PreferenceKind>(starterTagKinds);
 const requiredEditorialKinds = ["era", "format"] as const satisfies readonly PreferenceKind[];
@@ -195,6 +196,22 @@ function getTrackStatus(track: StarterTrackWithTags) {
   }
 
   return "Ready";
+}
+
+function formatSignalCount(count: number) {
+  if (count >= starterSignalTarget) {
+    return `${count} signal${count === 1 ? "" : "s"}`;
+  }
+
+  return `${count}/${starterSignalTarget}`;
+}
+
+function formatSelectedSignalCount(count: number) {
+  if (count >= starterSignalTarget) {
+    return `${count} selected`;
+  }
+
+  return `${count}/${starterSignalTarget} selected`;
 }
 
 export default function StarterStudioClient() {
@@ -399,7 +416,7 @@ export default function StarterStudioClient() {
       }
 
       if (next.size >= starterTagLimit) {
-        toast.error(`Choose ${starterTagLimit} starter tags or fewer.`);
+        toast.error(`Choose ${starterTagLimit} starter signals or fewer.`);
         return current;
       }
 
@@ -826,7 +843,7 @@ export default function StarterStudioClient() {
               <div className="rounded-lg border border-border/22 bg-background/24 px-3 py-2">
                 <p className="text-muted-foreground">Signals</p>
                 <p className="mt-1 tabular-nums text-foreground">
-                  {inspectedTags.length}/{starterTagLimit}
+                  {formatSignalCount(inspectedTags.length)}
                 </p>
               </div>
               <div className="rounded-lg border border-border/22 bg-background/24 px-3 py-2">
@@ -1073,7 +1090,7 @@ export default function StarterStudioClient() {
                   {inspectedStatus}
                 </Badge>
                 <span className="text-xs tabular-nums text-muted-foreground">
-                  {inspectedTags.length}/{starterTagLimit}
+                  {formatSignalCount(inspectedTags.length)}
                 </span>
               </div>
             </div>
@@ -1150,7 +1167,7 @@ export default function StarterStudioClient() {
           <div className="flex items-center gap-2 text-xs tabular-nums text-muted-foreground">
             <span>{starterTracks.length} picks</span>
             <span className="size-1 rounded-full bg-muted-foreground/30" />
-            <span>{selectedTagIds.size}/{starterTagLimit} selected</span>
+            <span>{formatSelectedSignalCount(selectedTagIds.size)}</span>
           </div>
         </div>
 
@@ -1229,7 +1246,7 @@ export default function StarterStudioClient() {
                 </div>
               ) : (
                 <p className="px-1 py-1.5 text-xs text-muted-foreground">
-                  Pick up to six signals before adding or updating a starter pick.
+                  Six signals is ready. Add more only when they sharpen the pick.
                 </p>
               )}
             </div>

--- a/apps/web/components/who-to-follow-rail.tsx
+++ b/apps/web/components/who-to-follow-rail.tsx
@@ -14,7 +14,10 @@ import { Skeleton } from "@/components/ui/skeleton";
 import UserAvatar from "@/components/user-avatar";
 import { helpFooterLinks } from "@/lib/help";
 import type { StarterTrack } from "@/lib/starter";
-import { getStarterRailQueryPath } from "@/lib/starter/surface";
+import {
+  getStarterRailQueryPath,
+  getStarterSurfaceFromPathname,
+} from "@/lib/starter/surface";
 import { fetchJson } from "@/queries/http";
 import { activeProfilesQueryOptions } from "@/queries/profiles";
 
@@ -26,7 +29,8 @@ type StarterRailResponse = {
   tracks: StarterTrack[];
 };
 
-const stableStarterRailQueryPath = "/api/starter/rail?surface=app&context=global";
+const starterRailDisplayLimit = 6;
+const starterRailFetchLimit = 12;
 const railFooterLinks = [
   ...helpFooterLinks,
   {
@@ -55,6 +59,48 @@ function useDesktopRail() {
   }, []);
 
   return isDesktop;
+}
+
+function withStarterRailLimit(path: string) {
+  const separator = path.includes("?") ? "&" : "?";
+
+  return `${path}${separator}limit=${starterRailFetchLimit}`;
+}
+
+function getAuthenticatedStarterRailQueryPath(pathname: string | null) {
+  const surface = getStarterSurfaceFromPathname(pathname);
+  const params = new URLSearchParams({
+    surface,
+    context: `${surface}:rail`,
+    limit: String(starterRailFetchLimit),
+  });
+
+  return `/api/starter/rail?${params.toString()}`;
+}
+
+function hashStarterRailKey(value: string) {
+  let hash = 0;
+
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash * 31 + value.charCodeAt(index)) >>> 0;
+  }
+
+  return hash;
+}
+
+function rotateStarterTracks(
+  tracks: StarterTrack[],
+  contextKey: string,
+  limit: number,
+) {
+  if (tracks.length <= limit) {
+    return tracks.slice(0, limit);
+  }
+
+  const offset = hashStarterRailKey(contextKey) % tracks.length;
+  const rotatedTracks = [...tracks.slice(offset), ...tracks.slice(0, offset)];
+
+  return rotatedTracks.slice(0, limit);
 }
 
 function StarterPickReviewTrigger({
@@ -121,11 +167,15 @@ export default function WhoToFollowRail({ isAuthenticated }: WhoToFollowRailProp
   const customRailContent = useSecondaryRailContent();
   const hasCustomRailContent = customRailContent !== null;
   const publicStarterRailQueryPath = useMemo(
-    () => getStarterRailQueryPath(pathname),
+    () => withStarterRailLimit(getStarterRailQueryPath(pathname)),
+    [pathname],
+  );
+  const authenticatedStarterRailQueryPath = useMemo(
+    () => getAuthenticatedStarterRailQueryPath(pathname),
     [pathname],
   );
   const starterRailQueryPath = isAuthenticated
-    ? stableStarterRailQueryPath
+    ? authenticatedStarterRailQueryPath
     : publicStarterRailQueryPath;
   const { data, isLoading } = useQuery({
     ...activeProfilesQueryOptions(3),
@@ -135,7 +185,7 @@ export default function WhoToFollowRail({ isAuthenticated }: WhoToFollowRailProp
     queryKey: [
       "starter",
       "rail",
-      isAuthenticated ? "global" : starterRailQueryPath,
+      starterRailQueryPath,
     ],
     queryFn: () => fetchJson<StarterRailResponse>(starterRailQueryPath),
     enabled: isDesktop && !isStudioRoute,
@@ -143,7 +193,15 @@ export default function WhoToFollowRail({ isAuthenticated }: WhoToFollowRailProp
     gcTime: 30 * 60 * 1000,
   });
   const profiles = data?.profiles ?? [];
-  const visibleStarterTracks = (starterRail?.tracks ?? []).slice(0, 6);
+  const visibleStarterTracks = useMemo(
+    () =>
+      rotateStarterTracks(
+        starterRail?.tracks ?? [],
+        starterRailQueryPath,
+        starterRailDisplayLimit,
+      ),
+    [starterRail?.tracks, starterRailQueryPath],
+  );
   const showStarterRail =
     !hasCustomRailContent &&
     !isStudioRoute &&

--- a/apps/web/lib/validation/schemas.ts
+++ b/apps/web/lib/validation/schemas.ts
@@ -238,7 +238,7 @@ export const starterTrackUpsertSchema = z.object({
   is_active: z.boolean().optional().default(true),
   tag_ids: z
     .array(z.string().uuid("Invalid starter tag."))
-    .max(6, "Choose 6 starter tags or fewer.")
+    .max(12, "Choose 12 starter signals or fewer.")
     .optional()
     .default([]),
   collection_slug: z

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -179,7 +179,9 @@ Use `supabase/scripts/maintenance/starter-curation-readiness-audit.sql` before a
 
 For assisted drafting, run `supabase/scripts/maintenance/starter-curation-draft-export.sql` from the SQL editor, copy the JSON cell into `tmp/starter-curation-export.json`, then run `pnpm curate:starter:draft`. The command writes `tmp/starter-curation/draft-input.json`, `draft-prompt.md`, and `draft-output-template.json`. This step still does not write to Supabase; it prepares reviewable input for a human or LLM-assisted curation pass.
 
-After reviewing and filling `tmp/starter-curation/draft-output.json`, run `pnpm curate:starter:sql`. The generated `tmp/starter-curation/apply-starter-curation-drafts.sql` is the SQL Editor patch. It updates prompts and editorial notes, adds existing non-genre tags, preserves manual tags, and refuses to run if any starter track id or tag slug is unknown. Genre candidates are written separately to `genre-candidates-for-review.md` for human review.
+After reviewing and filling `tmp/starter-curation/draft-output.json`, set `humanReviewed` to `true` and fill `reviewedBy` before running `pnpm curate:starter:sql`. The generated `tmp/starter-curation/apply-starter-curation-drafts.sql` is the SQL Editor patch. It updates prompts and editorial notes, adds existing non-genre tags, preserves manual tags, and refuses to run if any starter track id, tag slug, tag kind, or signal count is unsafe. Six non-genre signals is the ready target; twelve is the maintainer ceiling. Genre candidates are written separately to `genre-candidates-for-review.md` for human review, and `curation-review-report.md` summarizes warnings before you copy SQL into Supabase.
+
+This workflow is maintainer-only tooling. Outputs in `tmp/` must stay out of Git, and `--allow-unreviewed` is only for local fixture tests. Do not run generated SQL against Supabase Cloud unless the draft has been human-reviewed.
 
 The easiest way to seed starter picks is the internal route:
 

--- a/supabase/scripts/create-starter-curation-apply-sql.mjs
+++ b/supabase/scripts/create-starter-curation-apply-sql.mjs
@@ -13,7 +13,13 @@ const genreReviewPath = path.resolve(
   repoRoot,
   args.genreOutput ?? "tmp/starter-curation/genre-candidates-for-review.md",
 );
+const reviewReportPath = path.resolve(
+  repoRoot,
+  args.reviewOutput ?? "tmp/starter-curation/curation-review-report.md",
+);
 const tagInputPath = path.resolve(repoRoot, args.tagInput ?? "tmp/starter-curation/draft-input.json");
+const maxSignals = parsePositiveInt(args.maxSignals, 12);
+const targetSignals = parsePositiveInt(args.targetSignals, 6);
 
 if (args.help) {
   printHelp();
@@ -32,13 +38,18 @@ try {
 }
 
 const drafts = normalizeDrafts(payload);
+const reviewState = normalizeReviewState(payload);
 
 if (drafts.length === 0) {
   console.error("No drafts found. Expected a JSON object with a non-empty `drafts` array.");
   process.exit(1);
 }
 
+let safetyReport;
+
 try {
+  validateHumanReview(reviewState, Boolean(args.allowUnreviewed));
+  safetyReport = validateDraftSafety(drafts, { maxSignals, targetSignals });
   await validateDraftTagSlugs(drafts, tagInputPath, Boolean(args.tagInput));
 } catch (error) {
   console.error(error instanceof Error ? error.message : String(error));
@@ -46,11 +57,13 @@ try {
 }
 
 await fs.mkdir(path.dirname(outputPath), { recursive: true });
-await fs.writeFile(outputPath, buildApplySql(drafts), "utf8");
+await fs.writeFile(outputPath, buildApplySql(drafts, reviewState), "utf8");
 await fs.writeFile(genreReviewPath, buildGenreReview(drafts), "utf8");
+await fs.writeFile(reviewReportPath, buildReviewReport(drafts, safetyReport), "utf8");
 
 console.log(`Created ${path.relative(repoRoot, outputPath)}.`);
 console.log(`Created ${path.relative(repoRoot, genreReviewPath)}.`);
+console.log(`Created ${path.relative(repoRoot, reviewReportPath)}.`);
 console.log(`Drafts included: ${drafts.length}`);
 
 function parseArgs(argv) {
@@ -89,6 +102,29 @@ function parseArgs(argv) {
     if (arg === "--tag-input") {
       parsed.tagInput = argv[index + 1];
       index += 1;
+      continue;
+    }
+
+    if (arg === "--review-output") {
+      parsed.reviewOutput = argv[index + 1];
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--max-signals") {
+      parsed.maxSignals = argv[index + 1];
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--target-signals") {
+      parsed.targetSignals = argv[index + 1];
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--allow-unreviewed") {
+      parsed.allowUnreviewed = true;
     }
   }
 
@@ -100,6 +136,7 @@ function printHelp() {
   pnpm curate:starter:sql
   pnpm curate:starter:sql -- --input tmp/starter-curation/draft-output.json
   pnpm curate:starter:sql -- --tag-input tmp/starter-curation/draft-input.json
+  pnpm curate:starter:sql -- --allow-unreviewed
 
 Input:
   tmp/starter-curation/draft-output.json
@@ -107,15 +144,108 @@ Input:
 Output:
   tmp/starter-curation/apply-starter-curation-drafts.sql
   tmp/starter-curation/genre-candidates-for-review.md
+  tmp/starter-curation/curation-review-report.md
 
 The generated SQL:
   - updates prompt and editorial_note
   - inserts existing non-genre starter tags
   - preserves existing manual tags
+  - requires humanReviewed=true and reviewedBy unless --allow-unreviewed is passed
+  - fails when a draft exceeds the configured max signal count
   - validates suggested tag slugs against available tags by kind when draft-input.json exists
   - refuses to run when a starter track id or suggested tag slug is unknown
   - does not apply genre candidates automatically
 `);
+}
+
+function parsePositiveInt(value, fallback) {
+  const parsed = Number.parseInt(value, 10);
+
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function normalizeReviewState(payload) {
+  return {
+    humanReviewed: payload?.humanReviewed === true || payload?.human_reviewed === true,
+    reviewedBy: nullableString(payload?.reviewedBy ?? payload?.reviewed_by),
+    reviewedAt: nullableString(payload?.reviewedAt ?? payload?.reviewed_at),
+  };
+}
+
+function validateHumanReview(reviewState, allowUnreviewed) {
+  if (allowUnreviewed) {
+    return;
+  }
+
+  if (!reviewState.humanReviewed || !reviewState.reviewedBy) {
+    throw new Error(
+      [
+        "Starter curation drafts must be human-reviewed before SQL is generated.",
+        "Set humanReviewed to true and reviewedBy to the maintainer name in draft-output.json.",
+        "Use --allow-unreviewed only for local fixture tests, not for Supabase Cloud patches.",
+      ].join("\n"),
+    );
+  }
+}
+
+function validateDraftSafety(drafts, { maxSignals, targetSignals }) {
+  const errors = [];
+  const warnings = [];
+  const validConfidence = new Set(["low", "medium", "high"]);
+
+  for (const draft of drafts) {
+    const signalCount = countSuggestedSignals(draft);
+
+    if (signalCount > maxSignals) {
+      errors.push(`${draft.starterTrackId}: ${signalCount} non-genre signals exceeds max ${maxSignals}.`);
+    } else if (signalCount > targetSignals) {
+      warnings.push(`${draft.starterTrackId}: ${signalCount} non-genre signals; review for over-tagging.`);
+    }
+
+    if (draft.prompt && draft.prompt.length > 160) {
+      errors.push(`${draft.starterTrackId}: prompt is ${draft.prompt.length} characters; max is 160.`);
+    }
+
+    if (draft.editorialNote && draft.editorialNote.length > 240) {
+      errors.push(`${draft.starterTrackId}: editorialNote is ${draft.editorialNote.length} characters; max is 240.`);
+    }
+
+    if (draft.confidence && !validConfidence.has(draft.confidence)) {
+      errors.push(`${draft.starterTrackId}: confidence must be low, medium, or high.`);
+    }
+
+    if (!draft.rationale) {
+      warnings.push(`${draft.starterTrackId}: rationale is empty.`);
+    }
+
+    if (
+      !draft.prompt &&
+      !draft.editorialNote &&
+      signalCount === 0 &&
+      draft.genreCandidatesForHumanReview.length === 0
+    ) {
+      warnings.push(`${draft.starterTrackId}: draft has no copy, tags, or genre candidates.`);
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new Error(
+      `Starter curation draft failed safety validation:\n${errors.map((error) => `- ${error}`).join("\n")}`,
+    );
+  }
+
+  return {
+    maxSignals,
+    targetSignals,
+    warnings,
+  };
+}
+
+function countSuggestedSignals(draft) {
+  return Object.values(draft.suggestedTagSlugs).reduce(
+    (count, slugs) => count + slugs.length,
+    0,
+  );
 }
 
 async function validateDraftTagSlugs(drafts, inputPath, isExplicitInput) {
@@ -227,13 +357,17 @@ function nullableString(value) {
   return normalized.length > 0 ? normalized : null;
 }
 
-function buildApplySql(drafts) {
+function buildApplySql(drafts, reviewState) {
   const values = drafts.map(toDraftSqlValue).join(",\n");
+  const reviewedBy = reviewState.reviewedBy ?? "unreviewed override";
+  const reviewedAt = reviewState.reviewedAt ?? new Date().toISOString();
 
   return `-- Apply approved starter curation drafts.
 --
 -- Generated by supabase/scripts/create-starter-curation-apply-sql.mjs.
 -- Review before running in the Supabase SQL editor.
+-- Human-reviewed by: ${reviewedBy}
+-- Review timestamp: ${reviewedAt}
 --
 -- Safety rules:
 -- - This script preserves existing starter tags.
@@ -407,5 +541,37 @@ These genre candidates were intentionally not applied to Supabase.
 Review them manually in Starter Studio or create a separate human-approved SQL patch.
 
 ${rows.length > 0 ? rows.join("\n") : "No genre candidates were included in this draft output.\n"}
+`;
+}
+
+function buildReviewReport(drafts, safetyReport) {
+  const warningRows = safetyReport.warnings.map((warning) => `- ${warning}`);
+  const signalRows = drafts.map((draft) => {
+    const signalCount = countSuggestedSignals(draft);
+    const status = signalCount > safetyReport.targetSignals ? "review" : "ok";
+
+    return `| ${draft.starterTrackId} | ${signalCount} | ${status} | ${draft.confidence ?? "unknown"} |`;
+  });
+
+  return `# Starter Curation Review Report
+
+Generated by \`supabase/scripts/create-starter-curation-apply-sql.mjs\`.
+
+## Guardrails
+
+- Target non-genre signals per track: ${safetyReport.targetSignals}
+- Maximum non-genre signals per track: ${safetyReport.maxSignals}
+- Genre candidates are not applied by SQL.
+- SQL generation requires \`humanReviewed: true\` and \`reviewedBy\` unless explicitly bypassed.
+
+## Warnings
+
+${warningRows.length > 0 ? warningRows.join("\n") : "No warnings."}
+
+## Signal Counts
+
+| starterTrackId | signals | status | confidence |
+| --- | ---: | --- | --- |
+${signalRows.join("\n")}
 `;
 }

--- a/supabase/scripts/create-starter-curation-draft.mjs
+++ b/supabase/scripts/create-starter-curation-draft.mjs
@@ -185,8 +185,10 @@ You are helping Kocteau draft missing starter pick metadata.
 - Return JSON only.
 - Use only existing tag slugs from the available tag list.
 - Do not auto-apply genre. You may suggest genre candidates, but mark them for human review.
+- Do not mark the packet as reviewed. Leave humanReviewed false until a maintainer reviews it.
 - Keep prompts short: one question, 80 characters or fewer when possible.
 - Keep editorial notes short: one sentence, calm and music-native.
+- Treat six non-genre signals as ready. Suggest up to twelve only when each signal adds real precision.
 - Favor non-mainstream framing. Familiar artists should usually be treated as deep cuts, contrast picks, or familiar entry points.
 - Do not invent facts such as release years, scenes, or obscure biographical claims if the input does not support them.
 - Use confidence: "low", "medium", or "high".
@@ -195,6 +197,9 @@ You are helping Kocteau draft missing starter pick metadata.
 
 \`\`\`json
 {
+  "humanReviewed": false,
+  "reviewedBy": "",
+  "reviewedAt": "",
   "drafts": [
     {
       "starterTrackId": "uuid",
@@ -227,6 +232,9 @@ ${trackText}
 
 function buildOutputTemplate(tracks) {
   return {
+    humanReviewed: false,
+    reviewedBy: "",
+    reviewedAt: "",
     drafts: tracks.map((track) => ({
       starterTrackId: track.starterTrackId,
       prompt: "",


### PR DESCRIPTION
## What changed

- Relaxed Starter Studio signal handling so 6 signals is the ready target and 12 is the maintainer ceiling.
- Improved desktop starter rail variety by fetching a wider candidate pool and rotating picks by surface.
- Added maintainer guardrails for assisted curation drafts.
- Added human-review checks, signal-count validation, and review reports before SQL generation.

## Why

Starter picks can benefit from richer editorial signals, but the UI should not make 10 signals look broken. The rail also needed more variety on desktop. The assisted curation scripts are useful, but need stronger safety checks before future use.

## Testing

- [x] Ran `pnpm check`
- [ ] Added screenshots or a short recording for visible web UI changes
- [ ] Confirmed this does not touch auth, Supabase, recommendations, analytics, CI, or release behavior

Touches starter rail behavior, Starter Studio validation, and Supabase maintenance tooling.

## Changelog impact

No manual `CHANGELOG.md` edit is required. Release Please generates release notes from PR titles and squash commits.

- [x] User-facing web change
- [x] Developer experience or documentation change
- [x] Internal-only change
