### PR TITLE
feat(web): add Kocteau-first track search

### DIFF
--- a/apps/web/app/api/search/route.ts
+++ b/apps/web/app/api/search/route.ts
@@ -1,0 +1,374 @@
+import { NextResponse } from "next/server";
+import {
+  DeezerRequestError,
+  getDeezerArtistTopTracks,
+  searchDeezerArtists,
+  searchDeezerTracks,
+  type DeezerTrackResult,
+} from "@/lib/deezer";
+import {
+  isStrongArtistSearchMatch,
+  rankKocteauTrackSearchResults,
+  type KocteauTrackSearchCandidate,
+} from "@/lib/search/kocteau-first";
+import { supabasePublic } from "@/lib/supabase/public";
+import { deezerSearchQuerySchema } from "@/lib/validation/schemas";
+import { validationErrorResponse } from "@/lib/validation/server";
+
+type LocalEntityRow = {
+  id: string;
+  provider: string;
+  provider_id: string;
+  type: "track" | "album";
+  title: string;
+  artist_name: string | null;
+  cover_url: string | null;
+  deezer_url: string | null;
+};
+
+type StarterTrackRow = {
+  id: string;
+  provider: string;
+  provider_id: string;
+  type: "track" | "album";
+  title: string;
+  artist_name: string | null;
+  cover_url: string | null;
+  deezer_url: string | null;
+};
+
+type EntityLinkRow = {
+  id: string;
+  provider_id: string;
+};
+
+const localSearchLimit = 18;
+const deezerSearchLimit = 18;
+const artistMatchLimit = 12;
+const responseLimit = 28;
+
+function toIlikePattern(query: string) {
+  return `%${query.replace(/[\\%_]/g, "\\$&")}%`;
+}
+
+function dedupeByProviderId<T extends { provider_id: string }>(rows: T[]) {
+  const byProviderId = new Map<string, T>();
+
+  for (const row of rows) {
+    if (!byProviderId.has(row.provider_id)) {
+      byProviderId.set(row.provider_id, row);
+    }
+  }
+
+  return Array.from(byProviderId.values());
+}
+
+function mapLocalEntityCandidate(
+  row: LocalEntityRow,
+  sourceIndex: number,
+): KocteauTrackSearchCandidate {
+  return {
+    provider: "deezer",
+    provider_id: row.provider_id,
+    type: "track",
+    title: row.title,
+    artist_name: row.artist_name,
+    cover_url: row.cover_url,
+    deezer_url: row.deezer_url,
+    entity_id: row.id,
+    source: "local",
+    source_index: sourceIndex,
+  };
+}
+
+function mapStarterTrackCandidate(
+  row: StarterTrackRow,
+  sourceIndex: number,
+): KocteauTrackSearchCandidate {
+  return {
+    provider: "deezer",
+    provider_id: row.provider_id,
+    type: "track",
+    title: row.title,
+    artist_name: row.artist_name,
+    cover_url: row.cover_url,
+    deezer_url: row.deezer_url,
+    source: "starter",
+    source_index: sourceIndex,
+  };
+}
+
+function mapDeezerTrackCandidate({
+  track,
+  source,
+  sourceIndex,
+}: {
+  track: DeezerTrackResult;
+  source: "artist-match" | "deezer";
+  sourceIndex: number;
+}): KocteauTrackSearchCandidate {
+  return {
+    provider: "deezer",
+    provider_id: track.provider_id,
+    type: "track",
+    title: track.title,
+    artist_name: track.artist_name,
+    cover_url: track.cover_url,
+    deezer_url: track.deezer_url,
+    source,
+    source_index: sourceIndex,
+    rank: track.rank ?? null,
+  };
+}
+
+function mapSearchResponse(result: ReturnType<typeof rankKocteauTrackSearchResults>[number]) {
+  return {
+    provider: result.provider,
+    provider_id: result.provider_id,
+    type: result.type,
+    title: result.title,
+    artist_name: result.artist_name,
+    cover_url: result.cover_url,
+    deezer_url: result.deezer_url,
+    entity_id: result.entity_id ?? null,
+    source: result.source,
+    source_label: result.source_label,
+  };
+}
+
+async function getLocalEntityCandidates(query: string) {
+  const supabase = supabasePublic();
+  const pattern = toIlikePattern(query);
+  const baseSelect = "id, provider, provider_id, type, title, artist_name, cover_url, deezer_url";
+
+  const [titleResult, artistResult] = await Promise.all([
+    supabase
+      .from("entities")
+      .select(baseSelect)
+      .eq("provider", "deezer")
+      .eq("type", "track")
+      .ilike("title", pattern)
+      .limit(localSearchLimit),
+    supabase
+      .from("entities")
+      .select(baseSelect)
+      .eq("provider", "deezer")
+      .eq("type", "track")
+      .ilike("artist_name", pattern)
+      .limit(localSearchLimit),
+  ]);
+
+  if (titleResult.error) {
+    console.warn("[search.local_entities] title lookup failed", titleResult.error.message);
+  }
+
+  if (artistResult.error) {
+    console.warn("[search.local_entities] artist lookup failed", artistResult.error.message);
+  }
+
+  return dedupeByProviderId([
+    ...((titleResult.data ?? []) as LocalEntityRow[]),
+    ...((artistResult.data ?? []) as LocalEntityRow[]),
+  ]).map(mapLocalEntityCandidate);
+}
+
+async function getStarterTrackCandidates(query: string) {
+  const supabase = supabasePublic();
+  const pattern = toIlikePattern(query);
+  const baseSelect = "id, provider, provider_id, type, title, artist_name, cover_url, deezer_url";
+
+  const [titleResult, artistResult] = await Promise.all([
+    supabase
+      .from("starter_tracks")
+      .select(baseSelect)
+      .eq("provider", "deezer")
+      .eq("type", "track")
+      .eq("is_active", true)
+      .ilike("title", pattern)
+      .order("sort_order", { ascending: true })
+      .limit(localSearchLimit),
+    supabase
+      .from("starter_tracks")
+      .select(baseSelect)
+      .eq("provider", "deezer")
+      .eq("type", "track")
+      .eq("is_active", true)
+      .ilike("artist_name", pattern)
+      .order("sort_order", { ascending: true })
+      .limit(localSearchLimit),
+  ]);
+
+  if (titleResult.error) {
+    console.warn("[search.starter_tracks] title lookup failed", titleResult.error.message);
+  }
+
+  if (artistResult.error) {
+    console.warn("[search.starter_tracks] artist lookup failed", artistResult.error.message);
+  }
+
+  return dedupeByProviderId([
+    ...((titleResult.data ?? []) as StarterTrackRow[]),
+    ...((artistResult.data ?? []) as StarterTrackRow[]),
+  ]).map(mapStarterTrackCandidate);
+}
+
+async function getEntityIdsByProviderId(providerIds: string[]) {
+  const uniqueProviderIds = Array.from(new Set(providerIds));
+
+  if (uniqueProviderIds.length === 0) {
+    return new Map<string, string>();
+  }
+
+  const supabase = supabasePublic();
+  const { data, error } = await supabase
+    .from("entities")
+    .select("id, provider_id")
+    .eq("provider", "deezer")
+    .eq("type", "track")
+    .in("provider_id", uniqueProviderIds);
+
+  if (error) {
+    console.warn("[search.entity_links] lookup failed", error.message);
+    return new Map<string, string>();
+  }
+
+  return new Map(((data ?? []) as EntityLinkRow[]).map((row) => [row.provider_id, row.id]));
+}
+
+async function getDeezerCandidates(query: string) {
+  const candidates: KocteauTrackSearchCandidate[] = [];
+  const errors: unknown[] = [];
+  const [tracksResult, artistsResult] = await Promise.allSettled([
+    searchDeezerTracks(query, deezerSearchLimit),
+    searchDeezerArtists(query, 3),
+  ]);
+
+  if (tracksResult.status === "fulfilled") {
+    candidates.push(
+      ...tracksResult.value.map((track, index) =>
+        mapDeezerTrackCandidate({
+          track,
+          source: "deezer",
+          sourceIndex: index,
+        }),
+      ),
+    );
+  } else {
+    errors.push(tracksResult.reason);
+  }
+
+  if (artistsResult.status === "fulfilled") {
+    const artist = artistsResult.value.find((result) =>
+      isStrongArtistSearchMatch(query, result.name),
+    );
+
+    if (artist) {
+      try {
+        const tracks = await getDeezerArtistTopTracks(
+          {
+            id: artist.id,
+            fan_count: artist.fan_count,
+          },
+          artistMatchLimit,
+        );
+
+        candidates.push(
+          ...tracks.map((track, index) =>
+            mapDeezerTrackCandidate({
+              track,
+              source: "artist-match",
+              sourceIndex: index,
+            }),
+          ),
+        );
+      } catch (error) {
+        errors.push(error);
+      }
+    }
+  } else {
+    errors.push(artistsResult.reason);
+  }
+
+  return {
+    candidates,
+    errors,
+  };
+}
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const parsed = deezerSearchQuerySchema.safeParse({
+    q: searchParams.get("q") ?? undefined,
+    type: searchParams.get("type") ?? undefined,
+  });
+
+  if (!parsed.success) {
+    return validationErrorResponse(parsed.error, "Search query is invalid.");
+  }
+
+  const { q, type } = parsed.data;
+
+  if (!q) return NextResponse.json([], { status: 200 });
+  if (type !== "track") {
+    return NextResponse.json(
+      { error: `Search for ${type} is not available yet.` },
+      { status: 501 },
+    );
+  }
+
+  const [localCandidates, starterCandidates, deezerCandidatesResult] = await Promise.all([
+    getLocalEntityCandidates(q),
+    getStarterTrackCandidates(q),
+    getDeezerCandidates(q),
+  ]);
+
+  const candidates = [
+    ...localCandidates,
+    ...starterCandidates,
+    ...deezerCandidatesResult.candidates,
+  ];
+  const entityIdsByProviderId = await getEntityIdsByProviderId(
+    candidates.map((candidate) => candidate.provider_id),
+  );
+  const linkedCandidates = candidates.map((candidate) => ({
+    ...candidate,
+    entity_id: candidate.entity_id ?? entityIdsByProviderId.get(candidate.provider_id) ?? null,
+  }));
+  const results = rankKocteauTrackSearchResults({
+    query: q,
+    candidates: linkedCandidates,
+    limit: responseLimit,
+  });
+  const response = results.map(mapSearchResponse);
+
+  if (results.length > 0) {
+    if (deezerCandidatesResult.errors.length > 0) {
+      console.warn("[search.deezer] returned Kocteau fallback results", {
+        queryLength: q.length,
+        errorCount: deezerCandidatesResult.errors.length,
+      });
+    }
+
+    return NextResponse.json(response);
+  }
+
+  const [firstError] = deezerCandidatesResult.errors;
+
+  if (firstError) {
+    console.error("[search.deezer] failed with no fallback", {
+      type,
+      queryLength: q.length,
+      status: firstError instanceof DeezerRequestError ? firstError.status : null,
+      message: firstError instanceof Error ? firstError.message : "Unknown Deezer search error",
+    });
+
+    return NextResponse.json(
+      {
+        error: "Music search is taking longer than usual. Try again in a moment.",
+      },
+      { status: 502 },
+    );
+  }
+
+  return NextResponse.json([], { status: 200 });
+}

