### PR TITLE
feat(web): polish onboarding core experience

### DIFF
--- a/apps/web/app/(auth)/onboarding-preview/page.tsx
+++ b/apps/web/app/(auth)/onboarding-preview/page.tsx
@@ -1,5 +1,5 @@
-import { OnboardingFlowPreview } from "@/components/auth/onboarding-flow-preview";
 import ReactQueryProvider from "@/app/providers/react-query-provider";
+import { OnboardingPreviewSwitcher } from "@/components/auth/onboarding-preview-switcher";
 import { createPageMetadata } from "@/lib/metadata";
 
 export const metadata = createPageMetadata({
@@ -12,7 +12,7 @@ export const metadata = createPageMetadata({
 export default function OnboardingPreviewPage() {
   return (
     <ReactQueryProvider>
-      <OnboardingFlowPreview />
+      <OnboardingPreviewSwitcher />
     </ReactQueryProvider>
   );
 }

--- a/apps/web/components/auth/onboarding-flow-preview.tsx
+++ b/apps/web/components/auth/onboarding-flow-preview.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import Image from "next/image";
-import Link from "next/link";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { ArrowLeft, ArrowRight, Check, Disc3 } from "@/components/ui/icons";
 import { useEffect, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
+import { OnboardingProgressBar } from "@/components/auth/onboarding-progress-bar";
 import { PrimaryGrowButton } from "@/components/ui/grow-button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -39,8 +39,7 @@ type PreviewStep = {
     | "bio"
     | "signals"
     | "rooms"
-    | "track"
-    | "finish";
+    | "track";
   section: "Profile" | "Taste" | "Review";
   question: string;
   helper?: string;
@@ -63,7 +62,7 @@ const steps = [
     id: "avatar",
     section: "Profile",
     question: "Choose a profile image.",
-    helper: "Use a photo or a Kocteau disc.",
+    helper: "Pick a disc, or upload a photo.",
   },
   {
     id: "bio",
@@ -87,13 +86,7 @@ const steps = [
     id: "track",
     section: "Review",
     question: "Start with a track to review.",
-    helper: "Review now, or skip and start with your feed.",
-  },
-  {
-    id: "finish",
-    section: "Review",
-    question: "Your For You feed starts here.",
-    helper: "A final check before this becomes the real onboarding flow.",
+    helper: "Review now, or start using Kocteau.",
   },
 ] as const satisfies PreviewStep[];
 
@@ -155,6 +148,11 @@ const initialDraft: PreviewDraft = {
   starterTrack: null,
 };
 
+const previewFocusVisibleClass =
+  "focus-visible:border-white/42 focus-visible:ring-0 focus-visible:shadow-none";
+const previewFocusWithinClass =
+  "focus-within:border-white/42 focus-within:ring-0 focus-within:shadow-none";
+
 function normalizeUsername(value: string) {
   return value
     .toLowerCase()
@@ -192,6 +190,7 @@ export function OnboardingFlowPreview() {
 
   const stepError = getStepError(currentStep.id, draft);
   const showStepError = attemptedStepId === currentStep.id && Boolean(stepError);
+  const canGoBack = currentStepIndex > 0;
   const isLastStep = currentStepIndex === steps.length - 1;
 
   function updateDraft(nextDraft: Partial<PreviewDraft>) {
@@ -233,30 +232,12 @@ export function OnboardingFlowPreview() {
   }
 
   return (
-    <main className="flex h-svh overflow-hidden flex-col bg-background text-foreground">
-      <header className="mx-auto flex w-full max-w-[32rem] shrink-0 flex-col gap-3 px-5 pt-4 sm:px-8 sm:pt-6">
+    <main className="relative isolate flex h-svh overflow-hidden flex-col bg-background text-foreground">
+      <OnboardingProgressBar value={progress} />
+      <header className="relative z-10 mx-auto flex w-full max-w-[31rem] shrink-0 flex-col px-5 pt-5 sm:px-8 sm:pt-6">
         <div className="flex justify-center">
-          <Link
-            href="/"
-            className="inline-flex h-8 w-8 items-center justify-center text-foreground transition-[opacity,transform] duration-150 ease-out hover:opacity-80 active:scale-[0.96] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
-            aria-label="Go to Kocteau home"
-          >
+          <div className="inline-flex h-8 w-8 items-center justify-center text-foreground">
             <BrandLogo priority iconClassName="h-[1.35rem] w-[1.35rem]" />
-          </Link>
-        </div>
-
-        <div className="space-y-3">
-          <div className="flex items-end justify-between gap-4 text-sm">
-            <span className="font-medium text-foreground">{currentStep.section}</span>
-            <span className="tabular-nums text-muted-foreground">
-              {currentStepIndex + 1} / {steps.length}
-            </span>
-          </div>
-          <div className="h-px overflow-hidden bg-border/45" aria-hidden="true">
-            <div
-              className="h-full bg-foreground transition-[width] duration-200 ease-out"
-              style={{ width: `${progress}%` }}
-            />
           </div>
         </div>
       </header>
@@ -266,7 +247,7 @@ export function OnboardingFlowPreview() {
         onSubmit={goNext}
         className="grid min-h-0 flex-1 grid-rows-[minmax(0,1fr)_auto]"
       >
-        <section className="flex min-h-0 items-center justify-center px-5 py-3 sm:px-8 sm:py-5">
+        <section className="flex min-h-0 items-center justify-center px-5 py-2 sm:px-8 sm:py-3">
           <AnimatePresence mode="wait" initial={false}>
             <motion.div
               key={currentStep.id}
@@ -274,7 +255,7 @@ export function OnboardingFlowPreview() {
               animate={prefersReducedMotion ? undefined : { opacity: 1, y: 0 }}
               exit={prefersReducedMotion ? undefined : { opacity: 0, y: -6 }}
               transition={{ duration: 0.18, ease: "easeOut" }}
-              className="flex h-full max-h-[32rem] min-h-[25rem] w-full max-w-[32rem] flex-col justify-center gap-3"
+              className="flex h-full min-h-0 w-full max-w-[32rem] flex-col justify-center gap-3"
             >
               <div className="mx-auto max-w-[24rem] space-y-1.5 text-center">
                 <h1 className="text-balance font-heading text-[1.55rem] font-bold leading-tight tracking-tight text-foreground sm:text-[1.65rem]">
@@ -298,18 +279,21 @@ export function OnboardingFlowPreview() {
           </AnimatePresence>
         </section>
 
-        <footer className="mx-auto flex h-28 w-full max-w-[32rem] shrink-0 items-center justify-between gap-4 px-5 pb-14 sm:h-20 sm:px-8 sm:pb-7">
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-lg"
-            onClick={goBack}
-            disabled={currentStepIndex === 0}
-            aria-label="Go back"
-            className="size-10 rounded-full bg-foreground/[0.04] text-muted-foreground transition-[background-color,color,transform] duration-150 ease-out hover:bg-foreground/[0.08] hover:text-foreground active:scale-[0.96]"
-          >
-            <ArrowLeft className="size-4" />
-          </Button>
+        <footer className="mx-auto flex h-[4.75rem] w-full max-w-[32rem] shrink-0 items-center justify-between gap-4 pb-5 pl-5 pr-[5.5rem] sm:h-[4.5rem] sm:px-8 sm:pb-5">
+          {canGoBack ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-lg"
+              onClick={goBack}
+              aria-label="Go back"
+              className="size-10 rounded-full bg-foreground/[0.04] text-muted-foreground transition-[background-color,color,transform] duration-150 ease-out hover:bg-foreground/[0.08] hover:text-foreground active:scale-[0.96]"
+            >
+              <ArrowLeft className="size-4" />
+            </Button>
+          ) : (
+            <div className="size-10" aria-hidden="true" />
+          )}
 
           <div className="min-w-0 flex-1" aria-hidden="true" />
 
@@ -318,7 +302,7 @@ export function OnboardingFlowPreview() {
             size="lg"
             className="h-10 min-w-[8.75rem] rounded-full px-5 text-sm transition-[background-color,color,transform] duration-150 ease-out active:scale-[0.96]"
           >
-            {isLastStep ? "Finish preview" : currentStep.id === "track" ? "Skip for now" : "Continue"}
+            {currentStep.id === "track" ? "Start using app" : "Continue"}
             {!isLastStep && currentStep.id !== "track" ? <ArrowRight className="size-4" /> : null}
           </Button>
         </footer>
@@ -372,14 +356,22 @@ function renderStepControl(
         value={draft.displayName}
         onChange={(event) => updateDraft({ displayName: event.target.value })}
         placeholder="Fran Cocteau"
-        className="h-11 w-full rounded-[var(--kocteau-radius-control)] border-0 bg-[var(--kocteau-surface-control)] px-4 text-base shadow-[var(--kocteau-shadow-control)] placeholder:text-muted-foreground/55 focus-visible:ring-2 focus-visible:ring-ring/30"
+        className={cn(
+          "h-11 w-full rounded-[var(--kocteau-radius-control)] border border-transparent bg-[var(--kocteau-surface-control)] px-4 text-base shadow-[var(--kocteau-shadow-control)] placeholder:text-muted-foreground/55",
+          previewFocusVisibleClass,
+        )}
       />
     );
   }
 
   if (stepId === "handle") {
     return (
-      <div className="flex h-11 w-full items-center rounded-[var(--kocteau-radius-control)] bg-[var(--kocteau-surface-control)] px-4 shadow-[var(--kocteau-shadow-control)] focus-within:ring-2 focus-within:ring-ring/30">
+      <div
+        className={cn(
+          "flex h-11 w-full items-center rounded-[var(--kocteau-radius-control)] border border-transparent bg-[var(--kocteau-surface-control)] px-4 shadow-[var(--kocteau-shadow-control)]",
+          previewFocusWithinClass,
+        )}
+      >
         <span className="select-none text-base text-muted-foreground">@</span>
         <input
           autoFocus
@@ -403,7 +395,10 @@ function renderStepControl(
         value={draft.bio}
         onChange={(event) => updateDraft({ bio: event.target.value.slice(0, 180) })}
         placeholder="Dream pop, noisy guitars, late-night pop records."
-        className="min-h-28 w-full resize-none rounded-[var(--kocteau-radius-control)] border-0 bg-[var(--kocteau-surface-control)] p-4 text-base leading-6 shadow-[var(--kocteau-shadow-control)] placeholder:text-muted-foreground/55 focus-visible:ring-2 focus-visible:ring-ring/30"
+        className={cn(
+          "min-h-28 w-full resize-none rounded-[var(--kocteau-radius-control)] border border-transparent bg-[var(--kocteau-surface-control)] p-4 text-base leading-6 shadow-[var(--kocteau-shadow-control)] placeholder:text-muted-foreground/55",
+          previewFocusVisibleClass,
+        )}
       />
     );
   }
@@ -416,7 +411,6 @@ function renderStepControl(
         onToggle={(value) =>
           updateDraft({ signals: toggleLimitedValue(draft.signals, value, 5) })
         }
-        counter={`${draft.signals.length} / 5`}
       />
     );
   }
@@ -429,7 +423,6 @@ function renderStepControl(
         onToggle={(value) =>
           updateDraft({ scenes: toggleLimitedValue(draft.scenes, value, 4) })
         }
-        counter={`${draft.scenes.length} / 4`}
       />
     );
   }
@@ -456,13 +449,13 @@ function renderStepControl(
           onSuccess={() => updateDraft({ starterTrack: starterTracks[0].id })}
         />
         <p className="text-center text-xs leading-4 text-muted-foreground">
-          Optional. You can skip and review later.
+          Create a review now, or continue into your feed.
         </p>
       </div>
     );
   }
 
-  return <PreviewSummary draft={draft} />;
+  return null;
 }
 
 function AvatarStepControl({
@@ -497,7 +490,10 @@ function AvatarStepControl({
       <div className="relative">
         <label
           aria-label="Upload profile image"
-          className="group relative flex size-28 cursor-pointer items-center justify-center rounded-full bg-[var(--kocteau-surface-control)] p-1.5 shadow-[var(--kocteau-shadow-control),0_14px_42px_rgba(0,0,0,0.22)] transition-[box-shadow,transform,background-color] duration-150 ease-out hover:bg-[var(--kocteau-surface-control-hover)] hover:shadow-[var(--kocteau-shadow-card-hover),0_18px_52px_rgba(0,0,0,0.28)] active:scale-[0.96] focus-within:ring-2 focus-within:ring-ring/35"
+          className={cn(
+            "group relative flex size-28 cursor-pointer items-center justify-center rounded-full border border-transparent bg-[var(--kocteau-surface-control)] p-1.5 transition-[background-color,border-color,transform] duration-150 ease-out hover:bg-[var(--kocteau-surface-control-hover)] active:scale-[0.96]",
+            previewFocusWithinClass,
+          )}
         >
           <span className="relative flex size-full items-center justify-center overflow-hidden rounded-full bg-background outline outline-1 outline-white/10">
             <Image
@@ -527,7 +523,8 @@ function AvatarStepControl({
           aria-expanded={isDiscPickerOpen}
           onClick={() => setIsDiscPickerOpen((open) => !open)}
           className={cn(
-            "absolute -right-1 bottom-1 flex size-9 items-center justify-center rounded-full bg-background text-foreground shadow-[0_0_0_3px_var(--background),var(--kocteau-shadow-card-hover)] transition-[background-color,box-shadow,transform] duration-150 ease-out hover:bg-[var(--kocteau-surface-control-hover)] active:scale-[0.96] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/35",
+            "absolute -right-1 bottom-1 flex size-9 items-center justify-center rounded-full border border-transparent bg-background text-foreground ring-4 ring-background transition-[background-color,border-color,transform] duration-150 ease-out hover:bg-[var(--kocteau-surface-control-hover)] active:scale-[0.96] focus-visible:outline-none",
+            previewFocusVisibleClass,
             isDiscPickerOpen && "bg-foreground text-background",
           )}
         >
@@ -567,7 +564,8 @@ function AvatarStepControl({
                       setIsDiscPickerOpen(false);
                     }}
                     className={cn(
-                      "group relative flex aspect-square min-h-[4rem] items-center justify-center rounded-[0.85rem] bg-[var(--kocteau-surface-control)] shadow-[var(--kocteau-shadow-control)] transition-[background-color,box-shadow,transform] duration-150 ease-out hover:bg-[var(--kocteau-surface-control-hover)] active:scale-[0.96] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30",
+                      "group relative flex aspect-square min-h-[4rem] items-center justify-center rounded-[0.85rem] border border-transparent bg-[var(--kocteau-surface-control)] shadow-[var(--kocteau-shadow-control)] transition-[background-color,border-color,box-shadow,transform] duration-150 ease-out hover:bg-[var(--kocteau-surface-control-hover)] active:scale-[0.96] focus-visible:outline-none",
+                      previewFocusVisibleClass,
                       isSelected &&
                         "bg-[var(--kocteau-surface-featured)] shadow-[var(--kocteau-shadow-card-hover)]",
                     )}
@@ -600,19 +598,14 @@ function ChoiceCloud({
   values,
   selectedValues,
   onToggle,
-  counter,
 }: {
   values: string[];
   selectedValues: string[];
   onToggle: (value: string) => void;
-  counter: string;
 }) {
   return (
-    <div className="space-y-3">
-      <div className="flex justify-end text-xs tabular-nums text-muted-foreground">
-        {counter}
-      </div>
-      <div className="flex flex-wrap justify-center gap-1.5 sm:gap-2">
+    <div className="space-y-2.5">
+      <div className="flex flex-wrap justify-center gap-1.5">
         {values.map((value) => {
           const isSelected = selectedValues.includes(value);
 
@@ -623,7 +616,8 @@ function ChoiceCloud({
               aria-pressed={isSelected}
               onClick={() => onToggle(value)}
               className={cn(
-                "min-h-9 rounded-full bg-[var(--kocteau-surface-control)] px-3 text-sm text-muted-foreground shadow-[var(--kocteau-shadow-control)] transition-[background-color,color,box-shadow,transform] duration-150 ease-out hover:bg-[var(--kocteau-surface-control-hover)] hover:text-foreground active:scale-[0.96] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30 sm:min-h-10 sm:px-3.5",
+                "min-h-7 rounded-full border border-transparent bg-[var(--kocteau-surface-control)] px-2.5 text-[12px] font-normal leading-none text-muted-foreground shadow-[var(--kocteau-shadow-control)] transition-[background-color,border-color,color,box-shadow,transform] duration-150 ease-out hover:bg-[var(--kocteau-surface-control-hover)] hover:text-foreground active:scale-[0.96] focus-visible:outline-none",
+                previewFocusVisibleClass,
                 isSelected && "bg-foreground text-background shadow-none hover:bg-foreground hover:text-background",
               )}
             >
@@ -631,64 +625,6 @@ function ChoiceCloud({
             </button>
           );
         })}
-      </div>
-    </div>
-  );
-}
-
-function PreviewSummary({ draft }: { draft: PreviewDraft }) {
-  const selectedTrack =
-    starterTracks.find((track) => track.id === draft.starterTrack) ?? null;
-
-  return (
-    <div className="space-y-4 rounded-[1.15rem] bg-[var(--kocteau-surface-control)] p-4 shadow-[var(--kocteau-shadow-control)]">
-      <div className="flex items-center gap-3">
-        <Image
-          src={
-            draft.uploadedAvatarUrl ??
-            createAvatarPresetDataUrl(draft.avatarPresetId ?? "silver-haze", 180)
-          }
-          alt="Selected profile image"
-          width={64}
-          height={64}
-          unoptimized
-          className="size-14 rounded-full object-cover outline outline-1 outline-white/10"
-        />
-        <div className="min-w-0">
-          <p className="truncate text-sm font-medium text-foreground">
-            {draft.displayName}
-          </p>
-          <p className="truncate text-xs text-muted-foreground">@{draft.username}</p>
-        </div>
-      </div>
-
-      <p className="text-pretty text-sm leading-6 text-muted-foreground">
-        {draft.bio.trim() || "Taste note can come later."}
-      </p>
-
-      <div className="flex flex-wrap gap-1.5">
-        {[...draft.signals, ...draft.scenes].slice(0, 8).map((item) => (
-          <span
-            key={item}
-            className="rounded-full bg-background px-2.5 py-1 text-xs text-muted-foreground"
-          >
-            {item}
-          </span>
-        ))}
-      </div>
-
-      <div className="flex items-center gap-3 rounded-[0.8rem] bg-background p-3">
-        <span className="flex size-9 shrink-0 items-center justify-center rounded-full bg-foreground text-background">
-          <Disc3 className="size-4" />
-        </span>
-        <div className="min-w-0">
-          <p className="truncate text-sm font-medium text-foreground">
-            {selectedTrack ? selectedTrack.title : "First review"}
-          </p>
-          <p className="truncate text-xs text-muted-foreground">
-            {selectedTrack ? `first review prompt - ${selectedTrack.artist}` : "optional after onboarding"}
-          </p>
-        </div>
       </div>
     </div>
   );

--- a/apps/web/components/auth/onboarding-preview-switcher.tsx
+++ b/apps/web/components/auth/onboarding-preview-switcher.tsx
@@ -1,0 +1,394 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState, type FormEvent } from "react";
+import { ArrowLeft, ArrowRight, Check } from "@/components/ui/icons";
+import { Button } from "@/components/ui/button";
+import { PrimaryGrowButton } from "@/components/ui/grow-button";
+import { OnboardingFlowPreview } from "@/components/auth/onboarding-flow-preview";
+import { OnboardingProgressBar } from "@/components/auth/onboarding-progress-bar";
+import BrandLogo from "@/components/brand-logo";
+import ReviewGlyphIcon from "@/components/review-glyph-icon";
+import {
+  groupPreferenceTags,
+  preferenceKindLabels,
+  tasteOnboardingMaxTags,
+  tasteOnboardingMinTags,
+  type PreferenceTag,
+} from "@/lib/taste";
+import { cn } from "@/lib/utils";
+
+type PreviewMode = "profile" | "taste" | "edit";
+
+const previewModes = [
+  { id: "profile", label: "Profile" },
+  { id: "taste", label: "Taste" },
+  { id: "edit", label: "Edit" },
+] as const satisfies Array<{ id: PreviewMode; label: string }>;
+
+const createdAt = "2026-06-01T00:00:00.000Z";
+
+const previewTags = [
+  tag("genre", "alternative", "Alternative", 10),
+  tag("genre", "indie-rock", "Indie Rock", 20),
+  tag("genre", "electronic", "Electronic", 30),
+  tag("genre", "post-punk", "Post-punk", 40),
+  tag("mood", "melancholic", "Melancholic", 50),
+  tag("mood", "nocturnal", "Nocturnal", 60),
+  tag("mood", "euphoric", "Euphoric", 70),
+  tag("mood", "intimate", "Intimate", 80),
+  tag("scene", "bedroom", "Bedroom", 90),
+  tag("scene", "club", "Club", 100),
+  tag("scene", "underground", "Underground", 110),
+  tag("style", "dream-pop", "Dream pop", 120),
+  tag("style", "shoegaze", "Shoegaze", 130),
+  tag("style", "guitar-driven", "Guitar-driven", 140),
+  tag("style", "synth-heavy", "Synth-heavy", 150),
+  tag("era", "current", "Current", 160),
+  tag("era", "90s", "90s", 170),
+  tag("era", "00s", "00s", 180),
+  tag("era", "80s", "80s", 190),
+  tag("format", "album-focused", "Album-focused", 200),
+  tag("format", "deep-cuts", "Deep cuts", 210),
+  tag("format", "live-session", "Live session", 220),
+] satisfies PreferenceTag[];
+
+const previewSelectedTagIds = previewTags
+  .filter((tagItem) =>
+    [
+      "electronic",
+      "melancholic",
+      "nocturnal",
+      "euphoric",
+      "bedroom",
+      "dream-pop",
+      "shoegaze",
+      "deep-cuts",
+    ].includes(tagItem.slug),
+  )
+  .map((tagItem) => tagItem.id);
+
+const previewFocusVisibleClass =
+  "focus-visible:border-white/42 focus-visible:ring-0 focus-visible:shadow-none";
+
+export function OnboardingPreviewSwitcher() {
+  const [mode, setMode] = useState<PreviewMode>("taste");
+
+  return (
+    <>
+      <div className="fixed right-3 top-3 z-50 flex h-8 rounded-full border border-border/60 bg-background/88 p-0.5 shadow-[var(--kocteau-shadow-control)] backdrop-blur">
+        {previewModes.map((item) => (
+          <button
+            key={item.id}
+            type="button"
+            onClick={() => setMode(item.id)}
+            className={cn(
+              "min-w-[3.25rem] rounded-full border border-transparent px-2.5 text-[11px] font-medium text-muted-foreground transition-[background-color,border-color,color,transform] duration-150 ease-out hover:text-foreground active:scale-[0.96] focus-visible:outline-none",
+              previewFocusVisibleClass,
+              mode === item.id &&
+                "bg-foreground text-background hover:text-background",
+            )}
+          >
+            {item.label}
+          </button>
+        ))}
+      </div>
+
+      {mode === "profile" ? (
+        <OnboardingFlowPreview />
+      ) : (
+        <TastePreviewFlow key={mode} mode={mode} />
+      )}
+    </>
+  );
+}
+
+function TastePreviewFlow({ mode }: { mode: "taste" | "edit" }) {
+  const isEditMode = mode === "edit";
+  const [currentStepIndex, setCurrentStepIndex] = useState(0);
+  const [selectedIds, setSelectedIds] = useState(
+    () => new Set(isEditMode ? previewSelectedTagIds : []),
+  );
+  const [error, setError] = useState<string | null>(null);
+  const currentStepId = isEditMode || currentStepIndex === 0 ? "signals" : "review";
+  const totalSteps = isEditMode ? 1 : 2;
+  const progress = ((currentStepIndex + 1) / totalSteps) * 100;
+  const canGoBack = !isEditMode && currentStepIndex > 0;
+  const submitLabel =
+    currentStepId === "review"
+      ? "Start using app"
+      : isEditMode
+        ? "Save taste"
+        : "Continue";
+
+  function toggleTag(tagId: string) {
+    setError(null);
+    setSelectedIds((current) => {
+      const next = new Set(current);
+
+      if (next.has(tagId)) {
+        next.delete(tagId);
+        return next;
+      }
+
+      if (next.size >= tasteOnboardingMaxTags) {
+        setError(`Choose ${tasteOnboardingMaxTags} signals or fewer.`);
+        return current;
+      }
+
+      next.add(tagId);
+      return next;
+    });
+  }
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError(null);
+
+    if (currentStepId === "review") {
+      return;
+    }
+
+    if (selectedIds.size < tasteOnboardingMinTags) {
+      setError("Choose at least three signals.");
+      return;
+    }
+
+    if (!isEditMode) {
+      setCurrentStepIndex(1);
+    }
+  }
+
+  return (
+    <main className="relative isolate flex h-svh overflow-hidden flex-col bg-background text-foreground">
+      <OnboardingProgressBar value={progress} />
+
+      <header className="relative z-10 mx-auto flex w-full max-w-[31rem] shrink-0 flex-col px-5 pt-5 sm:px-8 sm:pt-6">
+        <div className="flex justify-center">
+          <div className="inline-flex h-8 w-8 items-center justify-center text-foreground">
+            <BrandLogo priority iconClassName="h-[1.35rem] w-[1.35rem]" />
+          </div>
+        </div>
+      </header>
+
+      <form
+        id="taste-preview-form"
+        onSubmit={handleSubmit}
+        className="grid min-h-0 flex-1 grid-rows-[minmax(0,1fr)_auto]"
+      >
+        <section className="flex min-h-0 items-center justify-center px-5 py-2 sm:px-8 sm:py-3">
+          <div className="flex h-full min-h-0 w-full max-w-[32rem] flex-col justify-center gap-3">
+            <div className="mx-auto max-w-[24rem] space-y-1.5 text-center">
+              <h1 className="text-balance font-heading text-[1.55rem] font-bold leading-tight tracking-tight text-foreground sm:text-[1.65rem]">
+                {currentStepId === "review"
+                  ? "Start with a track to review."
+                  : isEditMode
+                    ? "Tune your taste."
+                    : "Choose your first signals."}
+              </h1>
+              {currentStepId === "signals" && !isEditMode ? (
+                <p className="text-pretty text-sm leading-5 text-muted-foreground">
+                  Pick a few signals Kocteau can use to shape discovery.
+                </p>
+              ) : null}
+            </div>
+
+            <div className="mx-auto flex min-h-0 w-full max-w-[28rem] items-center justify-center px-1 py-1">
+              {currentStepId === "signals" ? (
+                <PreviewTasteSignalCloud
+                  tags={previewTags}
+                  selectedIds={selectedIds}
+                  onToggle={toggleTag}
+                />
+              ) : (
+                <PreviewReviewStarter />
+              )}
+            </div>
+
+            <div className="min-h-5 text-center text-xs text-destructive">
+              {error}
+            </div>
+          </div>
+        </section>
+
+        <footer className="mx-auto flex h-[4.75rem] w-full max-w-[32rem] shrink-0 items-center justify-between gap-4 pb-5 pl-5 pr-[5.5rem] sm:h-[4.5rem] sm:px-8 sm:pb-5">
+          {canGoBack ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-lg"
+              onClick={() => {
+                setError(null);
+                setCurrentStepIndex((index) => Math.max(index - 1, 0));
+              }}
+              aria-label="Go back"
+              className="size-10 rounded-full bg-foreground/[0.04] text-muted-foreground transition-[background-color,color,transform] duration-150 ease-out hover:bg-foreground/[0.08] hover:text-foreground active:scale-[0.96]"
+            >
+              <ArrowLeft className="size-4" />
+            </Button>
+          ) : (
+            <div className="size-10" aria-hidden="true" />
+          )}
+
+          <div className="min-w-0 flex-1" aria-hidden="true" />
+
+          <Button
+            type="submit"
+            size="lg"
+            className="h-10 min-w-[8.75rem] rounded-full px-5 text-sm transition-[background-color,color,transform] duration-150 ease-out active:scale-[0.96]"
+          >
+            {submitLabel}
+            {currentStepId === "signals" ? <ArrowRight className="size-4" /> : null}
+          </Button>
+        </footer>
+      </form>
+
+      <span className="sr-only" aria-live="polite">
+        {currentStepId === "review"
+          ? "Review step preview."
+          : isEditMode
+            ? "Taste edit preview."
+            : "Taste onboarding preview."}
+      </span>
+    </main>
+  );
+}
+
+function PreviewTasteSignalCloud({
+  tags,
+  selectedIds,
+  onToggle,
+}: {
+  tags: PreferenceTag[];
+  selectedIds: Set<string>;
+  onToggle: (tagId: string) => void;
+}) {
+  const groupedTags = useMemo(() => groupPreferenceTags(tags), [tags]);
+  const scrollAreaRef = useRef<HTMLDivElement | null>(null);
+  const [scrollEdges, setScrollEdges] = useState({
+    hasBottomOverflow: false,
+    hasTopOverflow: false,
+  });
+
+  function updateScrollEdges() {
+    const element = scrollAreaRef.current;
+
+    if (!element) {
+      return;
+    }
+
+    setScrollEdges({
+      hasBottomOverflow:
+        element.scrollTop + element.clientHeight < element.scrollHeight - 4,
+      hasTopOverflow: element.scrollTop > 4,
+    });
+  }
+
+  useEffect(() => {
+    updateScrollEdges();
+  }, [tags.length]);
+
+  return (
+    <div className="relative w-full max-w-[31rem]">
+      <div
+        aria-hidden="true"
+        className={cn(
+          "pointer-events-none absolute inset-x-0 top-0 z-10 h-5 bg-gradient-to-b from-background via-background/72 to-transparent opacity-0 transition-opacity duration-150 ease-out",
+          scrollEdges.hasTopOverflow && "opacity-100",
+        )}
+      />
+      <div
+        aria-hidden="true"
+        className={cn(
+          "pointer-events-none absolute inset-x-0 bottom-0 z-10 h-6 bg-gradient-to-t from-background via-background/78 to-transparent opacity-0 transition-opacity duration-150 ease-out",
+          scrollEdges.hasBottomOverflow && "opacity-100",
+        )}
+      />
+      <div
+        ref={scrollAreaRef}
+        onScroll={updateScrollEdges}
+        className="max-h-[min(19rem,52dvh)] overflow-y-auto overscroll-contain px-1.5 py-5 pr-2 [scrollbar-color:var(--scrollbar-thumb)_transparent] [scrollbar-gutter:stable] [scrollbar-width:thin] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-[3px] [&::-webkit-scrollbar-thumb]:bg-[var(--scrollbar-thumb)] [&::-webkit-scrollbar-thumb:hover]:bg-[var(--scrollbar-thumb-hover)]"
+      >
+        <div className="space-y-2.5">
+          {Array.from(groupedTags.entries()).map(([kind, kindTags]) => {
+            if (kindTags.length === 0) {
+              return null;
+            }
+
+            return (
+              <section key={kind} className="space-y-1.5">
+                <h2 className="text-center text-[10px] font-medium leading-none text-muted-foreground/55">
+                  {preferenceKindLabels[kind].toLowerCase()}
+                </h2>
+                <div className="flex flex-wrap justify-center gap-1.5">
+                  {kindTags.map((tagItem) => {
+                    const isSelected = selectedIds.has(tagItem.id);
+
+                    return (
+                      <button
+                        key={tagItem.id}
+                        type="button"
+                        aria-pressed={isSelected}
+                        onClick={() => onToggle(tagItem.id)}
+                        className={cn(
+                          "min-h-7 rounded-full border border-transparent bg-[var(--kocteau-surface-control)] px-2.5 text-[12px] font-normal leading-none text-muted-foreground shadow-[var(--kocteau-shadow-control)] transition-[background-color,border-color,color,box-shadow,transform] duration-150 ease-out hover:bg-[var(--kocteau-surface-control-hover)] hover:text-foreground active:scale-[0.96] focus-visible:outline-none",
+                          previewFocusVisibleClass,
+                          isSelected &&
+                            "bg-foreground text-background shadow-none hover:bg-foreground hover:text-background",
+                        )}
+                      >
+                        <span>{tagItem.label}</span>
+                        {isSelected ? (
+                          <Check className="ml-1 inline size-2.5 align-[-0.08em]" />
+                        ) : null}
+                      </button>
+                    );
+                  })}
+                </div>
+              </section>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PreviewReviewStarter() {
+  return (
+    <div className="mx-auto flex w-full max-w-[21rem] flex-col items-center gap-3">
+      <PrimaryGrowButton
+        type="button"
+        size="icon-lg"
+        aria-label="Start a track review"
+        className="relative isolate size-14 overflow-hidden rounded-[1rem] p-0 text-background"
+      >
+        <span
+          aria-hidden="true"
+          className="kocteau-review-glow pointer-events-none absolute inset-y-0 -left-1/2 w-1/2 bg-[linear-gradient(90deg,transparent,rgba(255,255,255,0.28),transparent)] opacity-70 blur-[1px]"
+        />
+        <ReviewGlyphIcon className="relative size-[1.1rem]" />
+      </PrimaryGrowButton>
+      <p className="text-center text-xs leading-4 text-muted-foreground">
+        Create a review now, or continue into your feed.
+      </p>
+    </div>
+  );
+}
+
+function tag(
+  kind: PreferenceTag["kind"],
+  slug: string,
+  label: string,
+  sortOrder: number,
+): PreferenceTag {
+  return {
+    created_at: createdAt,
+    description: null,
+    id: `preview-${slug}`,
+    is_featured: true,
+    kind,
+    label,
+    slug,
+    sort_order: sortOrder,
+  };
+}

--- a/apps/web/components/auth/onboarding-progress-bar.tsx
+++ b/apps/web/components/auth/onboarding-progress-bar.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { motion, useReducedMotion } from "motion/react";
+
+type OnboardingProgressBarProps = {
+  value: number;
+};
+
+export function OnboardingProgressBar({ value }: OnboardingProgressBarProps) {
+  const shouldReduceMotion = useReducedMotion();
+  const progressScale = Math.min(Math.max(value / 100, 0), 1);
+
+  return (
+    <div
+      aria-hidden="true"
+      className="absolute inset-x-0 top-0 z-20 h-1 overflow-hidden bg-border/25"
+    >
+      <motion.div
+        className="h-full origin-left bg-foreground"
+        initial={false}
+        animate={{ scaleX: progressScale }}
+        transition={
+          shouldReduceMotion
+            ? { duration: 0 }
+            : { type: "spring", duration: 0.32, bounce: 0 }
+        }
+      />
+    </div>
+  );
+}

--- a/apps/web/components/auth/onboarding-step-frame.tsx
+++ b/apps/web/components/auth/onboarding-step-frame.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import Link from "next/link";
 import type { FormEvent, ReactNode } from "react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { ArrowLeft } from "@/components/ui/icons";
 import BrandLogo from "@/components/brand-logo";
+import { OnboardingProgressBar } from "@/components/auth/onboarding-progress-bar";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { cn } from "@/lib/utils";
@@ -45,51 +45,28 @@ export default function OnboardingStepFrame({
   submitDisabled = false,
   submitLoading = false,
   submitIcon,
-  compact = false,
   controlClassName,
   panelClassName,
   liveMessage,
 }: OnboardingStepFrameProps) {
   const prefersReducedMotion = useReducedMotion();
   const progress = (currentStep / totalSteps) * 100;
+  const canGoBack = Boolean(onBack) && !backDisabled && !submitLoading;
 
   return (
-    <main className="flex h-svh overflow-hidden flex-col bg-background text-foreground">
+    <main className="relative isolate flex h-svh overflow-hidden flex-col bg-background text-foreground">
+      <OnboardingProgressBar value={progress} />
       <header
         className={cn(
-          "mx-auto flex w-full max-w-[32rem] shrink-0 flex-col px-5 sm:px-8",
-          compact ? "gap-2 pt-3 sm:pt-4" : "gap-3 pt-4 sm:pt-6",
+          "relative z-10 mx-auto flex w-full max-w-[31rem] shrink-0 flex-col px-5 sm:px-8",
+          "pt-5 sm:pt-6",
         )}
       >
         <div className="flex justify-center">
-          <Link
-            href="/"
-            className="inline-flex h-8 w-8 items-center justify-center text-foreground transition-[opacity,transform] duration-150 ease-out hover:opacity-80 active:scale-[0.96] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
-            aria-label="Go to Kocteau home"
-          >
+          <div className="inline-flex h-8 w-8 items-center justify-center text-foreground">
             <BrandLogo
               priority
-              iconClassName={compact ? "h-[1.05rem] w-[1.05rem]" : "h-[1.35rem] w-[1.35rem]"}
-            />
-          </Link>
-        </div>
-
-        <div className={compact ? "space-y-2" : "space-y-3"}>
-          <div
-            className={cn(
-              "flex items-end justify-between gap-4",
-              compact ? "text-[12px]" : "text-sm",
-            )}
-          >
-            <span className="font-medium text-foreground">{section}</span>
-            <span className="tabular-nums text-muted-foreground">
-              {currentStep} / {totalSteps}
-            </span>
-          </div>
-          <div className="h-px overflow-hidden bg-border/45" aria-hidden="true">
-            <div
-              className="h-full bg-foreground transition-[width] duration-200 ease-out"
-              style={{ width: `${progress}%` }}
+              iconClassName="h-[1.35rem] w-[1.35rem]"
             />
           </div>
         </div>
@@ -102,7 +79,7 @@ export default function OnboardingStepFrame({
         <section
           className={cn(
             "flex min-h-0 items-center justify-center px-5 sm:px-8",
-            compact ? "py-1.5 sm:py-3" : "py-3 sm:py-5",
+            "py-2 sm:py-3",
           )}
         >
           <AnimatePresence mode="wait" initial={false}>
@@ -113,25 +90,19 @@ export default function OnboardingStepFrame({
               exit={prefersReducedMotion ? undefined : { opacity: 0, y: -6 }}
               transition={{ duration: 0.18, ease: "easeOut" }}
               className={cn(
-                "flex h-full w-full max-w-[32rem] flex-col justify-center",
-                compact
-                  ? "max-h-[28rem] min-h-[20rem] gap-2"
-                  : "max-h-[32rem] min-h-[25rem] gap-3",
+                "flex h-full min-h-0 w-full max-w-[32rem] flex-col justify-center gap-3",
                 panelClassName,
               )}
             >
               <div
                 className={cn(
                   "mx-auto max-w-[24rem] text-center",
-                  compact ? "space-y-0.5" : "space-y-1.5",
+                  "space-y-1.5",
                 )}
               >
                 <h1
                   className={cn(
-                    "text-balance font-heading font-bold leading-tight tracking-tight text-foreground",
-                    compact
-                      ? "text-[1.25rem] sm:text-[1.35rem]"
-                      : "text-[1.55rem] sm:text-[1.65rem]",
+                    "text-balance font-heading text-[1.55rem] font-bold leading-tight tracking-tight text-foreground sm:text-[1.65rem]",
                   )}
                 >
                   {title}
@@ -139,8 +110,7 @@ export default function OnboardingStepFrame({
                 {description ? (
                   <p
                     className={cn(
-                      "text-pretty text-muted-foreground",
-                      compact ? "text-[12px] leading-4" : "text-sm leading-5",
+                      "text-pretty text-sm leading-5 text-muted-foreground",
                     )}
                   >
                     {description}
@@ -166,21 +136,23 @@ export default function OnboardingStepFrame({
 
         <footer
           className={cn(
-            "mx-auto flex w-full max-w-[32rem] shrink-0 items-center justify-between gap-4 px-5 sm:px-8",
-            compact ? "h-24 pb-12 sm:h-16 sm:pb-5" : "h-28 pb-14 sm:h-20 sm:pb-7",
+            "mx-auto flex h-[4.75rem] w-full max-w-[32rem] shrink-0 items-center justify-between gap-4 pb-5 pl-5 pr-[5.5rem] sm:h-[4.5rem] sm:px-8 sm:pb-5",
           )}
         >
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-lg"
-            onClick={onBack}
-            disabled={backDisabled || submitLoading}
-            aria-label="Go back"
-            className="size-10 rounded-full bg-foreground/[0.04] text-muted-foreground transition-[background-color,color,transform] duration-150 ease-out hover:bg-foreground/[0.08] hover:text-foreground active:scale-[0.96]"
-          >
-            <ArrowLeft className="size-4" />
-          </Button>
+          {canGoBack ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-lg"
+              onClick={onBack}
+              aria-label="Go back"
+              className="size-10 rounded-full bg-foreground/[0.04] text-muted-foreground transition-[background-color,color,transform] duration-150 ease-out hover:bg-foreground/[0.08] hover:text-foreground active:scale-[0.96]"
+            >
+              <ArrowLeft className="size-4" />
+            </Button>
+          ) : (
+            <div className="size-10" aria-hidden="true" />
+          )}
 
           <div className="min-w-0 flex-1" aria-hidden="true" />
 
@@ -189,8 +161,7 @@ export default function OnboardingStepFrame({
             size="lg"
             disabled={submitDisabled || submitLoading}
             className={cn(
-              "rounded-full transition-[background-color,color,transform] duration-150 ease-out active:scale-[0.96]",
-              compact ? "h-9 min-w-[7.75rem] px-4 text-[13px]" : "h-10 min-w-[8.75rem] px-5 text-sm",
+              "h-10 min-w-[8.75rem] rounded-full px-5 text-sm transition-[background-color,color,transform] duration-150 ease-out active:scale-[0.96]",
             )}
           >
             {submitLoading ? <Spinner className="size-3.5" /> : null}

--- a/apps/web/components/auth/profile-onboarding-flow.tsx
+++ b/apps/web/components/auth/profile-onboarding-flow.tsx
@@ -74,7 +74,7 @@ const profileSteps = [
     id: "avatar",
     section: "Profile",
     title: "Choose a profile image.",
-    description: "Use a photo or a Kocteau disc.",
+    description: "Pick a disc, or upload a photo.",
   },
   {
     id: "bio",
@@ -83,6 +83,11 @@ const profileSteps = [
     description: "Optional. Add one line now, or leave it for later.",
   },
 ] as const satisfies ProfileStep[];
+
+const onboardingFocusVisibleClass =
+  "focus-visible:border-white/42 focus-visible:ring-0 focus-visible:shadow-none";
+const onboardingFocusWithinClass =
+  "focus-within:border-white/42 focus-within:ring-0 focus-within:shadow-none";
 
 function normalizeUsername(value: string) {
   return value
@@ -548,14 +553,22 @@ function renderProfileStepControl({
           clearStepErrors();
         }}
         placeholder="Fran Cocteau"
-        className="h-11 w-full rounded-[var(--kocteau-radius-control)] border-0 bg-[var(--kocteau-surface-control)] px-4 text-base shadow-[var(--kocteau-shadow-control)] placeholder:text-muted-foreground/55 focus-visible:ring-2 focus-visible:ring-ring/30"
+        className={cn(
+          "h-11 w-full rounded-[var(--kocteau-radius-control)] border border-transparent bg-[var(--kocteau-surface-control)] px-4 text-base shadow-[var(--kocteau-shadow-control)] placeholder:text-muted-foreground/55",
+          onboardingFocusVisibleClass,
+        )}
       />
     );
   }
 
   if (stepId === "handle") {
     return (
-      <div className="flex h-11 w-full items-center rounded-[var(--kocteau-radius-control)] bg-[var(--kocteau-surface-control)] px-4 shadow-[var(--kocteau-shadow-control)] focus-within:ring-2 focus-within:ring-ring/30">
+      <div
+        className={cn(
+          "flex h-11 w-full items-center rounded-[var(--kocteau-radius-control)] border border-transparent bg-[var(--kocteau-surface-control)] px-4 shadow-[var(--kocteau-shadow-control)]",
+          onboardingFocusWithinClass,
+        )}
+      >
         <span className="select-none text-base text-muted-foreground">@</span>
         <input
           autoFocus
@@ -596,7 +609,10 @@ function renderProfileStepControl({
         clearStepErrors();
       }}
       placeholder="Dream pop, noisy guitars, late-night pop records."
-      className="min-h-28 w-full resize-none rounded-[var(--kocteau-radius-control)] border-0 bg-[var(--kocteau-surface-control)] p-4 text-base leading-6 shadow-[var(--kocteau-shadow-control)] placeholder:text-muted-foreground/55 focus-visible:ring-2 focus-visible:ring-ring/30"
+      className={cn(
+        "min-h-28 w-full resize-none rounded-[var(--kocteau-radius-control)] border border-transparent bg-[var(--kocteau-surface-control)] p-4 text-base leading-6 shadow-[var(--kocteau-shadow-control)] placeholder:text-muted-foreground/55",
+        onboardingFocusVisibleClass,
+      )}
     />
   );
 }
@@ -636,8 +652,9 @@ function ProfileAvatarControl({
           onDragOver={onAvatarDragOver}
           onDrop={onAvatarDrop}
           className={cn(
-            "group relative flex size-28 cursor-pointer items-center justify-center rounded-full bg-[var(--kocteau-surface-control)] p-1.5 shadow-[var(--kocteau-shadow-control),0_14px_42px_rgba(0,0,0,0.22)] transition-[background-color,box-shadow,transform] duration-150 ease-out hover:bg-[var(--kocteau-surface-control-hover)] hover:shadow-[var(--kocteau-shadow-card-hover),0_18px_52px_rgba(0,0,0,0.28)] active:scale-[0.96] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/35",
-            isDragging && "bg-[var(--kocteau-surface-control-hover)] ring-2 ring-ring/35",
+            "group relative flex size-28 cursor-pointer items-center justify-center rounded-full border border-transparent bg-[var(--kocteau-surface-control)] p-1.5 transition-[background-color,border-color,transform] duration-150 ease-out hover:bg-[var(--kocteau-surface-control-hover)] active:scale-[0.96] focus-visible:outline-none",
+            onboardingFocusVisibleClass,
+            isDragging && "border-white/42 bg-[var(--kocteau-surface-control-hover)]",
           )}
         >
           <span className="relative flex size-full items-center justify-center overflow-hidden rounded-full bg-background outline outline-1 outline-white/10">
@@ -660,7 +677,8 @@ function ProfileAvatarControl({
           aria-expanded={isDiscPickerOpen}
           onClick={() => setIsDiscPickerOpen((open) => !open)}
           className={cn(
-            "absolute -right-1 bottom-1 flex size-9 items-center justify-center rounded-full bg-background text-foreground shadow-[0_0_0_3px_var(--background),var(--kocteau-shadow-card-hover)] transition-[background-color,box-shadow,transform] duration-150 ease-out hover:bg-[var(--kocteau-surface-control-hover)] active:scale-[0.96] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/35",
+            "absolute -right-1 bottom-1 flex size-9 items-center justify-center rounded-full border border-transparent bg-background text-foreground ring-4 ring-background transition-[background-color,border-color,transform] duration-150 ease-out hover:bg-[var(--kocteau-surface-control-hover)] active:scale-[0.96] focus-visible:outline-none",
+            onboardingFocusVisibleClass,
             isDiscPickerOpen && "bg-foreground text-background",
           )}
         >
@@ -689,7 +707,8 @@ function ProfileAvatarControl({
                     setIsDiscPickerOpen(false);
                   }}
                   className={cn(
-                    "group relative flex aspect-square min-h-[4rem] items-center justify-center rounded-[0.85rem] bg-[var(--kocteau-surface-control)] shadow-[var(--kocteau-shadow-control)] transition-[background-color,box-shadow,transform] duration-150 ease-out hover:bg-[var(--kocteau-surface-control-hover)] active:scale-[0.96] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30",
+                    "group relative flex aspect-square min-h-[4rem] items-center justify-center rounded-[0.85rem] border border-transparent bg-[var(--kocteau-surface-control)] shadow-[var(--kocteau-shadow-control)] transition-[background-color,border-color,box-shadow,transform] duration-150 ease-out hover:bg-[var(--kocteau-surface-control-hover)] active:scale-[0.96] focus-visible:outline-none",
+                    onboardingFocusVisibleClass,
                     isSelected &&
                       "bg-[var(--kocteau-surface-featured)] shadow-[var(--kocteau-shadow-card-hover)]",
                   )}

--- a/apps/web/components/auth/taste-onboarding-form.tsx
+++ b/apps/web/components/auth/taste-onboarding-form.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { startTransition, useMemo, useState, type FormEvent } from "react";
+import {
+  startTransition,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type FormEvent,
+} from "react";
 import { useRouter } from "next/navigation";
 import { ArrowRight, Check } from "@/components/ui/icons";
 import OnboardingStepFrame from "@/components/auth/onboarding-step-frame";
@@ -8,6 +15,8 @@ import NewReviewDialog from "@/components/new-review-dialog";
 import ReviewGlyphIcon from "@/components/review-glyph-icon";
 import { PrimaryGrowButton } from "@/components/ui/grow-button";
 import {
+  groupPreferenceTags,
+  preferenceKindLabels,
   tasteOnboardingMaxTags,
   tasteOnboardingMinTags,
   type PreferenceTag,
@@ -37,7 +46,7 @@ const tasteSteps = [
     id: "review",
     section: "Review",
     title: "Start with a track to review.",
-    description: "Review now, or skip and start with your feed.",
+    description: "Review now, or start using Kocteau.",
   },
 ] as const;
 
@@ -47,6 +56,9 @@ const tasteEditStep = {
   title: "Tune your taste.",
   description: undefined,
 } as const;
+
+const onboardingFocusVisibleClass =
+  "focus-visible:border-white/42 focus-visible:ring-0 focus-visible:shadow-none";
 
 export function TasteOnboardingForm({
   tags,
@@ -70,10 +82,9 @@ export function TasteOnboardingForm({
   const currentStep = isEditMode ? tasteEditStep : tasteSteps[currentStepIndex];
   const totalSteps = isEditMode ? 1 : tasteSteps.length;
   const selectedCount = selectedIds.size;
-  const missingCount = Math.max(tasteOnboardingMinTags - selectedCount, 0);
   const submitLabel =
     currentStep.id === "review"
-      ? "Skip for now"
+      ? "Start using app"
       : isSaving
         ? "Saving"
         : isEditMode
@@ -111,7 +122,7 @@ export function TasteOnboardingForm({
     setError(null);
 
     if (selectedCount < tasteOnboardingMinTags) {
-      setError(`Choose ${missingCount} more to continue.`);
+      setError("Choose at least three signals.");
       return;
     }
 
@@ -191,9 +202,7 @@ export function TasteOnboardingForm({
       compact={isEditMode}
       controlClassName={
         currentStep.id === "signals"
-          ? isEditMode
-            ? "max-w-[24rem] py-0"
-            : "max-w-[30rem]"
+          ? "max-w-[28rem] py-0"
           : undefined
       }
       liveMessage={`${currentStep.section}, step ${currentStepIndex + 1} of ${totalSteps}.`}
@@ -202,8 +211,6 @@ export function TasteOnboardingForm({
         <TasteSignalCloud
           tags={tags}
           selectedIds={selectedIds}
-          selectedCount={selectedCount}
-          missingCount={missingCount}
           onToggle={toggleTag}
         />
       ) : (
@@ -216,16 +223,37 @@ export function TasteOnboardingForm({
 function TasteSignalCloud({
   tags,
   selectedIds,
-  selectedCount,
-  missingCount,
   onToggle,
 }: {
   tags: PreferenceTag[];
   selectedIds: Set<string>;
-  selectedCount: number;
-  missingCount: number;
   onToggle: (tagId: string) => void;
 }) {
+  const groupedTags = useMemo(() => groupPreferenceTags(tags), [tags]);
+  const scrollAreaRef = useRef<HTMLDivElement | null>(null);
+  const [scrollEdges, setScrollEdges] = useState({
+    hasBottomOverflow: false,
+    hasTopOverflow: false,
+  });
+
+  function updateScrollEdges() {
+    const element = scrollAreaRef.current;
+
+    if (!element) {
+      return;
+    }
+
+    setScrollEdges({
+      hasBottomOverflow:
+        element.scrollTop + element.clientHeight < element.scrollHeight - 4,
+      hasTopOverflow: element.scrollTop > 4,
+    });
+  }
+
+  useEffect(() => {
+    updateScrollEdges();
+  }, [tags.length]);
+
   if (tags.length === 0) {
     return (
       <p className="max-w-[22rem] text-center text-sm leading-5 text-muted-foreground">
@@ -235,32 +263,66 @@ function TasteSignalCloud({
   }
 
   return (
-    <div className="w-full space-y-3">
-      <div className="flex justify-end text-[11px] tabular-nums leading-none text-muted-foreground/78">
-        {selectedCount}/{tasteOnboardingMaxTags}
-        {missingCount > 0 ? ` · ${missingCount} left` : null}
-      </div>
-      <div className="flex flex-wrap justify-center gap-1.5 sm:gap-1.5">
-        {tags.map((tag) => {
-          const isSelected = selectedIds.has(tag.id);
+    <div className="relative w-full max-w-[31rem]">
+      <div
+        aria-hidden="true"
+        className={cn(
+          "pointer-events-none absolute inset-x-0 top-0 z-10 h-5 bg-gradient-to-b from-background via-background/72 to-transparent opacity-0 transition-opacity duration-150 ease-out",
+          scrollEdges.hasTopOverflow && "opacity-100",
+        )}
+      />
+      <div
+        aria-hidden="true"
+        className={cn(
+          "pointer-events-none absolute inset-x-0 bottom-0 z-10 h-6 bg-gradient-to-t from-background via-background/78 to-transparent opacity-0 transition-opacity duration-150 ease-out",
+          scrollEdges.hasBottomOverflow && "opacity-100",
+        )}
+      />
+      <div
+        ref={scrollAreaRef}
+        onScroll={updateScrollEdges}
+        className="max-h-[min(19rem,52dvh)] overflow-y-auto overscroll-contain px-1.5 py-5 pr-2 [scrollbar-color:var(--scrollbar-thumb)_transparent] [scrollbar-gutter:stable] [scrollbar-width:thin] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-[3px] [&::-webkit-scrollbar-thumb]:bg-[var(--scrollbar-thumb)] [&::-webkit-scrollbar-thumb:hover]:bg-[var(--scrollbar-thumb-hover)]"
+      >
+        <div className="space-y-2.5">
+          {Array.from(groupedTags.entries()).map(([kind, kindTags]) => {
+            if (kindTags.length === 0) {
+              return null;
+            }
 
-          return (
-            <button
-              key={tag.id}
-              type="button"
-              aria-pressed={isSelected}
-              onClick={() => onToggle(tag.id)}
-              className={cn(
-                "min-h-7 rounded-full bg-[var(--kocteau-surface-control)] px-2 text-[12px] font-normal leading-none text-muted-foreground shadow-[var(--kocteau-shadow-control)] transition-[background-color,color,box-shadow,transform] duration-150 ease-out hover:bg-[var(--kocteau-surface-control-hover)] hover:text-foreground active:scale-[0.96] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30 sm:min-h-7 sm:px-2.5",
-                isSelected &&
-                  "bg-foreground text-background shadow-none hover:bg-foreground hover:text-background",
-              )}
-            >
-              <span>{tag.label}</span>
-              {isSelected ? <Check className="ml-1 inline size-2.5 align-[-0.08em]" /> : null}
-            </button>
-          );
-        })}
+            return (
+              <section key={kind} className="space-y-1.5">
+                <h2 className="text-center text-[10px] font-medium leading-none text-muted-foreground/55">
+                  {preferenceKindLabels[kind].toLowerCase()}
+                </h2>
+                <div className="flex flex-wrap justify-center gap-1.5">
+                  {kindTags.map((tag) => {
+                    const isSelected = selectedIds.has(tag.id);
+
+                    return (
+                      <button
+                        key={tag.id}
+                        type="button"
+                        aria-pressed={isSelected}
+                        onClick={() => onToggle(tag.id)}
+                        className={cn(
+                          "min-h-7 rounded-full border border-transparent bg-[var(--kocteau-surface-control)] px-2.5 text-[12px] font-normal leading-none text-muted-foreground shadow-[var(--kocteau-shadow-control)] transition-[background-color,border-color,color,box-shadow,transform] duration-150 ease-out hover:bg-[var(--kocteau-surface-control-hover)] hover:text-foreground active:scale-[0.96] focus-visible:outline-none",
+                          onboardingFocusVisibleClass,
+                          isSelected &&
+                            "bg-foreground text-background shadow-none hover:bg-foreground hover:text-background",
+                        )}
+                      >
+                        <span>{tag.label}</span>
+                        {isSelected ? (
+                          <Check className="ml-1 inline size-2.5 align-[-0.08em]" />
+                        ) : null}
+                      </button>
+                    );
+                  })}
+                </div>
+              </section>
+            );
+          })}
+        </div>
       </div>
     </div>
   );
@@ -288,7 +350,7 @@ function ReviewStarterControl({ redirectTo }: { redirectTo: string }) {
         }
       />
       <p className="text-center text-xs leading-4 text-muted-foreground">
-        Optional. You can skip and review later.
+        Create a review now, or continue into your feed.
       </p>
     </div>
   );

--- a/apps/web/components/review-comments-panel.tsx
+++ b/apps/web/components/review-comments-panel.tsx
@@ -306,7 +306,7 @@ export default function ReviewCommentsPanel({
         scale: composerIsMultiline && !shouldReduceMotion ? 1.004 : 1,
       }}
       className={cn(
-        "flex items-end gap-2 border border-border/42 bg-muted/58 px-2 py-2 transition-[background-color,border-color,box-shadow] duration-100 ease-out focus-within:border-white/32 focus-within:bg-muted/72 focus-within:shadow-[0_0_0_1px_rgba(255,255,255,0.14),0_0_0_4px_rgba(255,255,255,0.035)] md:border-border/34 md:bg-muted/48 md:focus-within:border-white/34",
+        "flex items-end gap-2 border border-border/42 bg-muted/58 px-2 py-2 transition-[border-color] duration-100 ease-out focus-within:border-white/42 md:border-border/34 md:bg-muted/48 md:focus-within:border-white/42",
         !isInline && "w-full",
       )}
       initial={false}


### PR DESCRIPTION
## What changed

- Polished the official profile and taste onboarding flows.
- Added a motion-based onboarding progress bar with reduced-motion support.
- Made the onboarding logo static, removed visible step counters, and tightened footer/back-button behavior.
- Updated taste selection with grouped signals, Kocteau scrollbar styling, and subtle fade edges.
- Added `/onboarding-preview` tabs for Profile, Taste, and Edit preview states.
- Updated comment composer focus to use a clean brighter border instead of a halo.

## Why

This moves the approved onboarding preview into the real product flow while keeping Kocteau’s UI quieter, more consistent, and easier to scan across profile setup, taste setup, and taste editing.

## Testing

- [ ] Ran `pnpm check`
- [ ] Added screenshots or a short recording for visible web UI changes
- [ ] Confirmed this does not touch auth, Supabase, recommendations, analytics, CI, or release behavior

Also ran:

```text
pnpm --filter web lint
pnpm --filter web build
git diff --check
```

## Changelog impact

No manual `CHANGELOG.md` edit is required. Release Please generates release notes from PR titles and squash commits.

- [x] User-facing web change
- [ ] Developer experience or documentation change
- [ ] Internal-only change

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the onboarding flows with a motion-based progress bar, a quieter header/footer, and a redesigned taste selector. Added an `/onboarding-preview` switcher to preview Profile, Taste, and Edit states.

- **New Features**
  - Added `OnboardingProgressBar` with reduced-motion support; replaces visible step counter.
  - Introduced `OnboardingPreviewSwitcher` for tabbed Profile/Taste/Edit on `/onboarding-preview`.
  - Redesigned taste selector: grouped by kind, scrollable with thin scrollbar and fade edges.

- **Refactors**
  - Quieter chrome: static logo, no step counts, hidden back on first step, tighter footer spacing.
  - Copy and actions: “Start using app” replaces “Skip for now”; error reads “Choose at least three signals.”
  - Consistent focus styling: inputs, textareas, avatar controls, and chips use subtle border focus; comment composer now uses a brighter border only.
  - Preview flow removes the final “finish” step; updated review starter text.

<sup>Written for commit 9b5fcab775a5717f902499fd8501da448b42bfd7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/francozeta/kocteau/pull/81?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added onboarding preview switcher to cycle between Profile, Taste, and Edit preview modes.
  * Introduced animated progress bar for onboarding steps.

* **Style**
  * Standardized focus styling across form controls and buttons.
  * Refined onboarding layout spacing and typography.
  * Conditional back button visibility based on current step.

* **UI Improvements**
  * Updated helper text and copy throughout onboarding flow.
  * Enhanced visual feedback for form interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->