### PR TITLE
fix(web): bridge desktop scroll dead zones

### DIFF
--- a/apps/web/app/(main)/layout.tsx
+++ b/apps/web/app/(main)/layout.tsx
@@ -54,11 +54,13 @@ export default async function MainLayout({ children }: { children: React.ReactNo
           <RouteHeaderProvider>
             <SecondaryRailProvider>
               <GlobalShortcuts isAuthenticated={Boolean(safeProfile)} />
-              <div className="kocteau-app-frame flex min-h-svh flex-1 flex-col lg:min-h-0 lg:h-full lg:overflow-hidden lg:rounded-[0.8rem]">
+              <div
+                data-kocteau-scroll-boundary
+                className="kocteau-app-frame flex min-h-svh flex-1 flex-col lg:min-h-0 lg:h-full lg:overflow-hidden lg:rounded-[0.8rem]"
+              >
                 <Header profile={safeProfile} />
                 <DesktopScrollBridge />
                 <div
-                  data-kocteau-scroll-boundary
                   className="mx-auto flex min-h-0 w-full max-w-[82rem] flex-1 flex-col px-3.5 pt-[calc(env(safe-area-inset-top)+4rem)] pb-[calc(env(safe-area-inset-bottom)+6.5rem)] sm:px-6 sm:pt-[calc(env(safe-area-inset-top)+4.75rem)] sm:pb-28 lg:max-w-none lg:overflow-hidden lg:px-0 lg:py-0"
                 >
                   <div className="mx-auto grid min-h-0 w-full max-w-[76rem] flex-1 gap-5 lg:h-full lg:grid-cols-[minmax(0,44rem)_16rem] lg:items-stretch lg:justify-center lg:px-7 xl:gap-6 xl:px-8">

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -52,7 +52,7 @@ These are the next useful moves after enabling public contribution.
 | P0 | Confirm the `v0.2.0` tag and GitHub Release are created after the release PR merges. | ready | `chore`, `area:ci` |
 | P0 | Pin the public repository description, topics, website URL, and social preview image in GitHub settings. | ready | `docs`, `area:docs` |
 | P0 | Make recommendations visible on track pages so new visitors can see "what to hear next." | done | `feature`, `area:web`, `area:recommendations` |
-| P0 | Fix desktop scroll dead zones so the page still scrolls when the pointer is over the secondary rail or empty desktop space. | ready | `fix`, `area:web`, `area:ui` |
+| P0 | Fix desktop scroll dead zones so the page still scrolls when the pointer is over the secondary rail or empty desktop space. | done | `fix`, `area:web`, `area:ui` |
 | P0 | Make review cards open their review detail route without breaking like, save, or comment actions. | done | `feature`, `area:web`, `area:ui` |
 | P0 | Fix mobile toast placement so feedback is centered and clears the bottom navigation. | ready | `fix`, `area:web`, `area:ui` |
 | P1 | Harden Deezer-backed search with retry, clearer empty/error copy, and non-blocking fallbacks. | ready | `fix`, `area:web`, `area:search` |
@@ -417,7 +417,7 @@ Acceptance criteria:
 
 Suggested issue: `fix(web): make desktop feed scrolling work outside the main column`
 
-State: `ready`. Current desktop layouts can feel stuck when the pointer is over the secondary rail or empty layout space because the document itself is locked and only the main column scrolls.
+State: `done`. Current desktop layouts can feel stuck when the pointer is over the secondary rail or empty layout space because the document itself is locked and only the main column scrolls.
 
 - Route wheel/scroll behavior so desktop users can keep moving the main content even when their pointer is over the secondary rail or wide empty space.
 - Preserve the sidebar and rail layout stability.


### PR DESCRIPTION
## What changed

Fixed desktop scroll dead zones by making the main app frame the scroll bridge boundary, so wheel scrolling works from the main column, secondary rail, header area, and empty desktop space.

## Why

Desktop users could hit areas where scrolling felt broken unless the pointer was directly over the scrollable content. This keeps the reading/discovery surface feeling continuous.

## Testing

- [x] Ran `pnpm check`
- [ ] Added screenshots or a short recording for visible web UI changes
- [x] Confirmed this does not touch auth, Supabase, recommendations, analytics, CI, or release behavior

Also ran:
- `pnpm --filter web lint`
- `pnpm --filter web build`
- Playwright smoke on `/u/kocteau` confirming wheel scroll works on main, rail, header, and empty space

## Changelog impact

No manual `CHANGELOG.md` edit is required. Release Please generates release notes from PR titles and squash commits.

- [x] User-facing web change
- [x] Developer experience or documentation change
- [ ] Internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed desktop scroll dead zones impacting smooth page scrolling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->