--- a/apps/web/components/search-page-client.tsx
+++ b/apps/web/components/search-page-client.tsx
@@ -10,8 +10,8 @@ import TrackContextMenu from "@/components/track-context-menu";
 import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from "@/components/ui/empty";
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
+import { useKocteauSearch, type KocteauSearchResult } from "@/hooks/use-kocteau-search";
 import { useIsMobile } from "@/hooks/use-mobile";
-import { useDeezerSearch, type DeezerSearchResult } from "@/hooks/use-deezer-search";
 import type { DiscoveryTrack } from "@/lib/queries/discovery";
 import type { SearchEntityType } from "@/lib/search-types";
 import { cn } from "@/lib/utils";
@@ -116,7 +116,7 @@ function formatDate(value: string) {
   });
 }
 
-function getResultHref(result: DeezerSearchResult) {
+function getResultHref(result: KocteauSearchResult) {
   return result.entity_id ? `/track/${result.entity_id}` : `/track/deezer/${result.provider_id}`;
 }
 
@@ -294,12 +294,12 @@ export default function SearchPageClient({
     () => parseRecentSearchesSnapshot(recentSearchesSnapshot),
     [recentSearchesSnapshot],
   );
-  const { data = [], isFetching, error, refetch: retrySearch } = useDeezerSearch({
+  const { data = [], isFetching, error, refetch: retrySearch } = useKocteauSearch({
     query,
     type: searchType,
     enabled: searchType === "track",
   });
-  const results = data as DeezerSearchResult[];
+  const results = data as KocteauSearchResult[];
   const activeResultKey = useMemo(
     () =>
       [
@@ -646,7 +646,7 @@ export default function SearchPageClient({
                                 <Disc3 className="size-3" />
                                 <span>Track</span>
                                 <span aria-hidden="true">·</span>
-                                <span>{result.entity_id ? "In library" : "Deezer"}</span>
+                                <span>{result.source_label ?? (result.entity_id ? "Kocteau" : "Deezer")}</span>
                               </div>
                             </div>
                           </div>

--- a/apps/web/hooks/use-kocteau-search.ts
+++ b/apps/web/hooks/use-kocteau-search.ts
@@ -1,0 +1,30 @@
+"use client";
+
+import { useDeferredValue } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useDebouncedValue } from "@/hooks/use-debounced-value";
+import type { SearchEntityType } from "@/lib/search-types";
+import { kocteauTrackSearchQueryOptions } from "@/queries/tracks";
+
+export type { KocteauSearchResult } from "@/queries/tracks";
+
+type UseKocteauSearchOptions = {
+  query: string;
+  type?: SearchEntityType;
+  enabled?: boolean;
+};
+
+export function useKocteauSearch({
+  query,
+  type = "track",
+  enabled = true,
+}: UseKocteauSearchOptions) {
+  const trimmedQuery = query.trim();
+  const deferredQuery = useDeferredValue(trimmedQuery);
+  const debouncedQuery = useDebouncedValue(deferredQuery, 250);
+
+  return useQuery({
+    ...kocteauTrackSearchQueryOptions(debouncedQuery, type),
+    enabled: enabled && type === "track" && debouncedQuery.length >= 2,
+  });
+}

--- a/apps/web/lib/search/kocteau-first.test.ts
+++ b/apps/web/lib/search/kocteau-first.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  isStrongArtistSearchMatch,
+  rankKocteauTrackSearchResults,
+  type KocteauTrackSearchCandidate,
+} from "./kocteau-first.ts";
+
+function candidate(
+  providerId: string,
+  overrides: Partial<KocteauTrackSearchCandidate> = {},
+): KocteauTrackSearchCandidate {
+  return {
+    provider: "deezer",
+    provider_id: providerId,
+    type: "track",
+    title: `Track ${providerId}`,
+    artist_name: "Unknown Artist",
+    cover_url: null,
+    deezer_url: null,
+    source: "deezer",
+    source_index: 0,
+    rank: 100,
+    ...overrides,
+  };
+}
+
+describe("kocteau-first search ranking", () => {
+  it("prefers exact artist matches over unrelated exact title matches", () => {
+    const results = rankKocteauTrackSearchResults({
+      query: "The Cure",
+      candidates: [
+        candidate("olivia", {
+          title: "the cure",
+          artist_name: "Olivia Rodrigo",
+          source: "deezer",
+          rank: 900_000,
+          source_index: 0,
+        }),
+        candidate("cure-1", {
+          title: "Pictures of You",
+          artist_name: "The Cure",
+          source: "artist-match",
+          rank: 300_000,
+          source_index: 1,
+        }),
+      ],
+    });
+
+    assert.equal(results[0]?.provider_id, "cure-1");
+    assert.equal(results[0]?.source_label, "Artist match");
+  });
+
+  it("deduplicates results and prefers Kocteau local links", () => {
+    const results = rankKocteauTrackSearchResults({
+      query: "Jamais Pars",
+      candidates: [
+        candidate("123", {
+          title: "Jamais Pars",
+          artist_name: "black tape for a blue girl",
+          source: "deezer",
+        }),
+        candidate("123", {
+          title: "Jamais Pars",
+          artist_name: "black tape for a blue girl",
+          entity_id: "local-entity",
+          source: "local",
+        }),
+      ],
+    });
+
+    assert.equal(results.length, 1);
+    assert.equal(results[0]?.entity_id, "local-entity");
+    assert.equal(results[0]?.source_label, "Kocteau");
+  });
+
+  it("detects exact and partial artist intent without matching loose substrings", () => {
+    assert.equal(isStrongArtistSearchMatch("The Cure", "The Cure"), true);
+    assert.equal(isStrongArtistSearchMatch("cocteau tw", "Cocteau Twins"), true);
+    assert.equal(isStrongArtistSearchMatch("cure", "The Cure"), false);
+  });
+});

--- a/apps/web/lib/search/kocteau-first.ts
+++ b/apps/web/lib/search/kocteau-first.ts
@@ -1,0 +1,191 @@
+export type KocteauSearchSource = "local" | "starter" | "artist-match" | "deezer";
+
+export type KocteauTrackSearchCandidate = {
+  provider: "deezer";
+  provider_id: string;
+  type: "track";
+  title: string;
+  artist_name: string | null;
+  cover_url: string | null;
+  deezer_url: string | null;
+  entity_id?: string | null;
+  source: KocteauSearchSource;
+  source_index?: number;
+  rank?: number | null;
+};
+
+export type KocteauTrackSearchResult = KocteauTrackSearchCandidate & {
+  score: number;
+  source_label: string;
+};
+
+const sourceScore: Record<KocteauSearchSource, number> = {
+  local: 320,
+  starter: 260,
+  "artist-match": 150,
+  deezer: 0,
+};
+
+const sourceLabel: Record<KocteauSearchSource, string> = {
+  local: "Kocteau",
+  starter: "Starter pick",
+  "artist-match": "Artist match",
+  deezer: "Deezer",
+};
+
+export function normalizeSearchText(value: string | null | undefined) {
+  return (value ?? "")
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/&/g, " and ")
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+    .replace(/\s+/g, " ");
+}
+
+function hasWordMatch(value: string, query: string) {
+  if (!value || !query) return false;
+
+  return value.split(" ").includes(query);
+}
+
+function getTokenOverlapScore(value: string, query: string) {
+  if (!value || !query) return 0;
+
+  const valueTokens = new Set(value.split(" ").filter(Boolean));
+  const queryTokens = query.split(" ").filter((token) => token.length > 1);
+  const matches = queryTokens.filter((token) => valueTokens.has(token)).length;
+
+  return matches * 24;
+}
+
+function getRankTieBreaker(rank: number | null | undefined) {
+  if (!rank || rank <= 0) return 0;
+
+  return Math.min(35, Math.log10(rank) * 6);
+}
+
+function getSourcePriority(source: KocteauSearchSource) {
+  if (source === "local") return 4;
+  if (source === "starter") return 3;
+  if (source === "artist-match") return 2;
+  return 1;
+}
+
+function getCandidateIdentity(candidate: KocteauTrackSearchCandidate) {
+  return `${candidate.provider}:${candidate.type}:${candidate.provider_id}`;
+}
+
+function mergeDuplicateCandidate(
+  existing: KocteauTrackSearchCandidate,
+  incoming: KocteauTrackSearchCandidate,
+) {
+  const existingPriority = getSourcePriority(existing.source) + (existing.entity_id ? 1 : 0);
+  const incomingPriority = getSourcePriority(incoming.source) + (incoming.entity_id ? 1 : 0);
+  const winner = incomingPriority > existingPriority ? incoming : existing;
+  const fallback = winner === incoming ? existing : incoming;
+
+  return {
+    ...winner,
+    entity_id: winner.entity_id ?? fallback.entity_id ?? null,
+    cover_url: winner.cover_url ?? fallback.cover_url,
+    deezer_url: winner.deezer_url ?? fallback.deezer_url,
+    rank: winner.rank ?? fallback.rank ?? null,
+    source_index: Math.min(
+      winner.source_index ?? Number.MAX_SAFE_INTEGER,
+      fallback.source_index ?? Number.MAX_SAFE_INTEGER,
+    ),
+  };
+}
+
+export function getKocteauSearchScore(
+  query: string,
+  candidate: Pick<
+    KocteauTrackSearchCandidate,
+    "title" | "artist_name" | "source" | "entity_id" | "rank"
+  >,
+) {
+  const normalizedQuery = normalizeSearchText(query);
+  const normalizedTitle = normalizeSearchText(candidate.title);
+  const normalizedArtist = normalizeSearchText(candidate.artist_name);
+
+  if (!normalizedQuery) return 0;
+
+  let score = sourceScore[candidate.source];
+
+  if (candidate.entity_id) {
+    score += 45;
+  }
+
+  if (normalizedArtist === normalizedQuery) {
+    score += 650;
+  } else if (normalizedArtist.startsWith(normalizedQuery)) {
+    score += 430;
+  } else if (hasWordMatch(normalizedArtist, normalizedQuery)) {
+    score += 320;
+  } else if (normalizedArtist.includes(normalizedQuery)) {
+    score += 180;
+  }
+
+  if (normalizedTitle === normalizedQuery) {
+    score += 360;
+  } else if (normalizedTitle.startsWith(normalizedQuery)) {
+    score += 250;
+  } else if (hasWordMatch(normalizedTitle, normalizedQuery)) {
+    score += 180;
+  } else if (normalizedTitle.includes(normalizedQuery)) {
+    score += 120;
+  }
+
+  score += getTokenOverlapScore(normalizedArtist, normalizedQuery);
+  score += getTokenOverlapScore(normalizedTitle, normalizedQuery);
+  score += getRankTieBreaker(candidate.rank);
+
+  return score;
+}
+
+export function isStrongArtistSearchMatch(query: string, artistName: string | null | undefined) {
+  const normalizedQuery = normalizeSearchText(query);
+  const normalizedArtist = normalizeSearchText(artistName);
+
+  if (!normalizedQuery || !normalizedArtist) return false;
+  if (normalizedArtist === normalizedQuery) return true;
+
+  return normalizedQuery.length >= 4 && normalizedArtist.startsWith(normalizedQuery);
+}
+
+export function rankKocteauTrackSearchResults({
+  query,
+  candidates,
+  limit = 24,
+}: {
+  query: string;
+  candidates: KocteauTrackSearchCandidate[];
+  limit?: number;
+}): KocteauTrackSearchResult[] {
+  const deduped = new Map<string, KocteauTrackSearchCandidate>();
+
+  for (const candidate of candidates) {
+    const key = getCandidateIdentity(candidate);
+    const existing = deduped.get(key);
+
+    deduped.set(key, existing ? mergeDuplicateCandidate(existing, candidate) : candidate);
+  }
+
+  return Array.from(deduped.values())
+    .map((candidate) => ({
+      ...candidate,
+      score: getKocteauSearchScore(query, candidate),
+      source_label: sourceLabel[candidate.source],
+    }))
+    .sort((a, b) => {
+      if (b.score !== a.score) return b.score - a.score;
+      if (getSourcePriority(b.source) !== getSourcePriority(a.source)) {
+        return getSourcePriority(b.source) - getSourcePriority(a.source);
+      }
+
+      return (a.source_index ?? Number.MAX_SAFE_INTEGER) - (b.source_index ?? Number.MAX_SAFE_INTEGER);
+    })
+    .slice(0, limit);
+}

--- a/apps/web/queries/tracks.ts
+++ b/apps/web/queries/tracks.ts
@@ -48,6 +48,12 @@ export type DeezerSearchResult = {
   entity_id?: string | null;
 };
 
+export type KocteauSearchResult = DeezerSearchResult & {
+  source?: "local" | "starter" | "artist-match" | "deezer";
+  source_label?: string;
+  score?: number;
+};
+
 export const trackKeys = {
   all: ["tracks"] as const,
   detailPrefix: () => ["tracks", "detail"] as const,
@@ -55,6 +61,8 @@ export const trackKeys = {
   detail: (trackId: string) => ["tracks", "detail", trackId] as const,
   search: (type: SearchEntityType, query: string) =>
     ["tracks", "search", type, query] as const,
+  kocteauSearch: (type: SearchEntityType, query: string) =>
+    ["tracks", "kocteau-search", type, query] as const,
 };
 
 export function recentTracksQueryOptions(limit = 12) {
@@ -91,6 +99,30 @@ export function deezerTrackSearchQueryOptions(
     queryFn: async () => {
       const payload = await fetchJson<DeezerSearchResult[]>(
         `/api/deezer/search?${params.toString()}`,
+      );
+
+      return Array.isArray(payload) ? payload : [];
+    },
+    staleTime: 60_000,
+    gcTime: 10 * 60_000,
+    placeholderData: keepPreviousData,
+  });
+}
+
+export function kocteauTrackSearchQueryOptions(
+  query: string,
+  type: SearchEntityType = "track",
+) {
+  const params = new URLSearchParams({
+    q: query,
+    type,
+  });
+
+  return queryOptions({
+    queryKey: trackKeys.kocteauSearch(type, query),
+    queryFn: async () => {
+      const payload = await fetchJson<KocteauSearchResult[]>(
+        `/api/search?${params.toString()}`,
       );
 
       return Array.isArray(payload) ? payload : [];

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -51,7 +51,7 @@ These are the next useful moves after enabling public contribution.
 | P0 | Review and merge the Release Please PR if the generated changelog is accurate. | ready | `chore`, `area:ci` |
 | P0 | Confirm the `v0.2.0` tag and GitHub Release are created after the release PR merges. | ready | `chore`, `area:ci` |
 | P0 | Pin the public repository description, topics, website URL, and social preview image in GitHub settings. | ready | `docs`, `area:docs` |
-| P0 | Make recommendations visible on track pages so new visitors can see "what to hear next." | needs design | `feature`, `area:web`, `area:recommendations` |
+| P0 | Make recommendations visible on track pages so new visitors can see "what to hear next." | done | `feature`, `area:web`, `area:recommendations` |
 | P0 | Fix desktop scroll dead zones so the page still scrolls when the pointer is over the secondary rail or empty desktop space. | ready | `fix`, `area:web`, `area:ui` |
 | P0 | Make review cards open their review detail route without breaking like, save, or comment actions. | done | `feature`, `area:web`, `area:ui` |
 | P0 | Fix mobile toast placement so feedback is centered and clears the bottom navigation. | ready | `fix`, `area:web`, `area:ui` |
@@ -63,7 +63,7 @@ These are the next useful moves after enabling public contribution.
 | P1 | Add a mobile social discovery carousel near review detail pages. | needs design | `feature`, `area:web`, `area:ui` |
 | P1 | Design a listener-facing candidate finder for similar songs that feels curated rather than chart-driven. | needs design | `feature`, `area:web`, `area:recommendations` |
 | P1 | Explore a compact feed view for scanning more reviews without replacing the editorial default. | needs design | `feature`, `area:web`, `area:ui` |
-| P2 | Design Kocteau-first search across tracks, artists, albums, users, and categories. | needs maintainer decision | `feature`, `area:web`, `area:search`, `area:recommendations` |
+| P2 | Expand Kocteau-first search to artists, albums, users, and categories. | needs design | `feature`, `area:web`, `area:search`, `area:recommendations` |
 | P1 | Keep branch protection advisory until the first public PRs prove the flow. | needs maintainer decision | `chore`, `area:ci` |
 | P2 | Enable `Verify` as a required status check after 1-2 stable contribution weeks. | needs maintainer decision | `chore`, `area:ci` |
 
@@ -237,38 +237,35 @@ Acceptance criteria:
 
 Suggested issue: `feat(search): add Kocteau-first unified search`
 
-State: `needs maintainer decision`. The current search relies on Deezer track ranking, which can surface trend-biased false positives such as a song titled like an artist before the intended artist.
+State: `partial done`. Track search now goes through a Kocteau-first API that merges local entities, starter picks, Deezer artist matches, and Deezer track fallback before ranking results. The current implementation fixes trend-biased false positives such as a song titled like an artist before the intended artist.
 
-- Create a unified search path that can return tracks, artists, albums, users, and category/tag matches.
-- Prefer Kocteau-known objects before external fallback:
-  - profiles
-  - local entities
-  - reviewed tracks
-  - starter picks
-  - Deezer tracks, artists, and albums
-- Add a small intent re-ranker before showing results:
-  - exact artist match should outrank a title-only match
-  - exact title or album match should outrank fuzzy popularity
-  - starts-with and full-word matches should outrank partial substring matches
-  - Deezer popularity/rank should be a tie-breaker, not the primary product decision
-- Activate the existing disabled tabs only when they return real data.
-- Add category search later through Kocteau tags, such as genres, moods, scenes, eras, and formats.
+- Done in V1:
+  - `/api/search` returns track results from local entities, starter picks, Deezer artist-top tracks, and Deezer track fallback.
+  - Exact artist intent outranks unrelated title-only matches.
+  - Local Kocteau results and starter picks receive source labels in the shared result UI.
+  - Deezer rank is only a tie-breaker after Kocteau and intent signals.
+  - Deezer failures can still return Kocteau fallback results when local data exists.
+- Still needed for V2:
+  - Return profiles, artists, albums, and category/tag matches.
+  - Group results into `Best match`, `Artists`, `Tracks`, `Albums`, `Users`, and eventually `Categories`.
+  - Activate the existing disabled tabs only when they return real data.
+  - Add category search through Kocteau tags, such as genres, moods, scenes, eras, and formats.
 
-Suggested labels: `feature`, `area:web`, `area:search`, `area:recommendations`, `needs maintainer decision`
+Suggested labels: `feature`, `area:web`, `area:search`, `area:recommendations`
 
 Acceptance criteria:
 
-- Searching `The Cure` prioritizes the artist or tracks by the artist before unrelated title-only matches.
-- Search results can be grouped into `Best match`, `Artists`, `Tracks`, `Albums`, `Users`, and eventually `Categories`.
-- Search still supports review creation without forcing auth just to browse.
+- Searching `The Cure` prioritizes tracks by the artist before unrelated title-only matches.
+- Search still supports public browsing without forcing auth.
+- Review creation and Starter Studio keep using raw Deezer search where curator/source fidelity matters.
 - Local Kocteau results and Deezer fallback are clearly typed and can share one UI surface.
-- The ranking rules are documented enough for contributors to add tests.
+- The ranking rules are covered by tests so contributors can extend them safely.
 
 ### Track Page Recommendations V0
 
 Suggested issue: `feat(web): add more-to-hear recommendations on track pages`
 
-State: `needs design`. This is the highest-impact response to feedback that Kocteau's recommendations are not visible enough at first glance.
+State: `done`. This was implemented as a first visible recommendation layer on track pages.
 
 - Add a `More to hear` module on `/track/[id]` and `/track/deezer/[providerId]`.
 - Start with readable sources before heavier recommendation logic:

--- a/docs/web-roadmap.md
+++ b/docs/web-roadmap.md
@@ -223,13 +223,13 @@ In progress. For You and recommendation v2 are live. The next job is measurement
   - top rated this week
   - recently active tracks
 - Rework search so it transitions naturally into discovery and review creation.
-- Make search Kocteau-first before Deezer-first:
+- Extend the first Kocteau-first search layer beyond tracks:
   - local users
   - local entities
   - reviewed tracks
   - starter picks
   - Deezer fallback
-- Re-rank external search results by listener intent so exact artist, album, and track matches beat unrelated trend-biased matches.
+- Keep the V1 re-ranker covered by tests so exact artist, album, and track matches beat unrelated trend-biased matches.
 - Use analytics events to tune the feed:
   - For You loads
   - actions per loaded review


### PR DESCRIPTION
## What changed

Added a Kocteau-first `/api/search` path for track search that merges local entities, starter picks, Deezer artist matches, and Deezer fallback results before ranking.

## Why

Raw Deezer ranking can surface trend-biased false positives, like a song titled “the cure” before tracks by The Cure. Kocteau should prioritize listener intent and local/editorial context first.

## Testing

- [x] Ran `pnpm check`
- [ ] Added screenshots or a short recording for visible web UI changes
- [ ] Confirmed this does not touch auth, Supabase, recommendations, analytics, CI, or release behavior

Also ran:
- `node --experimental-strip-types --test lib\search\kocteau-first.test.ts`
- `pnpm --filter web lint`
- `pnpm --filter web build`
- API/UI smoke for `/search?q=the+cure`

Note: this touches Supabase read queries and search behavior, but no DB migration or SQL is needed.

## Changelog impact

No manual `CHANGELOG.md` edit is required. Release Please generates release notes from PR titles and squash commits.

- [x] User-facing web change
- [x] Developer experience or documentation change
- [ ] Internal-only change