### PR TITLE
fix(web): harden Deezer search resilience

### DIFF
--- a/apps/web/app/api/deezer/search/route.ts
+++ b/apps/web/app/api/deezer/search/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { DeezerRequestError, searchDeezerTracks } from "@/lib/deezer";
+import { getDeezerErrorDetails, searchDeezerTracks } from "@/lib/deezer";
 import { supabasePublic } from "@/lib/supabase/public";
 import { deezerSearchQuerySchema } from "@/lib/validation/schemas";
 import { validationErrorResponse } from "@/lib/validation/server";
@@ -60,8 +60,7 @@ export async function GET(req: Request) {
     console.error("[deezer.search] failed", {
       type,
       queryLength: q.length,
-      status: error instanceof DeezerRequestError ? error.status : null,
-      message: error instanceof Error ? error.message : "Unknown Deezer search error",
+      ...getDeezerErrorDetails(error),
     });
 
     return NextResponse.json(

--- a/apps/web/app/api/search/route.ts
+++ b/apps/web/app/api/search/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import {
-  DeezerRequestError,
   getDeezerArtistTopTracks,
+  getDeezerErrorDetails,
   searchDeezerArtists,
   searchDeezerTracks,
   type DeezerTrackResult,
@@ -358,8 +358,7 @@ export async function GET(req: Request) {
     console.error("[search.deezer] failed with no fallback", {
       type,
       queryLength: q.length,
-      status: firstError instanceof DeezerRequestError ? firstError.status : null,
-      message: firstError instanceof Error ? firstError.message : "Unknown Deezer search error",
+      ...getDeezerErrorDetails(firstError),
     });
 
     return NextResponse.json(

--- a/apps/web/components/starter-studio-client.tsx
+++ b/apps/web/components/starter-studio-client.tsx
@@ -264,6 +264,7 @@ export default function StarterStudioClient() {
     data: searchResults,
     isFetching: searchFetching,
     error: searchError,
+    refetch: retrySearch,
   } = useDeezerSearch({
     query,
     type: "track",
@@ -1782,9 +1783,24 @@ export default function StarterStudioClient() {
 
             <div className="space-y-2">
               {searchError ? (
-                <p className="rounded-lg border border-destructive/34 bg-destructive/10 px-3 py-2 text-sm text-destructive">
-                  {searchError.message}
-                </p>
+                <div className="flex items-center justify-between gap-3 rounded-lg border border-border/28 bg-card/18 px-3 py-2 text-sm text-muted-foreground">
+                  <span className="min-w-0">
+                    {searchError.message ||
+                      "Music search is taking longer than usual. Try again in a moment."}
+                  </span>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    disabled={searchFetching}
+                    onClick={() => {
+                      void retrySearch();
+                    }}
+                    className="h-7 shrink-0 rounded-full px-2.5 text-[11px]"
+                  >
+                    {searchFetching ? "Retrying" : "Retry"}
+                  </Button>
+                </div>
               ) : null}
 
               {normalizedQuery.length < 2 ? (

--- a/apps/web/lib/deezer.test.ts
+++ b/apps/web/lib/deezer.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  DeezerRequestError,
+  getDeezerErrorDetails,
+  getDeezerTrack,
+  searchDeezerTracks,
+} from "./deezer.ts";
+
+const originalFetch = globalThis.fetch;
+
+function jsonResponse(payload: unknown, status = 200) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: {
+      "content-type": "application/json",
+    },
+  });
+}
+
+test.afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+test("Deezer track search retries transient upstream failures", async () => {
+  let fetchCount = 0;
+
+  globalThis.fetch = (async () => {
+    fetchCount += 1;
+
+    if (fetchCount === 1) {
+      return jsonResponse({ error: { message: "temporary" } }, 502);
+    }
+
+    return jsonResponse({
+      data: [
+        {
+          id: 123,
+          title: "Alison",
+          link: "https://www.deezer.com/track/123",
+          rank: 120000,
+          artist: {
+            id: 45,
+            name: "Slowdive",
+            nb_fan: 42000,
+          },
+          album: {
+            cover_medium: "https://example.com/cover.jpg",
+          },
+        },
+      ],
+    });
+  }) as typeof fetch;
+
+  const results = await searchDeezerTracks("slowdive", 1);
+
+  assert.equal(fetchCount, 2);
+  assert.equal(results[0]?.provider_id, "123");
+  assert.equal(results[0]?.title, "Alison");
+  assert.equal(results[0]?.artist_name, "Slowdive");
+});
+
+test("Deezer track lookup degrades to null when the upstream request fails", async () => {
+  globalThis.fetch = (async () => {
+    throw new TypeError("network unavailable");
+  }) as typeof fetch;
+
+  const result = await getDeezerTrack("123");
+
+  assert.equal(result, null);
+});
+
+test("Deezer error log details keep only safe operational context", () => {
+  const details = getDeezerErrorDetails(
+    new DeezerRequestError("Deezer search request failed", 502),
+  );
+
+  assert.deepEqual(details, {
+    status: 502,
+    message: "Deezer search request failed",
+  });
+});

--- a/apps/web/lib/deezer.ts
+++ b/apps/web/lib/deezer.ts
@@ -47,6 +47,7 @@ type DeezerTrackApiItem = {
 
 type DeezerSearchResponse = {
   data?: DeezerTrackApiItem[];
+  error?: unknown;
 };
 
 type DeezerArtistApiItem = {
@@ -60,6 +61,7 @@ type DeezerArtistApiItem = {
 
 type DeezerArtistSearchResponse = {
   data?: DeezerArtistApiItem[];
+  error?: unknown;
 };
 
 type DeezerRelatedArtistsResponse = {
@@ -96,6 +98,7 @@ type DeezerTrackMapOptions = {
 
 const deezerRequestTimeoutMs = 8_000;
 const deezerSearchRetryDelaysMs = [250, 700] as const;
+const deezerResourceRetryDelaysMs = [300] as const;
 
 type DeezerFetchOptions = {
   errorMessage: string;
@@ -105,16 +108,37 @@ type DeezerFetchOptions = {
 
 export class DeezerRequestError extends Error {
   status: number | null;
+  cause?: unknown;
 
-  constructor(message: string, status: number | null = null) {
+  constructor(message: string, status: number | null = null, cause?: unknown) {
     super(message);
     this.name = "DeezerRequestError";
     this.status = status;
+    this.cause = cause;
   }
 }
 
 function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function shouldRetryDeezerError(error: unknown) {
+  if (error instanceof DeezerRequestError && error.status !== null) {
+    return error.status === 429 || error.status >= 500;
+  }
+
+  return true;
+}
+
+function hasDeezerApiError(payload: { error?: unknown }) {
+  return Object.prototype.hasOwnProperty.call(payload, "error");
+}
+
+export function getDeezerErrorDetails(error: unknown) {
+  return {
+    status: error instanceof DeezerRequestError ? error.status : null,
+    message: error instanceof Error ? error.message : "Unknown Deezer error",
+  };
 }
 
 async function fetchDeezerJson<T>(
@@ -146,7 +170,7 @@ async function fetchDeezerJson<T>(
     } catch (error) {
       lastError = error;
 
-      if (attempt >= retryDelays.length) {
+      if (attempt >= retryDelays.length || !shouldRetryDeezerError(error)) {
         break;
       }
 
@@ -157,10 +181,36 @@ async function fetchDeezerJson<T>(
   }
 
   if (lastError instanceof Error) {
-    throw lastError;
+    if (lastError instanceof DeezerRequestError) {
+      throw lastError;
+    }
+
+    throw new DeezerRequestError(errorMessage, null, lastError);
   }
 
   throw new DeezerRequestError(errorMessage);
+}
+
+async function fetchOptionalDeezerJson<T extends { error?: unknown }>(
+  url: string,
+  {
+    errorMessage,
+    revalidate,
+    scope,
+  }: DeezerFetchOptions & { scope: string },
+): Promise<T | null> {
+  try {
+    const json = await fetchDeezerJson<T>(url, {
+      errorMessage,
+      revalidate,
+      retryDelays: deezerResourceRetryDelaysMs,
+    });
+
+    return hasDeezerApiError(json) ? null : json;
+  } catch (error) {
+    console.warn(`[deezer.${scope}] unavailable`, getDeezerErrorDetails(error));
+    return null;
+  }
 }
 
 function getOptionalNumber(value: number | null | undefined) {
@@ -194,6 +244,10 @@ export async function searchDeezerTracks(query: string, limit = 12): Promise<Dee
     retryDelays: deezerSearchRetryDelaysMs,
   });
 
+  if (hasDeezerApiError(json)) {
+    throw new DeezerRequestError("Deezer search request failed");
+  }
+
   return (json.data ?? []).map((item) => mapDeezerTrack(item));
 }
 
@@ -223,6 +277,10 @@ export async function searchDeezerArtists(
     retryDelays: deezerSearchRetryDelaysMs,
   });
 
+  if (hasDeezerApiError(json)) {
+    throw new DeezerRequestError("Deezer artist request failed");
+  }
+
   return (json.data ?? []).flatMap((item) => {
     const artist = mapDeezerArtist(item);
     return artist ? [artist] : [];
@@ -249,19 +307,16 @@ export async function getDeezerRelatedArtists(
   limit = 8,
 ): Promise<DeezerArtistResult[]> {
   const url = `https://api.deezer.com/artist/${encodeURIComponent(artistId)}/related?limit=${limit}`;
-  const response = await fetch(url, {
-    next: { revalidate: 300 },
-  });
+  const json = await fetchOptionalDeezerJson<DeezerRelatedArtistsResponse & { error?: unknown }>(
+    url,
+    {
+      errorMessage: "Deezer related artists request failed",
+      revalidate: 300,
+      scope: "related_artists",
+    },
+  );
 
-  if (!response.ok) {
-    return [];
-  }
-
-  const json = (await response.json()) as DeezerRelatedArtistsResponse & {
-    error?: unknown;
-  };
-
-  if ("error" in json) {
+  if (!json) {
     return [];
   }
 
@@ -276,19 +331,16 @@ export async function getDeezerArtistAlbums(
   limit = 8,
 ): Promise<DeezerAlbumResult[]> {
   const url = `https://api.deezer.com/artist/${encodeURIComponent(artistId)}/albums?limit=${limit}`;
-  const response = await fetch(url, {
-    next: { revalidate: 300 },
-  });
+  const json = await fetchOptionalDeezerJson<DeezerArtistAlbumsResponse & { error?: unknown }>(
+    url,
+    {
+      errorMessage: "Deezer artist albums request failed",
+      revalidate: 300,
+      scope: "artist_albums",
+    },
+  );
 
-  if (!response.ok) {
-    return [];
-  }
-
-  const json = (await response.json()) as DeezerArtistAlbumsResponse & {
-    error?: unknown;
-  };
-
-  if ("error" in json) {
+  if (!json) {
     return [];
   }
 
@@ -303,19 +355,16 @@ export async function getDeezerArtistTopTracks(
   limit = 6,
 ): Promise<DeezerTrackResult[]> {
   const url = `https://api.deezer.com/artist/${encodeURIComponent(artist.id)}/top?limit=${limit}`;
-  const response = await fetch(url, {
-    next: { revalidate: 300 },
-  });
+  const json = await fetchOptionalDeezerJson<DeezerArtistTopTracksResponse & { error?: unknown }>(
+    url,
+    {
+      errorMessage: "Deezer artist top tracks request failed",
+      revalidate: 300,
+      scope: "artist_top_tracks",
+    },
+  );
 
-  if (!response.ok) {
-    return [];
-  }
-
-  const json = (await response.json()) as DeezerArtistTopTracksResponse & {
-    error?: unknown;
-  };
-
-  if ("error" in json) {
+  if (!json) {
     return [];
   }
 
@@ -333,19 +382,16 @@ export async function getDeezerAlbumTracks(
   limit = 12,
 ): Promise<DeezerTrackResult[]> {
   const url = `https://api.deezer.com/album/${encodeURIComponent(album.id)}/tracks?limit=${limit}`;
-  const response = await fetch(url, {
-    next: { revalidate: 300 },
-  });
+  const json = await fetchOptionalDeezerJson<DeezerAlbumTracksResponse & { error?: unknown }>(
+    url,
+    {
+      errorMessage: "Deezer album tracks request failed",
+      revalidate: 300,
+      scope: "album_tracks",
+    },
+  );
 
-  if (!response.ok) {
-    return [];
-  }
-
-  const json = (await response.json()) as DeezerAlbumTracksResponse & {
-    error?: unknown;
-  };
-
-  if ("error" in json) {
+  if (!json) {
     return [];
   }
 
@@ -361,17 +407,16 @@ export async function getDeezerAlbumTracks(
 
 export async function getDeezerTrack(providerId: string): Promise<DeezerTrackResult | null> {
   const url = `https://api.deezer.com/track/${encodeURIComponent(providerId)}`;
-  const response = await fetch(url, {
-    next: { revalidate: 300 },
-  });
+  const json = await fetchOptionalDeezerJson<DeezerTrackApiItem & { error?: unknown }>(
+    url,
+    {
+      errorMessage: "Deezer track request failed",
+      revalidate: 300,
+      scope: "track",
+    },
+  );
 
-  if (!response.ok) {
-    return null;
-  }
-
-  const json = (await response.json()) as DeezerTrackApiItem & { error?: unknown };
-
-  if ("error" in json || !json.id || !json.title) {
+  if (!json || !json.id || !json.title) {
     return null;
   }
 

--- a/apps/web/lib/queries/track-recommendations.ts
+++ b/apps/web/lib/queries/track-recommendations.ts
@@ -4,7 +4,11 @@ import {
   getCandidateSourceTracks,
   type DeezerCandidateSeedArtist,
 } from "@/lib/deezer-candidate-source";
-import { getDeezerTrack, type DeezerTrackResult } from "@/lib/deezer";
+import {
+  getDeezerErrorDetails,
+  getDeezerTrack,
+  type DeezerTrackResult,
+} from "@/lib/deezer";
 import { measureServerTask } from "@/lib/perf";
 import { getPublicStarterTracks } from "@/lib/queries/starter";
 import type { EntityTasteTag } from "@/lib/queries/entities";
@@ -368,6 +372,13 @@ export async function getTrackRecommendations({
             query: seedLabel,
             limit: requestedLimit,
             seedArtist,
+          }).catch((error) => {
+            console.warn("[track-recommendations.deezer] using editorial fallback", {
+              currentProviderId,
+              ...getDeezerErrorDetails(error),
+            });
+
+            return [];
           }),
           getEditorialFallbackCandidates({
             currentEntityId,

--- a/apps/web/queries/http.ts
+++ b/apps/web/queries/http.ts
@@ -1,3 +1,20 @@
+export class FetchJsonError extends Error {
+  status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "FetchJsonError";
+    this.status = status;
+  }
+}
+
+export function isRetryableFetchJsonError(error: unknown) {
+  return (
+    error instanceof FetchJsonError &&
+    (error.status === 408 || error.status === 429 || error.status >= 500)
+  );
+}
+
 export async function fetchJson<T>(input: string, init?: RequestInit) {
   const response = await fetch(input, {
     cache: "no-store",
@@ -19,10 +36,11 @@ export async function fetchJson<T>(input: string, init?: RequestInit) {
         ? payload.error
         : null;
 
-    throw new Error(
+    throw new FetchJsonError(
       typeof fallbackMessage === "string" && fallbackMessage
         ? fallbackMessage
         : "We couldn't load that data right now.",
+      response.status,
     );
   }
 

--- a/apps/web/queries/tracks.ts
+++ b/apps/web/queries/tracks.ts
@@ -3,7 +3,7 @@ import { keepPreviousData, queryOptions } from "@tanstack/react-query";
 import type { ReviewCardAuthor, ReviewCardData } from "@/components/review-card";
 import type { DiscoveryTrack } from "@/lib/types/discovery";
 import type { SearchEntityType } from "@/lib/search-types";
-import { fetchJson } from "@/queries/http";
+import { fetchJson, isRetryableFetchJsonError } from "@/queries/http";
 
 export type TrackEntity = {
   id: string;
@@ -106,6 +106,8 @@ export function deezerTrackSearchQueryOptions(
     staleTime: 60_000,
     gcTime: 10 * 60_000,
     placeholderData: keepPreviousData,
+    retry: (failureCount, error) =>
+      failureCount < 1 && isRetryableFetchJsonError(error),
   });
 }
 
@@ -130,6 +132,8 @@ export function kocteauTrackSearchQueryOptions(
     staleTime: 60_000,
     gcTime: 10 * 60_000,
     placeholderData: keepPreviousData,
+    retry: (failureCount, error) =>
+      failureCount < 1 && isRetryableFetchJsonError(error),
   });
 }
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -55,7 +55,7 @@ These are the next useful moves after enabling public contribution.
 | P0 | Fix desktop scroll dead zones so the page still scrolls when the pointer is over the secondary rail or empty desktop space. | done | `fix`, `area:web`, `area:ui` |
 | P0 | Make review cards open their review detail route without breaking like, save, or comment actions. | done | `feature`, `area:web`, `area:ui` |
 | P0 | Fix mobile toast placement so feedback is centered and clears the bottom navigation. | ready | `fix`, `area:web`, `area:ui` |
-| P1 | Harden Deezer-backed search with retry, clearer empty/error copy, and non-blocking fallbacks. | ready | `fix`, `area:web`, `area:search` |
+| P1 | Harden Deezer-backed search with retry, clearer empty/error copy, and non-blocking fallbacks. | done | `fix`, `area:web`, `area:search` |
 | P1 | Open 6-10 curated GitHub issues from this backlog before broader public sharing. | ready | `docs`, `help wanted` |
 | P1 | Add a short "first contribution path" section to the README with links to good first issues. | ready | `docs`, `area:docs`, `good first issue` |
 | P1 | Open discovery and curation issues from `docs/discovery-curation.md` with clear owner lanes. | ready | `docs`, `area:recommendations`, `needs maintainer decision` |
@@ -437,7 +437,7 @@ Acceptance criteria:
 
 Suggested issue: `fix(web): harden Deezer search fallbacks and error copy`
 
-State: `ready`. Deezer-backed search can work most of the time and still feel broken to a first-time visitor if one request returns `Deezer request failed`.
+State: `done`. Deezer-backed search can work most of the time and still feel broken to a first-time visitor if one request returns `Deezer request failed`.
 
 - Add a small retry or retry-after strategy for transient Deezer failures.
 - Keep stale previous results visible while a new query is updating when possible.


### PR DESCRIPTION
## What changed

Hardened Deezer-backed search and recommendation fallbacks so transient Deezer failures do not make Kocteau feel broken.

## Why

A first-time visitor reported intermittent `Deezer request failed` behavior. Search, review creation, Studio curation, and track recommendations should keep calm retry/fallback behavior when Deezer is slow or unavailable.

## Testing

- [x] Ran `pnpm check`
- [ ] Added screenshots or a short recording for visible web UI changes
- [ ] Confirmed this does not touch auth, Supabase, recommendations, analytics, CI, or release behavior

## Changelog impact

- [x] User-facing web change
- [ ] Developer experience or documentation change
- [ ] Internal-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added retry functionality for Deezer searches with a dedicated retry button when searches fail.

* **Bug Fixes**
  * Improved error handling with automatic retries for transient API failures.
  * Enhanced error message display in search results with a cleaner card interface.

* **Documentation**
  * Updated project backlog to reflect completion of Deezer search resilience work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->