### PR TITLE
feat(web): improve review detail interactions

### DIFF
--- a/apps/web/app/(main)/review/[id]/page.tsx
+++ b/apps/web/app/(main)/review/[id]/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 import { notFound } from "next/navigation";
 import JsonLd from "@/components/json-ld";
 import ReviewPageHeaderBridge from "@/components/review-page-header-bridge";
@@ -28,19 +27,26 @@ function getReviewTitle(review: ReviewPageReview) {
   const entity = review.entities;
   const authorLabel = getAuthorLabel(review);
 
-  if (review.title?.trim() && entity) {
-    return `${review.title.trim()} — ${entity.title}`;
-  }
-
   if (entity) {
-    const trackLabel = entity.artist_name
-      ? `${entity.title} by ${entity.artist_name}`
-      : entity.title;
+    const trackLabel = getTrackLabel(review);
+    const reviewTitle = review.title?.trim();
 
-    return `${trackLabel} review by ${authorLabel}`;
+    return reviewTitle
+      ? `${trackLabel} review by ${authorLabel}: ${reviewTitle}`
+      : `${trackLabel} review by ${authorLabel}`;
   }
 
   return `Review by ${authorLabel}`;
+}
+
+function getTrackLabel(review: ReviewPageReview) {
+  const entity = review.entities;
+
+  if (!entity) {
+    return "Review";
+  }
+
+  return entity.artist_name ? `${entity.title} by ${entity.artist_name}` : entity.title;
 }
 
 export async function generateMetadata({
@@ -113,8 +119,7 @@ export default async function ReviewPage({
   const entity = review.entities;
   const author = review.author;
   const canManage = Boolean(user?.id && author?.id === user.id);
-  const authorLabel = getAuthorLabel(review);
-  const headerTitle = review.title?.trim() || (entity ? `${entity.title} review` : "Review");
+  const headerTitle = getTrackLabel(review);
 
   return (
     <section className="mx-auto w-full max-w-3xl space-y-4 pb-4 sm:space-y-5">
@@ -128,37 +133,6 @@ export default async function ReviewPage({
         artistName={entity?.artist_name}
       />
 
-      <nav
-        aria-label="Breadcrumb"
-        className="flex flex-wrap items-center gap-2 text-[12px] text-muted-foreground"
-      >
-        <Link href="/reviews" className="transition-colors hover:text-foreground">
-          Reviews
-        </Link>
-        {entity ? (
-          <>
-            <span aria-hidden="true">/</span>
-            <Link
-              href={`/track/${entity.id}`}
-              className="line-clamp-1 transition-colors hover:text-foreground"
-            >
-              {entity.title}
-            </Link>
-          </>
-        ) : null}
-        {author?.username ? (
-          <>
-            <span aria-hidden="true">/</span>
-            <Link
-              href={`/u/${author.username}`}
-              className="line-clamp-1 transition-colors hover:text-foreground"
-            >
-              {authorLabel}
-            </Link>
-          </>
-        ) : null}
-      </nav>
-
       <ReviewPageCard
         review={review}
         entity={entity}
@@ -166,26 +140,6 @@ export default async function ReviewPage({
         isAuthenticated={Boolean(user)}
         canManage={canManage}
       />
-
-      {entity ? (
-        <div className="flex flex-wrap items-center gap-2 text-[12px] text-muted-foreground">
-          <span>More context</span>
-          <Link
-            href={`/track/${entity.id}`}
-            className="rounded-[0.5rem] border border-border/28 px-2.5 py-1 text-foreground/86 transition-colors hover:border-border/45 hover:text-foreground"
-          >
-            {entity.title}
-          </Link>
-          {author?.username ? (
-            <Link
-              href={`/u/${author.username}`}
-              className="rounded-[0.5rem] border border-border/28 px-2.5 py-1 text-foreground/86 transition-colors hover:border-border/45 hover:text-foreground"
-            >
-              @{author.username}
-            </Link>
-          ) : null}
-        </div>
-      ) : null}
     </section>
   );
 }

--- a/apps/web/app/(main)/review/[id]/page.tsx
+++ b/apps/web/app/(main)/review/[id]/page.tsx
@@ -124,7 +124,7 @@ export default async function ReviewPage({
   const headerTitle = getTrackLabel(review);
 
   return (
-    <section className="mx-auto w-full max-w-3xl space-y-4 pb-4 sm:space-y-5">
+    <section className="mx-auto w-full max-w-3xl space-y-3 pb-4 sm:space-y-4">
       <JsonLd data={buildReviewPageJsonLd(review)} id="review-structured-data" />
       <ReviewPageHeaderBridge
         reviewId={review.id}
@@ -159,6 +159,9 @@ export default async function ReviewPage({
         }
         variant="inline"
         replyTarget={author?.username ?? null}
+        anchorId="review-replies"
+        composerId="review-reply-composer"
+        autoFocusComposer
       />
     </section>
   );

--- a/apps/web/app/(main)/review/[id]/page.tsx
+++ b/apps/web/app/(main)/review/[id]/page.tsx
@@ -1,9 +1,10 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import JsonLd from "@/components/json-ld";
+import ReviewCommentsPanel from "@/components/review-comments-panel";
 import ReviewPageHeaderBridge from "@/components/review-page-header-bridge";
 import { ReviewPageCard } from "@/components/review-route-cards-server";
-import { getCurrentUser } from "@/lib/auth/server";
+import { getCurrentUser, getCurrentViewerProfile } from "@/lib/auth/server";
 import { createPageMetadata, createReviewDescription } from "@/lib/metadata";
 import {
   getPublicReviewById,
@@ -105,6 +106,7 @@ export default async function ReviewPage({
   }
 
   const user = await getCurrentUser();
+  const viewerProfile = user ? await getCurrentViewerProfile() : null;
   const bundle = await getReviewPageBundle(parsedParams.data.reviewId, user?.id);
 
   if (!bundle) {
@@ -139,6 +141,24 @@ export default async function ReviewPage({
         author={author}
         isAuthenticated={Boolean(user)}
         canManage={canManage}
+      />
+
+      <ReviewCommentsPanel
+        reviewId={review.id}
+        initialCount={review.comments_count}
+        isAuthenticated={Boolean(user)}
+        viewer={
+          viewerProfile
+            ? {
+                id: viewerProfile.id,
+                username: viewerProfile.username,
+                display_name: viewerProfile.display_name,
+                avatar_url: viewerProfile.avatar_url,
+              }
+            : null
+        }
+        variant="inline"
+        replyTarget={author?.username ?? null}
       />
     </section>
   );

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -566,6 +566,11 @@
     background: var(--kocteau-surface-raised-hover);
   }
 
+  .kocteau-review-card [data-prevent-review-link="true"] {
+    position: relative;
+    z-index: 2;
+  }
+
   .kocteau-review-card-featured {
     background: var(--kocteau-surface-featured);
   }

--- a/apps/web/components/review-card-body.tsx
+++ b/apps/web/components/review-card-body.tsx
@@ -67,7 +67,7 @@ export default function ReviewCardBody({
       {canToggle ? (
         <button
           aria-expanded={expanded}
-          className="inline-flex h-8 items-center rounded-[0.48rem] pr-2 text-[12.5px] font-medium text-muted-foreground/82 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30"
+          className="relative z-[2] inline-flex h-8 items-center rounded-[0.48rem] pr-2 text-[12.5px] font-medium text-muted-foreground/82 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30"
           data-prevent-review-link="true"
           onClick={(event) => {
             event.preventDefault();

--- a/apps/web/components/review-card-interaction-bar.tsx
+++ b/apps/web/components/review-card-interaction-bar.tsx
@@ -11,6 +11,10 @@ type ReviewCardInteractionBarProps = {
   isAuthenticated?: boolean;
   bookmarkButtonRef?: Ref<HTMLButtonElement>;
   analyticsSource?: string | null;
+  commentInlineTarget?: {
+    targetId: string;
+    composerId?: string;
+  } | null;
   viewer?: {
     id: string;
     username: string;
@@ -24,6 +28,7 @@ export default function ReviewCardInteractionBar({
   isAuthenticated = false,
   bookmarkButtonRef,
   analyticsSource = null,
+  commentInlineTarget = null,
   viewer = null,
 }: ReviewCardInteractionBarProps) {
   return (
@@ -41,6 +46,7 @@ export default function ReviewCardInteractionBar({
         isAuthenticated={isAuthenticated}
         analyticsSource={analyticsSource}
         viewer={viewer}
+        inlineTarget={commentInlineTarget}
       />
       <ReviewBookmarkButton
         reviewId={review.id}

--- a/apps/web/components/review-card.tsx
+++ b/apps/web/components/review-card.tsx
@@ -1,4 +1,5 @@
 import type { ComponentPropsWithoutRef, ReactNode } from "react";
+import Link from "next/link";
 import { Star } from "@/components/ui/icons";
 import { Badge } from "@/components/ui/badge";
 import EntityCoverImage from "@/components/entity-cover-image";
@@ -44,6 +45,7 @@ export type ReviewCardDisplayOptions = {
   showEntity?: boolean;
   showRatingBadge?: boolean;
   entityMode?: "full" | "inline" | "cover";
+  entityHeadingLevel?: 1 | 2 | 3;
   eyebrow?: string;
   featured?: boolean;
   imagePriority?: boolean;
@@ -65,6 +67,7 @@ export type ReviewCardEntitySummaryProps = {
   className?: string;
   priority?: boolean;
   tone?: ReviewCardCopyTone;
+  headingLevel?: 1 | 2 | 3;
 };
 
 type ReviewCardProps = {
@@ -74,6 +77,8 @@ type ReviewCardProps = {
   display?: ReviewCardDisplayOptions;
   slots?: ReviewCardSlots;
   rootProps?: ComponentPropsWithoutRef<"article">;
+  reviewHref?: string | null;
+  reviewLinkLabel?: string;
 };
 
 function formatDate(value: string) {
@@ -106,12 +111,16 @@ export function ReviewCardEntitySummary({
   className,
   priority = false,
   tone = "default",
+  headingLevel,
 }: ReviewCardEntitySummaryProps) {
   if (!entity) {
     return null;
   }
 
   if (mode === "cover") {
+    const EntityTitle =
+      headingLevel === 1 ? "h1" : headingLevel === 2 ? "h2" : headingLevel === 3 ? "h3" : "p";
+
     return (
       <div
         className={cn(
@@ -119,7 +128,7 @@ export function ReviewCardEntitySummary({
           className,
         )}
       >
-        <p
+        <EntityTitle
           className={cn(
             "line-clamp-2 font-serif font-semibold tracking-normal text-foreground",
             tone === "balanced"
@@ -128,7 +137,7 @@ export function ReviewCardEntitySummary({
           )}
         >
           {entity.title}
-        </p>
+        </EntityTitle>
         <p
           className={cn(
             "line-clamp-1 text-muted-foreground/88",
@@ -229,12 +238,15 @@ export default function ReviewCard({
   display,
   slots,
   rootProps,
+  reviewHref = null,
+  reviewLinkLabel = "Open review",
 }: ReviewCardProps) {
   const {
     showAuthor = true,
     showEntity = true,
     showRatingBadge = true,
     entityMode = "full",
+    entityHeadingLevel,
     eyebrow,
     featured = false,
     bodyClampLines,
@@ -252,11 +264,20 @@ export default function ReviewCard({
     <article
       {...articleProps}
       className={cn(
-        "kocteau-review-card overflow-hidden rounded-[var(--kocteau-radius-card)]",
+        "kocteau-review-card relative isolate overflow-hidden rounded-[var(--kocteau-radius-card)]",
+        reviewHref && "cursor-pointer",
         featured && "kocteau-review-card-featured",
         className,
       )}
     >
+      {reviewHref ? (
+        <Link
+          href={reviewHref}
+          aria-label={reviewLinkLabel}
+          className="absolute inset-0 z-[1] rounded-[inherit] outline-none focus-visible:ring-2 focus-visible:ring-ring/38 focus-visible:ring-inset"
+        />
+      ) : null}
+
       <div className="space-y-3.5 p-3.5 sm:p-4">
         <div className="flex items-start justify-between gap-3">
           <div className="min-w-0 space-y-2">
@@ -304,7 +325,11 @@ export default function ReviewCard({
                   {review.rating.toFixed(1)}
                 </div>
               ) : null}
-              {headerActions}
+              {headerActions ? (
+                <div data-prevent-review-link="true" className="relative z-[2] flex items-center">
+                  {headerActions}
+                </div>
+              ) : null}
             </div>
           ) : null}
         </div>
@@ -321,7 +346,14 @@ export default function ReviewCard({
             </div>
 
             <div className={cn("min-w-0 self-start", usesBalancedCopy ? "space-y-2.5" : "space-y-3")}>
-              {slots?.entity ?? <ReviewCardEntitySummary entity={entity} mode="cover" tone={copyTone} />}
+              {slots?.entity ?? (
+                <ReviewCardEntitySummary
+                  entity={entity}
+                  mode="cover"
+                  tone={copyTone}
+                  headingLevel={entityHeadingLevel}
+                />
+              )}
 
               {hasTitle ? (
                 <h3
@@ -377,7 +409,7 @@ export default function ReviewCard({
         {footer ? (
           <div
             data-prevent-review-link="true"
-            className="flex items-center justify-between gap-3 pt-0.5"
+            className="relative z-[2] flex items-center justify-between gap-3 pt-0.5"
           >
             {footer}
           </div>

--- a/apps/web/components/review-comments-button.tsx
+++ b/apps/web/components/review-comments-button.tsx
@@ -55,6 +55,10 @@ export default function ReviewCommentsButton({
     initialCount,
     enabled: open,
   });
+  const commentsDescription =
+    commentsCount > 0
+      ? `${commentsCount} ${commentsCount === 1 ? "reply" : "replies"}`
+      : "No replies yet";
 
   function handleTriggerClick() {
     if (inlineTarget) {
@@ -120,12 +124,10 @@ export default function ReviewCommentsButton({
       <>
         {trigger}
         <Drawer open={open} onOpenChange={setOpen}>
-          <DrawerContent className="flex h-[88vh] max-h-[88vh] flex-col border-border/30">
-            <DrawerHeader className="border-b border-border/30 text-left">
+          <DrawerContent className="flex h-[88vh] max-h-[88vh] flex-col p-0 text-foreground before:inset-0 before:rounded-t-[1.35rem] before:border-x before:border-b-0 before:border-t before:border-border/36 before:bg-background">
+            <DrawerHeader className="border-b border-border/24 px-4 py-3 text-left">
               <DrawerTitle>Comments</DrawerTitle>
-              <DrawerDescription>
-                {commentsCount} {commentsCount === 1 ? "comment" : "comments"}
-              </DrawerDescription>
+              <DrawerDescription>{commentsDescription}</DrawerDescription>
             </DrawerHeader>
             <ReviewCommentsPanel
               reviewId={reviewId}
@@ -148,13 +150,11 @@ export default function ReviewCommentsButton({
         <SheetContent
           side="right"
           showOverlay={false}
-          className="border-border/30 bg-background/95 p-0 supports-backdrop-filter:backdrop-blur-xl data-[side=right]:w-[min(21.5rem,calc(100vw-0.75rem))] data-[side=right]:rounded-l-[1.5rem] data-[side=right]:sm:max-w-[21.5rem]"
+          className="border-border/30 bg-background/98 p-0 shadow-none ring-0 supports-backdrop-filter:backdrop-blur-xl data-[side=right]:w-[min(24rem,calc(100vw-0.75rem))] data-[side=right]:rounded-none data-[side=right]:sm:max-w-[24rem]"
         >
-          <SheetHeader className="border-b border-border/30 px-4 py-4 pr-12">
+          <SheetHeader className="border-b border-border/24 px-4 py-3 pr-12">
             <SheetTitle>Comments</SheetTitle>
-            <SheetDescription>
-              {commentsCount} {commentsCount === 1 ? "comment" : "comments"}
-            </SheetDescription>
+            <SheetDescription>{commentsDescription}</SheetDescription>
           </SheetHeader>
           <ReviewCommentsPanel
             reviewId={reviewId}

--- a/apps/web/components/review-comments-button.tsx
+++ b/apps/web/components/review-comments-button.tsx
@@ -34,6 +34,10 @@ type ReviewCommentsButtonProps = {
     display_name: string | null;
     avatar_url: string | null;
   } | null;
+  inlineTarget?: {
+    targetId: string;
+    composerId?: string;
+  } | null;
 };
 
 export default function ReviewCommentsButton({
@@ -42,6 +46,7 @@ export default function ReviewCommentsButton({
   isAuthenticated,
   analyticsSource = null,
   viewer = null,
+  inlineTarget = null,
 }: ReviewCommentsButtonProps) {
   const isMobile = useIsMobile();
   const [open, setOpen] = useState(false);
@@ -52,6 +57,25 @@ export default function ReviewCommentsButton({
   });
 
   function handleTriggerClick() {
+    if (inlineTarget) {
+      const target = document.getElementById(inlineTarget.targetId);
+
+      target?.scrollIntoView({
+        behavior: "smooth",
+        block: "center",
+      });
+
+      const composerId = inlineTarget.composerId;
+
+      if (isAuthenticated && composerId) {
+        window.requestAnimationFrame(() => {
+          document.getElementById(composerId)?.focus();
+        });
+      }
+
+      return;
+    }
+
     if (!isAuthenticated) {
       toastAuthRequired("comment");
       return;
@@ -79,8 +103,8 @@ export default function ReviewCommentsButton({
     <button
       type="button"
       onClick={handleTriggerClick}
-      aria-label={open ? "Close comments" : "Open comments"}
-      aria-expanded={open}
+      aria-label={inlineTarget ? "Reply to this review" : open ? "Close comments" : "Open comments"}
+      aria-expanded={inlineTarget ? undefined : open}
       className={cn(
         "inline-flex min-h-8 items-center gap-1 rounded-md border border-transparent px-2 py-1 text-[11px] font-medium text-muted-foreground/88 transition-[color,background-color,transform] duration-150 hover:bg-foreground/[0.055] hover:text-foreground active:scale-[0.96]",
         open && "text-foreground",

--- a/apps/web/components/review-comments-panel.tsx
+++ b/apps/web/components/review-comments-panel.tsx
@@ -32,6 +32,7 @@ type ReviewCommentsPanelProps = {
   variant?: "dialog" | "inline";
   hideForm?: boolean;
   autoFocusComposer?: boolean;
+  replyTarget?: string | null;
 };
 
 function formatDate(value: string) {
@@ -49,6 +50,7 @@ export default function ReviewCommentsPanel({
   variant = "dialog",
   hideForm = false,
   autoFocusComposer = false,
+  replyTarget = null,
 }: ReviewCommentsPanelProps) {
   const [body, setBody] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
@@ -77,6 +79,7 @@ export default function ReviewCommentsPanel({
 
   const trimmedBody = useMemo(() => body.trim(), [body]);
   const isInline = variant === "inline";
+  const replyPlaceholder = replyTarget ? `Reply to @${replyTarget}...` : "Reply to this review...";
 
   useEffect(() => {
     if (!autoFocusComposer || hideForm || !isAuthenticated) {
@@ -138,7 +141,7 @@ export default function ReviewCommentsPanel({
   }
 
   const commentsList = (
-    <div className={cn("space-y-4", isInline ? "py-0" : "py-5")}>
+    <div className={cn(isInline ? "space-y-0" : "space-y-4 py-5")}>
       {isLoading ? (
         <div className="flex justify-center py-10">
           <Spinner className="size-4 text-muted-foreground/70" />
@@ -157,7 +160,9 @@ export default function ReviewCommentsPanel({
               key={comment.id}
               id={`comment-${comment.id}`}
               className={cn(
-                "rounded-xl border border-border/40 bg-card/46 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)] transition-opacity md:border-border/30 md:bg-card/40",
+                isInline
+                  ? "border-b border-border/24 py-4 transition-opacity last:border-b-0"
+                  : "rounded-xl border border-border/40 bg-card/46 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)] transition-opacity md:border-border/30 md:bg-card/40",
                 comment.optimistic && "opacity-70",
               )}
             >
@@ -170,9 +175,18 @@ export default function ReviewCommentsPanel({
                     className="size-8"
                   />
                   <div className="min-w-0">
-                    <p className="truncate text-sm font-medium text-foreground">
-                      {authorLabel}
-                    </p>
+                    {author?.username ? (
+                      <Link
+                        href={`/u/${author.username}`}
+                        className="block truncate text-sm font-medium text-foreground transition-colors hover:text-foreground/82 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30"
+                      >
+                        {authorLabel}
+                      </Link>
+                    ) : (
+                      <p className="truncate text-sm font-medium text-foreground">
+                        {authorLabel}
+                      </p>
+                    )}
                     <p className="text-xs text-muted-foreground">
                       {comment.optimistic ? "Posting..." : formatDate(comment.created_at)}
                     </p>
@@ -231,65 +245,131 @@ export default function ReviewCommentsPanel({
           );
         })
       ) : (
-        <div className="rounded-xl border border-dashed border-border/48 bg-card/36 p-6 text-sm text-muted-foreground shadow-[inset_0_1px_0_rgba(255,255,255,0.02)] md:border-border/40 md:bg-card/30">
-          No comments yet. Start the conversation around this review.
+        <div
+          className={cn(
+            "text-sm text-muted-foreground",
+            isInline
+              ? "border-b border-border/24 px-1 py-4"
+              : "rounded-xl border border-dashed border-border/48 bg-card/36 p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.02)] md:border-border/40 md:bg-card/30",
+          )}
+        >
+          <p className="font-medium text-foreground/86">No replies yet.</p>
+          <p className="mt-1 text-xs text-muted-foreground">Be the first to respond to this review.</p>
         </div>
       )}
     </div>
   );
 
   const form = isAuthenticated ? (
-    <div className="space-y-3">
-      <Textarea
-        ref={textareaRef}
-        value={body}
-        onChange={(event) => setBody(event.target.value)}
-        placeholder="Add a short comment..."
-        className={cn("min-h-24", !isInline && "min-h-28")}
-        maxLength={1000}
-      />
-      <div className="flex items-center justify-between gap-3">
-        <p className="text-xs text-muted-foreground">
-          {commentsCount} {commentsCount === 1 ? "comment" : "comments"}
+    isInline ? (
+      <div className="space-y-2">
+        <div className="flex items-end gap-2 rounded-full border border-border/36 bg-card/42 px-2 py-2 shadow-[inset_0_1px_0_rgba(255,255,255,0.025)] md:border-border/28 md:bg-card/34">
+          <UserAvatar
+            avatarUrl={viewer?.avatar_url}
+            displayName={viewer?.display_name ?? null}
+            username={viewer?.username ?? null}
+            className="size-8"
+            fallbackClassName="text-[11px]"
+          />
+          <Textarea
+            ref={textareaRef}
+            value={body}
+            onChange={(event) => setBody(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key !== "Enter" || event.shiftKey || event.nativeEvent.isComposing) {
+                return;
+              }
+
+              event.preventDefault();
+              void handleSubmit();
+            }}
+            placeholder={replyPlaceholder}
+            className="max-h-28 min-h-8 flex-1 border-0 bg-transparent px-0 py-1.5 text-[13px] leading-5 shadow-none focus-visible:border-transparent focus-visible:ring-0"
+            maxLength={1000}
+            rows={1}
+          />
+          <Button
+            type="button"
+            size="icon"
+            onClick={handleSubmit}
+            disabled={!trimmedBody || isPosting}
+            className="size-8 shrink-0 rounded-full"
+            aria-label="Post comment"
+          >
+            {isPosting ? <Spinner className="size-3.5" /> : <Send className="size-3.5" />}
+          </Button>
+        </div>
+        <p className="px-1 text-[11px] text-muted-foreground/68">
+          {commentsCount} {commentsCount === 1 ? "reply" : "replies"}
         </p>
-        <Button
-          size="sm"
-          onClick={handleSubmit}
-          disabled={!trimmedBody || isPosting}
-          className="gap-2"
-        >
-          <Send className="size-3.5" />
-          {isPosting ? "Posting..." : "Post comment"}
-        </Button>
       </div>
-    </div>
+    ) : (
+      <div className="space-y-3">
+        <Textarea
+          ref={textareaRef}
+          value={body}
+          onChange={(event) => setBody(event.target.value)}
+          placeholder="Add a short comment..."
+          className="min-h-28"
+          maxLength={1000}
+        />
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-xs text-muted-foreground">
+            {commentsCount} {commentsCount === 1 ? "comment" : "comments"}
+          </p>
+          <Button
+            size="sm"
+            onClick={handleSubmit}
+            disabled={!trimmedBody || isPosting}
+            className="gap-2"
+          >
+            <Send className="size-3.5" />
+            {isPosting ? "Posting..." : "Post comment"}
+          </Button>
+        </div>
+      </div>
+    )
   ) : (
-    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-      <div className="space-y-1">
-        <p className="text-sm font-medium text-foreground">Sign in to comment</p>
-        <p className="text-xs text-muted-foreground">
-          You can read comments already, but posting requires an account.
+    <div
+      className={cn(
+        "flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between",
+        isInline && "rounded-full border border-border/36 bg-card/42 px-3 py-2 md:border-border/28 md:bg-card/34",
+      )}
+    >
+      <div className={cn("space-y-1", isInline && "min-w-0")}>
+        <p className={cn("text-sm font-medium text-foreground", isInline && "truncate text-[13px]")}>
+          Log in to reply
         </p>
+        {!isInline ? (
+          <p className="text-xs text-muted-foreground">
+            You can read comments already, but posting requires an account.
+          </p>
+        ) : null}
       </div>
       <div className="flex gap-2">
-        <Link href="/login">
-          <Button size="sm">Log in</Button>
+        <Link href={`/login?next=${encodeURIComponent(`/review/${reviewId}`)}`}>
+          <Button size="sm" className={cn(isInline && "h-8 rounded-full px-4")}>Log in</Button>
         </Link>
-        <Link href="/signup">
+        {!isInline ? (
+          <Link href="/signup">
           <Button size="sm" variant="outline">
             Create account
           </Button>
-        </Link>
+          </Link>
+        ) : null}
       </div>
     </div>
   );
 
   if (isInline) {
     return (
-      <div className="space-y-5">
+      <section
+        aria-label="Review replies"
+        className="kocteau-review-card overflow-hidden rounded-[var(--kocteau-radius-card)] px-3.5 py-3 sm:px-4 sm:py-3.5"
+      >
         {commentsList}
-        {!hideForm ? <div className="border-t border-border/28 pt-4 md:border-border/20">{form}</div> : null}
-      </div>
+        {!hideForm ? <div className="pt-3">{form}</div> : null}
+      </section>
     );
   }
 

--- a/apps/web/components/review-comments-panel.tsx
+++ b/apps/web/components/review-comments-panel.tsx
@@ -33,6 +33,8 @@ type ReviewCommentsPanelProps = {
   hideForm?: boolean;
   autoFocusComposer?: boolean;
   replyTarget?: string | null;
+  anchorId?: string;
+  composerId?: string;
 };
 
 function formatDate(value: string) {
@@ -51,6 +53,8 @@ export default function ReviewCommentsPanel({
   hideForm = false,
   autoFocusComposer = false,
   replyTarget = null,
+  anchorId,
+  composerId,
 }: ReviewCommentsPanelProps) {
   const [body, setBody] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
@@ -245,14 +249,12 @@ export default function ReviewCommentsPanel({
           );
         })
       ) : (
-        <div
-          className={cn(
-            "text-sm text-muted-foreground",
-            isInline
-              ? "border-b border-border/24 px-1 py-4"
-              : "rounded-xl border border-dashed border-border/48 bg-card/36 p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.02)] md:border-border/40 md:bg-card/30",
-          )}
-        >
+        <div className={cn(
+          "text-sm text-muted-foreground",
+          isInline
+            ? "px-1 py-4"
+            : "rounded-xl border border-dashed border-border/48 bg-card/36 p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.02)] md:border-border/40 md:bg-card/30",
+        )}>
           <p className="font-medium text-foreground/86">No replies yet.</p>
           <p className="mt-1 text-xs text-muted-foreground">Be the first to respond to this review.</p>
         </div>
@@ -263,7 +265,7 @@ export default function ReviewCommentsPanel({
   const form = isAuthenticated ? (
     isInline ? (
       <div className="space-y-2">
-        <div className="flex items-end gap-2 rounded-full border border-border/36 bg-card/42 px-2 py-2 shadow-[inset_0_1px_0_rgba(255,255,255,0.025)] md:border-border/28 md:bg-card/34">
+        <div className="flex items-end gap-2 rounded-[1.15rem] border border-border/42 bg-muted/58 px-2 py-2 transition-colors focus-within:border-border/60 focus-within:bg-muted/70 md:border-border/34 md:bg-muted/48">
           <UserAvatar
             avatarUrl={viewer?.avatar_url}
             displayName={viewer?.display_name ?? null}
@@ -272,6 +274,7 @@ export default function ReviewCommentsPanel({
             fallbackClassName="text-[11px]"
           />
           <Textarea
+            id={composerId}
             ref={textareaRef}
             value={body}
             onChange={(event) => setBody(event.target.value)}
@@ -284,7 +287,7 @@ export default function ReviewCommentsPanel({
               void handleSubmit();
             }}
             placeholder={replyPlaceholder}
-            className="max-h-28 min-h-8 flex-1 border-0 bg-transparent px-0 py-1.5 text-[13px] leading-5 shadow-none focus-visible:border-transparent focus-visible:ring-0"
+            className="max-h-28 min-h-8 flex-1 border-0 bg-transparent px-0 py-1.5 text-[13px] leading-5 shadow-none placeholder:text-muted-foreground/82 focus-visible:border-transparent focus-visible:ring-0"
             maxLength={1000}
             rows={1}
           />
@@ -299,9 +302,11 @@ export default function ReviewCommentsPanel({
             {isPosting ? <Spinner className="size-3.5" /> : <Send className="size-3.5" />}
           </Button>
         </div>
-        <p className="px-1 text-[11px] text-muted-foreground/68">
-          {commentsCount} {commentsCount === 1 ? "reply" : "replies"}
-        </p>
+        {commentsCount > 0 ? (
+          <p className="px-1 text-[11px] text-muted-foreground/68">
+            {commentsCount} {commentsCount === 1 ? "reply" : "replies"}
+          </p>
+        ) : null}
       </div>
     ) : (
       <div className="space-y-3">
@@ -333,7 +338,7 @@ export default function ReviewCommentsPanel({
     <div
       className={cn(
         "flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between",
-        isInline && "rounded-full border border-border/36 bg-card/42 px-3 py-2 md:border-border/28 md:bg-card/34",
+        isInline && "rounded-full border border-border/42 bg-muted/58 px-3 py-2 md:border-border/34 md:bg-muted/48",
       )}
     >
       <div className={cn("space-y-1", isInline && "min-w-0")}>
@@ -364,11 +369,12 @@ export default function ReviewCommentsPanel({
   if (isInline) {
     return (
       <section
+        id={anchorId}
         aria-label="Review replies"
-        className="kocteau-review-card overflow-hidden rounded-[var(--kocteau-radius-card)] px-3.5 py-3 sm:px-4 sm:py-3.5"
+        className="space-y-3 px-1"
       >
+        {!hideForm ? form : null}
         {commentsList}
-        {!hideForm ? <div className="pt-3">{form}</div> : null}
       </section>
     );
   }

--- a/apps/web/components/review-comments-panel.tsx
+++ b/apps/web/components/review-comments-panel.tsx
@@ -63,7 +63,6 @@ export default function ReviewCommentsPanel({
   const composerBaseHeightRef = useRef<number | null>(null);
   const {
     comments,
-    commentsCount,
     isLoading,
     isError,
     createComment,
@@ -106,7 +105,7 @@ export default function ReviewCommentsPanel({
   }, [autoFocusComposer, hideForm, isAuthenticated]);
 
   useEffect(() => {
-    if (!isInline || !isAuthenticated) {
+    if (!isAuthenticated) {
       return;
     }
 
@@ -135,7 +134,7 @@ export default function ReviewCommentsPanel({
     return () => {
       observer.disconnect();
     };
-  }, [body, isAuthenticated, isInline]);
+  }, [body, isAuthenticated]);
 
   async function handleSubmit() {
     if (!trimmedBody) {
@@ -181,13 +180,16 @@ export default function ReviewCommentsPanel({
   }
 
   const commentsList = (
-    <div className={cn(isInline ? "space-y-0" : "space-y-4 py-5")}>
+    <div className="space-y-0">
       {isLoading ? (
         <div className="flex justify-center py-10">
           <Spinner className="size-4 text-muted-foreground/70" />
         </div>
       ) : isError ? (
-        <div className="rounded-xl border border-border/40 bg-card/46 p-4 text-sm text-muted-foreground shadow-[inset_0_1px_0_rgba(255,255,255,0.03)] md:border-border/30 md:bg-card/40">
+        <div className={cn(
+          "border-t border-border/24 text-sm text-muted-foreground",
+          isInline ? "px-1 py-4" : "px-4 py-5",
+        )}>
           Comments are temporarily unavailable.
         </div>
       ) : comments.length > 0 ? (
@@ -200,9 +202,8 @@ export default function ReviewCommentsPanel({
               key={comment.id}
               id={`comment-${comment.id}`}
               className={cn(
-                isInline
-                  ? "border-b border-border/24 py-4 transition-opacity last:border-b-0"
-                  : "rounded-xl border border-border/40 bg-card/46 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)] transition-opacity md:border-border/30 md:bg-card/40",
+                "border-t border-border/24 transition-opacity",
+                isInline ? "px-1 py-4" : "px-4 py-4",
                 comment.optimistic && "opacity-70",
               )}
             >
@@ -289,7 +290,7 @@ export default function ReviewCommentsPanel({
           "text-sm text-muted-foreground",
           isInline
             ? "px-1 py-4"
-            : "rounded-xl border border-dashed border-border/48 bg-card/36 p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.02)] md:border-border/40 md:bg-card/30",
+            : "border-t border-border/24 px-4 py-5",
         )}>
           <p className="font-medium text-foreground/86">No replies yet.</p>
           <p className="mt-1 text-xs text-muted-foreground">Be the first to respond to this review.</p>
@@ -299,89 +300,58 @@ export default function ReviewCommentsPanel({
   );
 
   const form = isAuthenticated ? (
-    isInline ? (
-      <div className="space-y-2">
-        <motion.div
-          animate={{
-            borderRadius: composerIsMultiline ? 18 : 999,
-            scale: composerIsMultiline && !shouldReduceMotion ? 1.004 : 1,
-          }}
-          className="flex items-end gap-2 border border-border/42 bg-muted/58 px-2 py-2 transition-colors duration-100 ease-out focus-within:border-border/60 focus-within:bg-muted/70 md:border-border/34 md:bg-muted/48"
-          initial={false}
-          transition={
-            shouldReduceMotion
-              ? { duration: 0 }
-              : { type: "spring", duration: 0.18, bounce: 0 }
+    <motion.div
+      animate={{
+        borderRadius: composerIsMultiline ? 18 : 999,
+        scale: composerIsMultiline && !shouldReduceMotion ? 1.004 : 1,
+      }}
+      className={cn(
+        "flex items-end gap-2 border border-border/42 bg-muted/58 px-2 py-2 transition-colors duration-100 ease-out focus-within:border-border/60 focus-within:bg-muted/70 md:border-border/34 md:bg-muted/48",
+        !isInline && "w-full",
+      )}
+      initial={false}
+      transition={
+        shouldReduceMotion
+          ? { duration: 0 }
+          : { type: "spring", duration: 0.18, bounce: 0 }
+      }
+    >
+      <UserAvatar
+        avatarUrl={viewer?.avatar_url}
+        displayName={viewer?.display_name ?? null}
+        username={viewer?.username ?? null}
+        className="size-8"
+        fallbackClassName="text-[11px]"
+      />
+      <Textarea
+        id={composerId}
+        ref={textareaRef}
+        value={body}
+        onChange={(event) => setBody(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key !== "Enter" || event.shiftKey || event.nativeEvent.isComposing) {
+            return;
           }
-        >
-          <UserAvatar
-            avatarUrl={viewer?.avatar_url}
-            displayName={viewer?.display_name ?? null}
-            username={viewer?.username ?? null}
-            className="size-8"
-            fallbackClassName="text-[11px]"
-          />
-          <Textarea
-            id={composerId}
-            ref={textareaRef}
-            value={body}
-            onChange={(event) => setBody(event.target.value)}
-            onKeyDown={(event) => {
-              if (event.key !== "Enter" || event.shiftKey || event.nativeEvent.isComposing) {
-                return;
-              }
 
-              event.preventDefault();
-              void handleSubmit();
-            }}
-            placeholder={replyPlaceholder}
-            className="max-h-28 min-h-8 flex-1 border-0 bg-transparent px-0 py-1.5 text-[13px] leading-5 shadow-none placeholder:text-muted-foreground/82 focus-visible:border-transparent focus-visible:ring-0"
-            maxLength={1000}
-            rows={1}
-          />
-          <Button
-            type="button"
-            size="icon"
-            onClick={handleSubmit}
-            disabled={!trimmedBody || isPosting}
-            className="size-8 shrink-0 rounded-full"
-            aria-label="Post comment"
-          >
-            {isPosting ? <Spinner className="size-3.5" /> : <Send className="size-3.5" />}
-          </Button>
-        </motion.div>
-        {commentsCount > 0 ? (
-          <p className="px-1 text-[11px] text-muted-foreground/68">
-            {commentsCount} {commentsCount === 1 ? "reply" : "replies"}
-          </p>
-        ) : null}
-      </div>
-    ) : (
-      <div className="space-y-3">
-        <Textarea
-          ref={textareaRef}
-          value={body}
-          onChange={(event) => setBody(event.target.value)}
-          placeholder="Add a short comment..."
-          className="min-h-28"
-          maxLength={1000}
-        />
-        <div className="flex items-center justify-between gap-3">
-          <p className="text-xs text-muted-foreground">
-            {commentsCount} {commentsCount === 1 ? "comment" : "comments"}
-          </p>
-          <Button
-            size="sm"
-            onClick={handleSubmit}
-            disabled={!trimmedBody || isPosting}
-            className="gap-2"
-          >
-            <Send className="size-3.5" />
-            {isPosting ? "Posting..." : "Post comment"}
-          </Button>
-        </div>
-      </div>
-    )
+          event.preventDefault();
+          void handleSubmit();
+        }}
+        placeholder={replyPlaceholder}
+        className="max-h-28 min-h-8 flex-1 border-0 bg-transparent px-0 py-1.5 text-[13px] leading-5 shadow-none placeholder:text-muted-foreground/82 focus-visible:border-transparent focus-visible:ring-0"
+        maxLength={1000}
+        rows={1}
+      />
+      <Button
+        type="button"
+        size="icon"
+        onClick={handleSubmit}
+        disabled={!trimmedBody || isPosting}
+        className="size-8 shrink-0 rounded-full"
+        aria-label="Post comment"
+      >
+        {isPosting ? <Spinner className="size-3.5" /> : <Send className="size-3.5" />}
+      </Button>
+    </motion.div>
   ) : (
     <div
       className={cn(
@@ -429,11 +399,11 @@ export default function ReviewCommentsPanel({
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      <ScrollArea className="min-h-0 flex-1 px-4">
+      <ScrollArea className="min-h-0 flex-1">
         {commentsList}
       </ScrollArea>
 
-      <div className="border-t border-border/36 px-4 py-4 md:border-border/30">
+      <div className="border-t border-border/30 px-3 py-3 md:border-border/24">
         {!hideForm ? form : null}
       </div>
     </div>

--- a/apps/web/components/review-comments-panel.tsx
+++ b/apps/web/components/review-comments-panel.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { motion, useReducedMotion } from "motion/react";
 import { Flag, MoreHorizontal, Send, Trash2 } from "@/components/ui/icons";
 import { Button } from "@/components/ui/button";
 import {
@@ -57,7 +58,9 @@ export default function ReviewCommentsPanel({
   composerId,
 }: ReviewCommentsPanelProps) {
   const [body, setBody] = useState("");
+  const [composerIsMultiline, setComposerIsMultiline] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const composerBaseHeightRef = useRef<number | null>(null);
   const {
     comments,
     commentsCount,
@@ -83,6 +86,7 @@ export default function ReviewCommentsPanel({
 
   const trimmedBody = useMemo(() => body.trim(), [body]);
   const isInline = variant === "inline";
+  const shouldReduceMotion = useReducedMotion();
   const replyPlaceholder = replyTarget ? `Reply to @${replyTarget}...` : "Reply to this review...";
 
   useEffect(() => {
@@ -100,6 +104,38 @@ export default function ReviewCommentsPanel({
       window.cancelAnimationFrame(frame);
     };
   }, [autoFocusComposer, hideForm, isAuthenticated]);
+
+  useEffect(() => {
+    if (!isInline || !isAuthenticated) {
+      return;
+    }
+
+    const node = textareaRef.current;
+
+    if (!node) {
+      return;
+    }
+
+    const syncComposerShape = () => {
+      if (!body) {
+        composerBaseHeightRef.current = node.scrollHeight;
+        setComposerIsMultiline(false);
+        return;
+      }
+
+      const baseline = composerBaseHeightRef.current ?? node.scrollHeight;
+      setComposerIsMultiline(node.scrollHeight > baseline + 4);
+    };
+
+    syncComposerShape();
+
+    const observer = new ResizeObserver(syncComposerShape);
+    observer.observe(node);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [body, isAuthenticated, isInline]);
 
   async function handleSubmit() {
     if (!trimmedBody) {
@@ -265,7 +301,19 @@ export default function ReviewCommentsPanel({
   const form = isAuthenticated ? (
     isInline ? (
       <div className="space-y-2">
-        <div className="flex items-end gap-2 rounded-[1.15rem] border border-border/42 bg-muted/58 px-2 py-2 transition-colors focus-within:border-border/60 focus-within:bg-muted/70 md:border-border/34 md:bg-muted/48">
+        <motion.div
+          animate={{
+            borderRadius: composerIsMultiline ? 18 : 999,
+            scale: composerIsMultiline && !shouldReduceMotion ? 1.004 : 1,
+          }}
+          className="flex items-end gap-2 border border-border/42 bg-muted/58 px-2 py-2 transition-colors duration-100 ease-out focus-within:border-border/60 focus-within:bg-muted/70 md:border-border/34 md:bg-muted/48"
+          initial={false}
+          transition={
+            shouldReduceMotion
+              ? { duration: 0 }
+              : { type: "spring", duration: 0.18, bounce: 0 }
+          }
+        >
           <UserAvatar
             avatarUrl={viewer?.avatar_url}
             displayName={viewer?.display_name ?? null}
@@ -301,7 +349,7 @@ export default function ReviewCommentsPanel({
           >
             {isPosting ? <Spinner className="size-3.5" /> : <Send className="size-3.5" />}
           </Button>
-        </div>
+        </motion.div>
         {commentsCount > 0 ? (
           <p className="px-1 text-[11px] text-muted-foreground/68">
             {commentsCount} {commentsCount === 1 ? "reply" : "replies"}

--- a/apps/web/components/review-route-cards-server.tsx
+++ b/apps/web/components/review-route-cards-server.tsx
@@ -19,6 +19,7 @@ export type ReviewCardBehaviorOptions = {
   showHeaderActions?: boolean;
   showInteractionBar?: boolean;
   showContextMenu?: boolean;
+  openReviewLink?: boolean;
 };
 
 export type ReviewCardPermissions = {
@@ -72,11 +73,21 @@ function buildTrackReviewCardDisplay(): ReviewCardDisplayOptions {
 function buildReviewPageCardDisplay(): ReviewCardDisplayOptions {
   return {
     entityMode: "cover",
+    entityHeadingLevel: 1,
   };
 }
 
 function getAuthorLabel(author: ReviewCardAuthor | null | undefined) {
   return author?.display_name ?? (author ? `@${author.username}` : "Unknown user");
+}
+
+function getReviewLinkLabel(
+  entity: ReviewCardEntity | null,
+  author: ReviewCardAuthor | null | undefined,
+) {
+  const subject = entity?.title ? `${entity.title} review` : "review";
+
+  return `Open ${subject} by ${getAuthorLabel(author)}`;
 }
 
 function createEditSeed(
@@ -111,39 +122,25 @@ function createEditSeed(
   };
 }
 
-function LinkedAuthorName({ author }: { author: ReviewCardAuthor | null | undefined }) {
-  if (!author) {
-    return null;
-  }
-
-  return (
-    <Link
-      href={`/u/${author.username}`}
-      data-prevent-review-link="true"
-      className="text-xs font-medium text-foreground transition-colors hover:underline sm:text-sm"
-    >
-      {getAuthorLabel(author)}
-    </Link>
-  );
-}
-
 function LinkedEntitySummary({
   entity,
   mode,
   priority = false,
   tone = "default",
+  headingLevel,
 }: {
   entity: ReviewCardEntity | null;
   mode: "full" | "inline" | "cover";
   priority?: boolean;
   tone?: "default" | "balanced";
+  headingLevel?: 1 | 2 | 3;
 }) {
   if (!entity) {
     return null;
   }
 
   return (
-    <div data-prevent-review-link="true">
+    <div data-prevent-review-link="true" className="relative z-[2]">
       <Link href={`/track/${entity.id}`} className="block">
         <ReviewCardEntitySummary
           entity={entity}
@@ -151,6 +148,7 @@ function LinkedEntitySummary({
           interactive
           priority={priority}
           tone={tone}
+          headingLevel={headingLevel}
         />
       </Link>
     </div>
@@ -169,7 +167,7 @@ function LinkedEntityCover({
   }
 
   return (
-    <div data-prevent-review-link="true">
+    <div data-prevent-review-link="true" className="relative z-[2]">
       <Link href={`/track/${entity.id}`} className="block">
         <ReviewCardEntityCover entity={entity} priority={priority} />
       </Link>
@@ -186,6 +184,7 @@ async function RoutedReviewCardServer({
   permissions,
 }: RoutedReviewCardProps) {
   const { entityMode = "full" } = display ?? {};
+  const entityHeadingLevel = display?.entityHeadingLevel;
   const entityPriority = Boolean(display?.featured || display?.imagePriority);
   const copyTone = getReviewCardCopyTone(review);
   const { isAuthenticated = false, canManage = false } = permissions ?? {};
@@ -194,6 +193,7 @@ async function RoutedReviewCardServer({
     showHeaderActions = canUseReviewMenus,
     showInteractionBar = true,
     showContextMenu = canUseReviewMenus,
+    openReviewLink = true,
   } = behavior ?? {};
   const viewerProfile =
     isAuthenticated && showInteractionBar
@@ -206,64 +206,58 @@ async function RoutedReviewCardServer({
   const initialBookmarked = Boolean(review.viewer_has_bookmarked);
 
   const card = (
-    <div>
-      <Link
-        href={`/review/${review.id}`}
-        className="sr-only focus:not-sr-only focus:mb-2 focus:inline-flex focus:h-8 focus:items-center focus:rounded-[0.55rem] focus:border focus:border-border/35 focus:bg-muted/18 focus:px-3 focus:text-xs focus:font-medium focus:text-foreground focus:outline-none focus:ring-2 focus:ring-ring/30"
-      >
-        Open review
-      </Link>
-      <ReviewCard
-        review={review}
-        entity={entity}
-        author={author}
-        display={display}
-        rootProps={rootProps}
-        slots={{
-          authorName: author ? <LinkedAuthorName author={author} /> : undefined,
-          entity: entity ? (
-            <LinkedEntitySummary
-              entity={entity}
-              mode={entityMode}
-              priority={entityPriority}
-              tone={copyTone}
-            />
+    <ReviewCard
+      review={review}
+      entity={entity}
+      author={author}
+      display={display}
+      rootProps={rootProps}
+      reviewHref={openReviewLink ? `/review/${review.id}` : null}
+      reviewLinkLabel={getReviewLinkLabel(entity, author)}
+      slots={{
+        entity: entity ? (
+          <LinkedEntitySummary
+            entity={entity}
+            mode={entityMode}
+            priority={entityPriority}
+            tone={copyTone}
+            headingLevel={entityHeadingLevel}
+          />
+        ) : undefined,
+        entityCover:
+          entity && entityMode === "cover" ? (
+            <LinkedEntityCover entity={entity} priority={entityPriority} />
           ) : undefined,
-          entityCover:
-            entity && entityMode === "cover" ? (
-              <LinkedEntityCover entity={entity} priority={entityPriority} />
-            ) : undefined,
-          headerActions: showHeaderActions ? (
-            <ReviewActionsMenu
-              reviewId={review.id}
-              reviewTitle={review.title}
-              entityTitle={entity?.title ?? null}
-              entityId={entity?.id ?? null}
-              canManage={canManage}
-              editSeed={editSeed}
-              initialBookmarked={initialBookmarked}
-              isAuthenticated={isAuthenticated}
-            />
-          ) : null,
-          footer: showInteractionBar ? (
-            <ReviewCardInteractionBar
-              review={review}
-              isAuthenticated={isAuthenticated}
-              viewer={
-                viewerProfile
-                  ? {
-                      id: viewerProfile.id,
-                      username: viewerProfile.username,
-                      display_name: viewerProfile.display_name,
-                      avatar_url: viewerProfile.avatar_url,
-                    }
-                  : null
-              }
-            />
-          ) : null,
-        }}
-      />
-    </div>
+        headerActions: showHeaderActions ? (
+          <ReviewActionsMenu
+            reviewId={review.id}
+            reviewTitle={review.title}
+            entityTitle={entity?.title ?? null}
+            entityId={entity?.id ?? null}
+            canManage={canManage}
+            editSeed={editSeed}
+            initialBookmarked={initialBookmarked}
+            isAuthenticated={isAuthenticated}
+          />
+        ) : null,
+        footer: showInteractionBar ? (
+          <ReviewCardInteractionBar
+            review={review}
+            isAuthenticated={isAuthenticated}
+            viewer={
+              viewerProfile
+                ? {
+                    id: viewerProfile.id,
+                    username: viewerProfile.username,
+                    display_name: viewerProfile.display_name,
+                    avatar_url: viewerProfile.avatar_url,
+                  }
+                : null
+            }
+          />
+        ) : null,
+      }}
+    />
   );
 
   if (!showContextMenu) {
@@ -357,6 +351,7 @@ export async function ReviewPageCard({
       entity={entity}
       author={author}
       display={buildReviewPageCardDisplay()}
+      behavior={{ openReviewLink: false }}
       permissions={{ isAuthenticated, canManage }}
     />
   );

--- a/apps/web/components/review-route-cards-server.tsx
+++ b/apps/web/components/review-route-cards-server.tsx
@@ -90,6 +90,22 @@ function getReviewLinkLabel(
   return `Open ${subject} by ${getAuthorLabel(author)}`;
 }
 
+function LinkedAuthorName({ author }: { author: ReviewCardAuthor | null | undefined }) {
+  if (!author) {
+    return null;
+  }
+
+  return (
+    <Link
+      href={`/u/${author.username}`}
+      data-prevent-review-link="true"
+      className="relative z-[2] text-xs font-medium text-foreground transition-colors hover:underline sm:text-sm"
+    >
+      {getAuthorLabel(author)}
+    </Link>
+  );
+}
+
 function createEditSeed(
   review: ReviewCardData,
   entity: ReviewCardEntity | null,
@@ -215,6 +231,7 @@ async function RoutedReviewCardServer({
       reviewHref={openReviewLink ? `/review/${review.id}` : null}
       reviewLinkLabel={getReviewLinkLabel(entity, author)}
       slots={{
+        authorName: author ? <LinkedAuthorName author={author} /> : undefined,
         entity: entity ? (
           <LinkedEntitySummary
             entity={entity}

--- a/apps/web/components/review-route-cards-server.tsx
+++ b/apps/web/components/review-route-cards-server.tsx
@@ -20,6 +20,10 @@ export type ReviewCardBehaviorOptions = {
   showInteractionBar?: boolean;
   showContextMenu?: boolean;
   openReviewLink?: boolean;
+  commentInlineTarget?: {
+    targetId: string;
+    composerId?: string;
+  } | null;
 };
 
 export type ReviewCardPermissions = {
@@ -210,6 +214,7 @@ async function RoutedReviewCardServer({
     showInteractionBar = true,
     showContextMenu = canUseReviewMenus,
     openReviewLink = true,
+    commentInlineTarget = null,
   } = behavior ?? {};
   const viewerProfile =
     isAuthenticated && showInteractionBar
@@ -261,6 +266,7 @@ async function RoutedReviewCardServer({
           <ReviewCardInteractionBar
             review={review}
             isAuthenticated={isAuthenticated}
+            commentInlineTarget={commentInlineTarget}
             viewer={
               viewerProfile
                 ? {
@@ -368,7 +374,13 @@ export async function ReviewPageCard({
       entity={entity}
       author={author}
       display={buildReviewPageCardDisplay()}
-      behavior={{ openReviewLink: false }}
+      behavior={{
+        openReviewLink: false,
+        commentInlineTarget: {
+          targetId: "review-replies",
+          composerId: "review-reply-composer",
+        },
+      }}
       permissions={{ isAuthenticated, canManage }}
     />
   );

--- a/apps/web/components/review-route-cards.tsx
+++ b/apps/web/components/review-route-cards.tsx
@@ -22,6 +22,10 @@ export type ReviewCardBehaviorOptions = {
   showInteractionBar?: boolean;
   showContextMenu?: boolean;
   openReviewLink?: boolean;
+  commentInlineTarget?: {
+    targetId: string;
+    composerId?: string;
+  } | null;
 };
 
 export type ReviewCardPermissions = {
@@ -212,6 +216,7 @@ function RoutedReviewCard({
     showInteractionBar = true,
     showContextMenu = true,
     openReviewLink = true,
+    commentInlineTarget = null,
   } = behavior ?? {};
   const { isAuthenticated = false, canManage = false } = permissions ?? {};
   const initialBookmarked = Boolean(review.viewer_has_bookmarked);
@@ -284,6 +289,7 @@ function RoutedReviewCard({
             isAuthenticated={isAuthenticated}
             viewer={viewer}
             analyticsSource={analyticsSource}
+            commentInlineTarget={commentInlineTarget}
           />
         ) : null,
       }}
@@ -415,7 +421,13 @@ export function ReviewPageCard({
       entity={entity}
       author={author}
       display={buildReviewPageCardDisplay()}
-      behavior={{ openReviewLink: false }}
+      behavior={{
+        openReviewLink: false,
+        commentInlineTarget: {
+          targetId: "review-replies",
+          composerId: "review-reply-composer",
+        },
+      }}
       permissions={{ isAuthenticated, canManage }}
       viewer={viewer}
     />

--- a/apps/web/components/review-route-cards.tsx
+++ b/apps/web/components/review-route-cards.tsx
@@ -21,6 +21,7 @@ export type ReviewCardBehaviorOptions = {
   showHeaderActions?: boolean;
   showInteractionBar?: boolean;
   showContextMenu?: boolean;
+  openReviewLink?: boolean;
 };
 
 export type ReviewCardPermissions = {
@@ -98,6 +99,7 @@ function buildSavedReviewCardDisplay(): ReviewCardDisplayOptions {
 function buildReviewPageCardDisplay(): ReviewCardDisplayOptions {
   return {
     entityMode: "cover",
+    entityHeadingLevel: 1,
   };
 }
 
@@ -105,20 +107,13 @@ function getAuthorLabel(author: ReviewCardAuthor | null | undefined) {
   return author?.display_name ?? (author ? `@${author.username}` : "Unknown user");
 }
 
-function LinkedAuthorName({ author }: { author: ReviewCardAuthor | null | undefined }) {
-  if (!author) {
-    return null;
-  }
+function getReviewLinkLabel(
+  entity: ReviewCardEntity | null,
+  author: ReviewCardAuthor | null | undefined,
+) {
+  const subject = entity?.title ? `${entity.title} review` : "review";
 
-  return (
-    <PrefetchLink
-      href={`/u/${author.username}`}
-      data-prevent-review-link="true"
-      className="text-xs font-medium text-foreground transition-colors hover:underline sm:text-sm"
-    >
-      {getAuthorLabel(author)}
-    </PrefetchLink>
-  );
+  return `Open ${subject} by ${getAuthorLabel(author)}`;
 }
 
 function LinkedEntitySummary({
@@ -126,18 +121,20 @@ function LinkedEntitySummary({
   mode,
   priority = false,
   tone = "default",
+  headingLevel,
 }: {
   entity: ReviewCardEntity | null;
   mode: "full" | "inline" | "cover";
   priority?: boolean;
   tone?: "default" | "balanced";
+  headingLevel?: 1 | 2 | 3;
 }) {
   if (!entity) {
     return null;
   }
 
   return (
-    <div data-prevent-review-link="true">
+    <div data-prevent-review-link="true" className="relative z-[2]">
       <PrefetchLink
         href={`/track/${entity.id}`}
         queryWarmup={{ kind: "track", id: entity.id }}
@@ -149,6 +146,7 @@ function LinkedEntitySummary({
           interactive
           priority={priority}
           tone={tone}
+          headingLevel={headingLevel}
         />
       </PrefetchLink>
     </div>
@@ -167,7 +165,7 @@ function LinkedEntityCover({
   }
 
   return (
-    <div data-prevent-review-link="true">
+    <div data-prevent-review-link="true" className="relative z-[2]">
       <PrefetchLink
         href={`/track/${entity.id}`}
         queryWarmup={{ kind: "track", id: entity.id }}
@@ -190,12 +188,14 @@ function RoutedReviewCard({
   viewer = null,
 }: RoutedReviewCardProps) {
   const { entityMode = "full" } = display ?? {};
+  const entityHeadingLevel = display?.entityHeadingLevel;
   const entityPriority = Boolean(display?.featured || display?.imagePriority);
   const copyTone = getReviewCardCopyTone(review);
   const {
     showHeaderActions = true,
     showInteractionBar = true,
     showContextMenu = true,
+    openReviewLink = true,
   } = behavior ?? {};
   const { isAuthenticated = false, canManage = false } = permissions ?? {};
   const initialBookmarked = Boolean(review.viewer_has_bookmarked);
@@ -227,56 +227,50 @@ function RoutedReviewCard({
   };
 
   const card = (
-    <div>
-      <PrefetchLink
-        href={`/review/${review.id}`}
-        className="sr-only focus:not-sr-only focus:mb-2 focus:inline-flex focus:h-8 focus:items-center focus:rounded-[0.55rem] focus:border focus:border-border/35 focus:bg-muted/18 focus:px-3 focus:text-xs focus:font-medium focus:text-foreground focus:outline-none focus:ring-2 focus:ring-ring/30"
-      >
-        Open review
-      </PrefetchLink>
-      <ReviewCard
-        review={review}
-        entity={entity}
-        author={author}
-        display={display}
-        rootProps={rootProps}
-        slots={{
-          authorName: author ? <LinkedAuthorName author={author} /> : undefined,
-          entity: entity ? (
-            <LinkedEntitySummary
-              entity={entity}
-              mode={entityMode}
-              priority={entityPriority}
-              tone={copyTone}
-            />
+    <ReviewCard
+      review={review}
+      entity={entity}
+      author={author}
+      display={display}
+      rootProps={rootProps}
+      reviewHref={openReviewLink ? `/review/${review.id}` : null}
+      reviewLinkLabel={getReviewLinkLabel(entity, author)}
+      slots={{
+        entity: entity ? (
+          <LinkedEntitySummary
+            entity={entity}
+            mode={entityMode}
+            priority={entityPriority}
+            tone={copyTone}
+            headingLevel={entityHeadingLevel}
+          />
+        ) : undefined,
+        entityCover:
+          entity && entityMode === "cover" ? (
+            <LinkedEntityCover entity={entity} priority={entityPriority} />
           ) : undefined,
-          entityCover:
-            entity && entityMode === "cover" ? (
-              <LinkedEntityCover entity={entity} priority={entityPriority} />
-            ) : undefined,
-          headerActions: showHeaderActions ? (
-            <ReviewActionsMenu
-              reviewId={review.id}
-              reviewTitle={review.title}
-              entityTitle={entity?.title ?? null}
-              entityId={entity?.id ?? null}
-              canManage={canManage}
-              editSeed={editSeed}
-              initialBookmarked={initialBookmarked}
-              isAuthenticated={isAuthenticated}
-            />
-          ) : null,
-          footer: showInteractionBar ? (
-            <ReviewCardInteractionBar
-              review={review}
-              isAuthenticated={isAuthenticated}
-              viewer={viewer}
-              analyticsSource={analyticsSource}
-            />
-          ) : null,
-        }}
-      />
-    </div>
+        headerActions: showHeaderActions ? (
+          <ReviewActionsMenu
+            reviewId={review.id}
+            reviewTitle={review.title}
+            entityTitle={entity?.title ?? null}
+            entityId={entity?.id ?? null}
+            canManage={canManage}
+            editSeed={editSeed}
+            initialBookmarked={initialBookmarked}
+            isAuthenticated={isAuthenticated}
+          />
+        ) : null,
+        footer: showInteractionBar ? (
+          <ReviewCardInteractionBar
+            review={review}
+            isAuthenticated={isAuthenticated}
+            viewer={viewer}
+            analyticsSource={analyticsSource}
+          />
+        ) : null,
+      }}
+    />
   );
 
   if (!showContextMenu) {
@@ -404,6 +398,7 @@ export function ReviewPageCard({
       entity={entity}
       author={author}
       display={buildReviewPageCardDisplay()}
+      behavior={{ openReviewLink: false }}
       permissions={{ isAuthenticated, canManage }}
       viewer={viewer}
     />

--- a/apps/web/components/review-route-cards.tsx
+++ b/apps/web/components/review-route-cards.tsx
@@ -116,6 +116,22 @@ function getReviewLinkLabel(
   return `Open ${subject} by ${getAuthorLabel(author)}`;
 }
 
+function LinkedAuthorName({ author }: { author: ReviewCardAuthor | null | undefined }) {
+  if (!author) {
+    return null;
+  }
+
+  return (
+    <PrefetchLink
+      href={`/u/${author.username}`}
+      data-prevent-review-link="true"
+      className="relative z-[2] text-xs font-medium text-foreground transition-colors hover:underline sm:text-sm"
+    >
+      {getAuthorLabel(author)}
+    </PrefetchLink>
+  );
+}
+
 function LinkedEntitySummary({
   entity,
   mode,
@@ -236,6 +252,7 @@ function RoutedReviewCard({
       reviewHref={openReviewLink ? `/review/${review.id}` : null}
       reviewLinkLabel={getReviewLinkLabel(entity, author)}
       slots={{
+        authorName: author ? <LinkedAuthorName author={author} /> : undefined,
         entity: entity ? (
           <LinkedEntitySummary
             entity={entity}


### PR DESCRIPTION
## What changed

- Review cards now route clearly:
  - cover, song name, and artist go to the track page
  - the rest of the card opens the review page
  - action buttons stay independent
- `/review/:id` now prioritizes the track/artist in SEO and page semantics.
- Added inline replies under review detail.
- Made the review author linkable.
- Refined comments drawer/sheet:
  - flatter 2D layout
  - comments divided by subtle lines instead of boxed cards
  - composer matches the inline reply input
  - composer morphs from full rounded to card-like when multiline

## Why

This makes the review detail page feel like a real core surface: easier to open, easier to respond to, and visually consistent with the review/comment interaction model.

## Testing

- [x] Ran `pnpm check`
- [x] Added screenshots or a short recording for visible web UI changes
- [ ] Confirmed this does not touch auth, Supabase, recommendations, analytics, CI, or release behavior

Ran targeted checks instead of full `pnpm check`:

```text
pnpm --filter web lint
pnpm --filter web build
```

## Changelog impact

No manual `CHANGELOG.md` edit is required. Release Please generates release notes from PR titles and squash commits.

- [x] User-facing web change
- [ ] Developer experience or documentation change
- [ ] Internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inline reply functionality for review comments with auto-focused composer.
  * Added direct links to open reviews from review cards.

* **Improvements**
  * Enhanced comment composer with improved placeholder text and Enter-to-submit behavior.
  * Improved visual layering of interactive elements on review cards.
  * Better heading structure for improved accessibility in reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->