### PR TITLE
fix(web): harden search and desktop scrolling

### DIFF
--- a/apps/web/app/(main)/layout.tsx
+++ b/apps/web/app/(main)/layout.tsx
@@ -6,6 +6,7 @@ import GlobalShortcuts from "@/components/global-shortcuts";
 import MobileBottomBar from "@/components/mobile-bottom-bar";
 import { RouteHeaderProvider } from "@/components/route-header-context";
 import { SecondaryRailProvider } from "@/components/secondary-rail-context";
+import DesktopScrollBridge from "@/components/desktop-scroll-bridge";
 import WhoToFollowRail from "@/components/who-to-follow-rail";
 import { getCurrentOnboardingState, getCurrentUser, getCurrentViewerProfile } from "@/lib/auth/server";
 import { getStarterCuratorAccess } from "@/lib/queries/curation";
@@ -55,9 +56,16 @@ export default async function MainLayout({ children }: { children: React.ReactNo
               <GlobalShortcuts isAuthenticated={Boolean(safeProfile)} />
               <div className="kocteau-app-frame flex min-h-svh flex-1 flex-col lg:min-h-0 lg:h-full lg:overflow-hidden lg:rounded-[0.8rem]">
                 <Header profile={safeProfile} />
-                <div className="mx-auto flex min-h-0 w-full max-w-[82rem] flex-1 flex-col px-3.5 pt-[calc(env(safe-area-inset-top)+4rem)] pb-[calc(env(safe-area-inset-bottom)+6.5rem)] sm:px-6 sm:pt-[calc(env(safe-area-inset-top)+4.75rem)] sm:pb-28 lg:max-w-none lg:overflow-hidden lg:px-0 lg:py-0">
+                <DesktopScrollBridge />
+                <div
+                  data-kocteau-scroll-boundary
+                  className="mx-auto flex min-h-0 w-full max-w-[82rem] flex-1 flex-col px-3.5 pt-[calc(env(safe-area-inset-top)+4rem)] pb-[calc(env(safe-area-inset-bottom)+6.5rem)] sm:px-6 sm:pt-[calc(env(safe-area-inset-top)+4.75rem)] sm:pb-28 lg:max-w-none lg:overflow-hidden lg:px-0 lg:py-0"
+                >
                   <div className="mx-auto grid min-h-0 w-full max-w-[76rem] flex-1 gap-5 lg:h-full lg:grid-cols-[minmax(0,44rem)_16rem] lg:items-stretch lg:justify-center lg:px-7 xl:gap-6 xl:px-8">
-                    <main className="no-scrollbar min-w-0 lg:min-h-0 lg:overflow-x-hidden lg:overflow-y-auto lg:pr-1">
+                    <main
+                      data-kocteau-scroll-main
+                      className="no-scrollbar min-w-0 lg:min-h-0 lg:overflow-x-hidden lg:overflow-y-auto lg:pr-1"
+                    >
                       {children}
                     </main>
                     <WhoToFollowRail isAuthenticated={Boolean(safeProfile)} />

--- a/apps/web/app/api/deezer/search/route.ts
+++ b/apps/web/app/api/deezer/search/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { searchDeezerTracks } from "@/lib/deezer";
+import { DeezerRequestError, searchDeezerTracks } from "@/lib/deezer";
 import { supabasePublic } from "@/lib/supabase/public";
 import { deezerSearchQuerySchema } from "@/lib/validation/schemas";
 import { validationErrorResponse } from "@/lib/validation/server";
@@ -56,7 +56,19 @@ export async function GET(req: Request) {
         entity_id: entityByProviderId.get(result.provider_id) ?? null,
       }))
     );
-  } catch {
-    return NextResponse.json({ error: "Deezer request failed" }, { status: 502 });
+  } catch (error) {
+    console.error("[deezer.search] failed", {
+      type,
+      queryLength: q.length,
+      status: error instanceof DeezerRequestError ? error.status : null,
+      message: error instanceof Error ? error.message : "Unknown Deezer search error",
+    });
+
+    return NextResponse.json(
+      {
+        error: "Music search is taking longer than usual. Try again in a moment.",
+      },
+      { status: 502 },
+    );
   }
 }

