### PR TITLE
fix(web): polish empty states across sparse surfaces

### DIFF
--- a/apps/web/app/(main)/saved/page.tsx
+++ b/apps/web/app/(main)/saved/page.tsx
@@ -67,7 +67,7 @@ export default async function SavedReviewsPage() {
               <Bookmark className="size-4" />
             </EmptyMedia>
             <EmptyTitle>No saved reviews yet</EmptyTitle>
-            <EmptyDescription>Save a review to keep it here.</EmptyDescription>
+            <EmptyDescription>Save reviews you want to revisit.</EmptyDescription>
           </EmptyHeader>
           <CardContent className="p-0 pt-2">
             <PrefetchLink

--- a/apps/web/app/(main)/u/[username]/page.tsx
+++ b/apps/web/app/(main)/u/[username]/page.tsx
@@ -201,7 +201,11 @@ export default async function UserProfilePage({
             <Empty className="rounded-[1.65rem] border-border/32 bg-card/24 px-6 py-10 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)] md:border-border/20 md:bg-card/18">
               <EmptyHeader>
                 <EmptyTitle>No reviews yet</EmptyTitle>
-                <EmptyDescription>Nothing here yet.</EmptyDescription>
+                <EmptyDescription>
+                  {isOwnProfile
+                    ? "When you review tracks, they'll show up here."
+                    : "This listener hasn't published any reviews yet."}
+                </EmptyDescription>
               </EmptyHeader>
             </Empty>
         ) : null}

--- a/apps/web/components/notifications-button.tsx
+++ b/apps/web/components/notifications-button.tsx
@@ -185,7 +185,7 @@ export default function NotificationsButton({
                   No notifications yet
                 </p>
                 <p className="max-w-[16rem] text-[11px] text-sidebar-foreground/58 text-balance">
-                  New replies, follows, and review activity will appear here.
+                  New likes and replies to your reviews will appear here.
                 </p>
               </div>
             )}

--- a/apps/web/components/notifications-button.tsx
+++ b/apps/web/components/notifications-button.tsx
@@ -184,6 +184,9 @@ export default function NotificationsButton({
                 <p className="text-[13px] font-medium text-sidebar-foreground">
                   No notifications yet
                 </p>
+                <p className="max-w-[16rem] text-[11px] text-sidebar-foreground/58 text-balance">
+                  New replies, follows, and review activity will appear here.
+                </p>
               </div>
             )}
           </div>

--- a/apps/web/components/notifications-inbox.tsx
+++ b/apps/web/components/notifications-inbox.tsx
@@ -83,7 +83,7 @@ export default function NotificationsInbox({
             </EmptyMedia>
             <EmptyTitle>No notifications yet</EmptyTitle>
             <EmptyDescription>
-              Likes and comments will show up here.
+              New replies, follows, and review activity will appear here.
             </EmptyDescription>
           </EmptyHeader>
         </Empty>

--- a/apps/web/components/notifications-inbox.tsx
+++ b/apps/web/components/notifications-inbox.tsx
@@ -83,7 +83,7 @@ export default function NotificationsInbox({
             </EmptyMedia>
             <EmptyTitle>No notifications yet</EmptyTitle>
             <EmptyDescription>
-              New replies, follows, and review activity will appear here.
+              New likes and replies to your reviews will appear here.
             </EmptyDescription>
           </EmptyHeader>
         </Empty>

--- a/apps/web/components/search-page-client.tsx
+++ b/apps/web/components/search-page-client.tsx
@@ -745,6 +745,9 @@ export default function SearchPageClient({
                       <Music2 className="size-4" />
                     </EmptyMedia>
                     <EmptyTitle>No tracks yet</EmptyTitle>
+                    <EmptyDescription>
+                      New reviews will surface here as the community grows.
+                    </EmptyDescription>
                   </EmptyHeader>
                 </Empty>
               )}

--- a/apps/web/components/who-to-follow-rail.tsx
+++ b/apps/web/components/who-to-follow-rail.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { usePathname } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
+import { PencilLine } from "@/components/ui/icons";
 import FollowProfileButton from "@/components/follow-profile-button";
 import { WhoToFollowRailSkeleton } from "@/components/feed-loading-skeletons";
 import NewReviewDialog from "@/components/new-review-dialog";
@@ -276,8 +277,16 @@ export default function WhoToFollowRail({ isAuthenticated }: WhoToFollowRailProp
                 })}
               </div>
             ) : (
-              <div className="px-1 py-3 text-[13px] text-muted-foreground/78">
-                No writers to notice yet.
+              <div className="flex flex-col items-center gap-2 px-1 py-6 text-center">
+                <span className="flex size-8 items-center justify-center rounded-full bg-muted/50 text-muted-foreground/70">
+                  <PencilLine className="size-4" />
+                </span>
+                <p className="text-[13px] font-medium text-foreground/80">
+                  No writers to notice yet
+                </p>
+                <p className="max-w-[14rem] text-[11px] leading-relaxed text-muted-foreground/60 text-balance">
+                  Active reviewers will appear here as the community grows.
+                </p>
               </div>
             )}
           </section>


### PR DESCRIPTION
Descripción:
## Summary

Improves empty states across sparse surfaces to feel more editorial, calm, and useful.

Closes #86.

## Surfaces updated

- **Saved reviews** – refined description copy
- **Notifications (page + popover)** – aligned description around likes and replies
- **Profile reviews** – contextual empty state for own vs. other profiles
- **Search – Recently discussed** – added description about community growth
- **Writers to notice rail** – added icon, title, and description to empty state

## Acceptance criteria

- [x] Empty states explain what happened.
- [x] Each state offers one clear next action when useful.
- [x] Layout holds on desktop and narrow/mobile viewports.
- [x] No data, auth, Supabase, recommendation, analytics, CI, or release behavior changes included.

## Contribution lane

Fast Lane – UI/copy only changes in existing surfaces.

## Screenshots

<img width="251" height="226" alt="Captura de pantalla 2026-06-08 122957" src="https://github.com/user-attachments/assets/890d15ea-4d74-4397-a32b-ae590b4450c2" />
<img width="1441" height="447" alt="Captura de pantalla 2026-06-08 123004" src="https://github.com/user-attachments/assets/47fd6fa7-1a01-41b9-b2f2-bd99ecb461d8" />
<img width="962" height="289" alt="Captura de pantalla 2026-06-08 120718" src="https://github.com/user-attachments/assets/f1cf647a-997f-4a16-a952-bcc1b8f7458a" />
<img width="826" height="440" alt="Captura de pantalla 2026-06-08 124925" src="https://github.com/user-attachments/assets/4fcfcb19-1c19-419b-957d-63495ab5d806" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved empty states across saved, notifications, profiles, search, and the writers rail with clearer copy and calmer layout. No changes to data, auth, or analytics.

- **New Features**
  - Saved reviews: refined copy (“Save reviews you want to revisit.”).
  - Notifications (page + popover): aligned copy; mentions likes and replies.
  - Profile reviews: contextual message for own vs. other profiles.
  - Search – Recently discussed: added community-growth hint.
  - Writers to notice rail: added icon, title, and helpful description.

<sup>Written for commit 4b30d7898cc84da3cfd7513cbfbcd5fa64686ada. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/francozeta/kocteau/pull/95?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated empty-state messaging across saved reviews, notifications, search results, and "who to follow" sections with clearer, more helpful guidance
  * Profile pages now display personalized messages depending on whether you're viewing your own profile or someone else's
  * Enhanced visual presentation with descriptive text and icons explaining what content will appear

<!-- end of auto-generated comment: release notes by coderabbit.ai -->