--- a/apps/web/components/desktop-scroll-bridge.tsx
+++ b/apps/web/components/desktop-scroll-bridge.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useEffect } from "react";
+
+const desktopQuery = "(min-width: 1024px)";
+
+function canScrollElement(element: HTMLElement, deltaY: number) {
+  const style = window.getComputedStyle(element);
+  const canOverflow =
+    style.overflowY === "auto" ||
+    style.overflowY === "scroll" ||
+    style.overflowY === "overlay";
+
+  if (!canOverflow || element.scrollHeight <= element.clientHeight + 1) {
+    return false;
+  }
+
+  if (deltaY < 0) {
+    return element.scrollTop > 0;
+  }
+
+  if (deltaY > 0) {
+    return element.scrollTop + element.clientHeight < element.scrollHeight - 1;
+  }
+
+  return false;
+}
+
+function targetCanHandleScroll({
+  boundary,
+  deltaY,
+  main,
+  target,
+}: {
+  boundary: HTMLElement;
+  deltaY: number;
+  main: HTMLElement;
+  target: EventTarget | null;
+}) {
+  if (!(target instanceof Node)) {
+    return false;
+  }
+
+  if (main.contains(target)) {
+    return true;
+  }
+
+  let current: Node | null = target;
+
+  while (current && current !== boundary) {
+    if (current instanceof HTMLElement && canScrollElement(current, deltaY)) {
+      return true;
+    }
+
+    current = current.parentNode;
+  }
+
+  return false;
+}
+
+export default function DesktopScrollBridge() {
+  useEffect(() => {
+    const boundaryElement = document.querySelector<HTMLElement>("[data-kocteau-scroll-boundary]");
+    const mainElement = document.querySelector<HTMLElement>("[data-kocteau-scroll-main]");
+
+    if (!boundaryElement || !mainElement) {
+      return undefined;
+    }
+
+    const boundary = boundaryElement;
+    const main = mainElement;
+    const media = window.matchMedia(desktopQuery);
+
+    function handleWheel(event: WheelEvent) {
+      if (
+        !media.matches ||
+        event.defaultPrevented ||
+        event.ctrlKey ||
+        Math.abs(event.deltaY) <= Math.abs(event.deltaX)
+      ) {
+        return;
+      }
+
+      if (
+        targetCanHandleScroll({
+          boundary,
+          deltaY: event.deltaY,
+          main,
+          target: event.target,
+        })
+      ) {
+        return;
+      }
+
+      const maxScrollTop = main.scrollHeight - main.clientHeight;
+
+      if (maxScrollTop <= 0) {
+        return;
+      }
+
+      const nextScrollTop = Math.min(
+        maxScrollTop,
+        Math.max(0, main.scrollTop + event.deltaY),
+      );
+
+      if (nextScrollTop === main.scrollTop) {
+        return;
+      }
+
+      event.preventDefault();
+      main.scrollTop = nextScrollTop;
+    }
+
+    boundary.addEventListener("wheel", handleWheel, { passive: false });
+
+    return () => {
+      boundary.removeEventListener("wheel", handleWheel);
+    };
+  }, []);
+
+  return null;
+}

--- a/apps/web/components/new-review-form.tsx
+++ b/apps/web/components/new-review-form.tsx
@@ -166,7 +166,7 @@ function NewReviewFormState({
   const suggestedSearches = ["Radiohead", "Björk", "Bad Bunny", "Frank Ocean", "Massive Attack", "The Cure"];
   const searchEnabled = step === "search";
   const normalizedQuery = query.trim();
-  const { data, isFetching, error: searchError } = useDeezerSearch({
+  const { data, isFetching, error: searchError, refetch: retrySearch } = useDeezerSearch({
     query,
     type: "track",
     enabled: searchEnabled,
@@ -570,9 +570,21 @@ function NewReviewFormState({
           ) : null}
 
           {searchError ? (
-            <Alert variant="destructive" className="mb-4 shrink-0">
-              <AlertTitle>We could not search</AlertTitle>
-              <AlertDescription>{searchError.message}</AlertDescription>
+            <Alert className="mb-4 shrink-0 border-border/28 bg-card/22 pr-24">
+              <AlertTitle>Music search is slow</AlertTitle>
+              <AlertDescription>
+                {searchError.message || "Music search is taking longer than usual. Try again in a moment."}
+              </AlertDescription>
+              <button
+                type="button"
+                onClick={() => {
+                  void retrySearch();
+                }}
+                disabled={isFetching}
+                className="absolute top-1/2 right-2 inline-flex h-7 -translate-y-1/2 items-center rounded-full border border-border/28 px-2.5 text-[11px] font-medium text-foreground/88 transition hover:bg-foreground/[0.055] disabled:pointer-events-none disabled:opacity-55"
+              >
+                {isFetching ? "Retrying" : "Retry"}
+              </button>
             </Alert>
           ) : null}
           <FieldError>{fieldErrors.selected}</FieldError>

--- a/apps/web/components/search-page-client.tsx
+++ b/apps/web/components/search-page-client.tsx
@@ -294,7 +294,7 @@ export default function SearchPageClient({
     () => parseRecentSearchesSnapshot(recentSearchesSnapshot),
     [recentSearchesSnapshot],
   );
-  const { data = [], isFetching, error } = useDeezerSearch({
+  const { data = [], isFetching, error, refetch: retrySearch } = useDeezerSearch({
     query,
     type: searchType,
     enabled: searchType === "track",
@@ -377,6 +377,11 @@ export default function SearchPageClient({
 
   const showSkeletonResults =
     hasQuery && normalizedQuery.length >= 2 && isFetching && results.length === 0;
+  const showSearchError = normalizedQuery.length >= 2 && Boolean(error);
+  const searchErrorMessage =
+    error instanceof Error && error.message
+      ? error.message
+      : "Music search is taking longer than usual. Try again in a moment.";
 
   function persistRecentSearch(nextQuery: string) {
     const label = nextQuery.trim();
@@ -457,7 +462,24 @@ export default function SearchPageClient({
             <SearchTypeTabs activeType={searchType} query={normalizedQuery} />
           </div>
 
-          {error ? <p className="mt-3 text-sm text-destructive">{error.message}</p> : null}
+          {showSearchError ? (
+            <div className="relative rounded-[var(--kocteau-radius-card)] border border-border/28 bg-[var(--kocteau-surface)] px-4 py-3 pr-24 text-sm shadow-[inset_0_1px_0_rgba(255,255,255,0.035)]">
+              <p className="font-medium text-foreground">Music search is slow</p>
+              <p className="mt-0.5 text-xs leading-5 text-muted-foreground/82">
+                {searchErrorMessage}
+              </p>
+              <button
+                type="button"
+                onClick={() => {
+                  void retrySearch();
+                }}
+                disabled={isFetching}
+                className="absolute top-1/2 right-3 inline-flex h-8 -translate-y-1/2 items-center rounded-full border border-border/28 px-3 text-[12px] font-medium text-foreground/88 transition hover:bg-foreground/[0.055] disabled:pointer-events-none disabled:opacity-55"
+              >
+                {isFetching ? "Retrying" : "Retry"}
+              </button>
+            </div>
+          ) : null}
 
           {!hasQuery ? (
             <section className="overflow-hidden rounded-[var(--kocteau-radius-card)] border border-border/24 bg-[var(--kocteau-surface)] shadow-none">
@@ -539,7 +561,7 @@ export default function SearchPageClient({
                 </Empty>
               ) : null}
 
-              {!showSkeletonResults && normalizedQuery.length >= 2 && results.length === 0 ? (
+              {!showSkeletonResults && !showSearchError && normalizedQuery.length >= 2 && results.length === 0 ? (
                 <Empty className="rounded-[var(--kocteau-radius-card)] border-border/24 bg-[var(--kocteau-surface)] px-6 py-9 shadow-[inset_0_1px_0_rgba(255,255,255,0.035)]">
                   <EmptyHeader>
                     <EmptyMedia variant="icon">

--- a/apps/web/lib/deezer.ts
+++ b/apps/web/lib/deezer.ts
@@ -94,6 +94,75 @@ type DeezerTrackMapOptions = {
   cover_url?: string | null;
 };
 
+const deezerRequestTimeoutMs = 8_000;
+const deezerSearchRetryDelaysMs = [250, 700] as const;
+
+type DeezerFetchOptions = {
+  errorMessage: string;
+  revalidate: number;
+  retryDelays?: readonly number[];
+};
+
+export class DeezerRequestError extends Error {
+  status: number | null;
+
+  constructor(message: string, status: number | null = null) {
+    super(message);
+    this.name = "DeezerRequestError";
+    this.status = status;
+  }
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function fetchDeezerJson<T>(
+  url: string,
+  {
+    errorMessage,
+    revalidate,
+    retryDelays = [],
+  }: DeezerFetchOptions,
+): Promise<T> {
+  let lastError: unknown = null;
+  const maxAttempts = retryDelays.length + 1;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), deezerRequestTimeoutMs);
+
+    try {
+      const response = await fetch(url, {
+        next: { revalidate },
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        throw new DeezerRequestError(errorMessage, response.status);
+      }
+
+      return (await response.json()) as T;
+    } catch (error) {
+      lastError = error;
+
+      if (attempt >= retryDelays.length) {
+        break;
+      }
+
+      await sleep(retryDelays[attempt] ?? 0);
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  if (lastError instanceof Error) {
+    throw lastError;
+  }
+
+  throw new DeezerRequestError(errorMessage);
+}
+
 function getOptionalNumber(value: number | null | undefined) {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
@@ -119,15 +188,12 @@ function mapDeezerTrack(
 
 export async function searchDeezerTracks(query: string, limit = 12): Promise<DeezerTrackResult[]> {
   const url = `https://api.deezer.com/search?q=${encodeURIComponent(query)}&limit=${limit}`;
-  const response = await fetch(url, {
-    next: { revalidate: 60 },
+  const json = await fetchDeezerJson<DeezerSearchResponse>(url, {
+    errorMessage: "Deezer search request failed",
+    revalidate: 60,
+    retryDelays: deezerSearchRetryDelaysMs,
   });
 
-  if (!response.ok) {
-    throw new Error("Deezer request failed");
-  }
-
-  const json = (await response.json()) as DeezerSearchResponse;
   return (json.data ?? []).map((item) => mapDeezerTrack(item));
 }
 
@@ -151,15 +217,12 @@ export async function searchDeezerArtists(
   limit = 3,
 ): Promise<DeezerArtistResult[]> {
   const url = `https://api.deezer.com/search/artist?q=${encodeURIComponent(query)}&limit=${limit}`;
-  const response = await fetch(url, {
-    next: { revalidate: 300 },
+  const json = await fetchDeezerJson<DeezerArtistSearchResponse>(url, {
+    errorMessage: "Deezer artist request failed",
+    revalidate: 300,
+    retryDelays: deezerSearchRetryDelaysMs,
   });
 
-  if (!response.ok) {
-    throw new Error("Deezer artist request failed");
-  }
-
-  const json = (await response.json()) as DeezerArtistSearchResponse;
   return (json.data ?? []).flatMap((item) => {
     const artist = mapDeezerArtist(item);
     return artist ? [artist] : [];

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -10,7 +10,7 @@ const nextConfig: NextConfig = {
     formats: ["image/avif", "image/webp"],
     imageSizes: [24, 32, 40, 44, 48, 56, 64, 80, 96, 112, 128, 160, 192, 256],
     minimumCacheTTL: 60 * 60 * 24 * 7,
-    qualities: [56, 64, 70, 75, 84, 86, 88, 90],
+    qualities: [56, 64, 70, 75, 78, 82, 84, 86, 88, 90],
     remotePatterns: [
       {
         protocol: "https",


### PR DESCRIPTION
## What changed

- Fixed desktop scroll dead zones so scrolling over the secondary rail or wide empty space moves the main content.
- Hardened Deezer-backed search with timeout/retry handling and calmer retry UI.
- Added allowed Next image qualities for search cover art to avoid unconfigured quality warnings.

## Why

First-time users were hitting rough edges: desktop scroll felt stuck outside the main column, Deezer failures surfaced as a hard technical error, and cover image quality warnings polluted dev logs.

## Testing

- [ ] Ran `pnpm check`
- [ ] Added screenshots or a short recording for visible web UI changes
- [x] Confirmed this does not touch auth, Supabase, recommendations, analytics, CI, or release behavior

Additional verification:
- Ran `pnpm --filter web lint`
- Ran `pnpm --filter web build`
- Ran `git diff --check`
- Smoke-tested `/search?q=the+cure` desktop/mobile scroll behavior
- Confirmed `/api/deezer/search?q=the%20cure&type=track` returned `200` in repeated local checks

## Changelog impact

No manual `CHANGELOG.md` edit is required. Release Please generates release notes from PR titles and squash commits.

- [x] User-facing web change
- [ ] Developer experience or documentation change
- [ ] Internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added desktop scroll bridging to improve scrolling experience across layout regions.
  * Added retry button for failed music searches to enhance reliability.

* **Bug Fixes**
  * Enhanced error handling for music searches with improved timeout management.
  * Improved search robustness with automatic retry logic and clearer error messages.
  * Optimized image quality levels for better visual performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->