### PR TITLE
feat(web): refine editorial review cards

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -579,6 +579,53 @@
     background: var(--kocteau-surface-featured-hover);
   }
 
+  .kocteau-review-card-editorial {
+    border: 0;
+    border-radius: 0 !important;
+    background: transparent;
+    box-shadow: none;
+  }
+
+  .kocteau-review-card-editorial:hover {
+    border-color: transparent;
+    background: transparent;
+  }
+
+  .kocteau-review-card-editorial.kocteau-review-card-featured,
+  .kocteau-review-card-editorial.kocteau-review-card-featured:hover {
+    background: transparent;
+  }
+
+  .kocteau-review-card-editorial + .kocteau-review-card-editorial,
+  .kocteau-review-card-frame + .kocteau-review-card-frame,
+  .kocteau-review-card-list-item + .kocteau-review-card-list-item {
+    margin-top: 0.55rem !important;
+  }
+
+  .kocteau-review-card-frame,
+  .kocteau-review-card-list-item {
+    position: relative;
+  }
+
+  .kocteau-review-card-editorial + .kocteau-review-card-editorial,
+  .kocteau-review-card-frame + .kocteau-review-card-frame .kocteau-review-card-editorial,
+  .kocteau-review-card-list-item + .kocteau-review-card-list-item .kocteau-review-card-editorial {
+    padding-top: 1.1rem;
+  }
+
+  .kocteau-review-card-editorial + .kocteau-review-card-editorial::before,
+  .kocteau-review-card-frame + .kocteau-review-card-frame .kocteau-review-card-editorial::before,
+  .kocteau-review-card-list-item + .kocteau-review-card-list-item .kocteau-review-card-editorial::before {
+    content: "";
+    position: absolute;
+    inset-inline: 0;
+    top: 0;
+    height: 1px;
+    border-radius: 0;
+    background: color-mix(in oklch, var(--foreground) 14%, transparent);
+    pointer-events: none;
+  }
+
   .kocteau-toast {
     --kocteau-toast-accent: color-mix(in oklch, var(--foreground) 56%, transparent);
     --kocteau-toast-bg: color-mix(in oklch, var(--kocteau-surface) 82%, black);

--- a/apps/web/components/feed-review-list.tsx
+++ b/apps/web/components/feed-review-list.tsx
@@ -472,7 +472,7 @@ export default function FeedReviewList({
         const author = review.author;
 
         return (
-          <div key={review.id} ref={setReviewNodeRef(review.id)}>
+          <div key={review.id} ref={setReviewNodeRef(review.id)} className="kocteau-review-card-list-item">
             <FeedReviewCard
               review={review}
               entity={review.entities}

--- a/apps/web/components/rating-stars.tsx
+++ b/apps/web/components/rating-stars.tsx
@@ -97,7 +97,8 @@ export default function RatingStars({
               type="button"
               disabled={disabled}
               className={cn(
-                "relative h-8 w-8 cursor-pointer outline-none transition-transform",
+                "relative h-8 w-8 appearance-none overflow-visible border-0 bg-transparent p-0 shadow-none outline-none transition-transform",
+                !disabled && "cursor-pointer hover:bg-transparent active:bg-transparent",
                 !disabled && "hover:scale-105",
                 disabled && "cursor-not-allowed opacity-60"
               )}
@@ -108,20 +109,18 @@ export default function RatingStars({
               aria-checked={value === starNumber || value === starNumber - 0.5}
               aria-label={`${starNumber} estrellas`}
             >
-              {/* estrella base */}
               <Star
-                className="absolute inset-0 h-8 w-8 text-muted-foreground/40"
+                className="absolute inset-0 h-8 w-8 text-muted-foreground/34 transition-colors"
                 fill="none"
                 stroke="currentColor"
               />
 
-              {/* capa rellenada */}
               <div
                 className="absolute inset-y-0 left-0 overflow-hidden"
                 style={{ width: `${fillPercent}%` }}
               >
                 <Star
-                  className="h-8 w-8 text-amber-400"
+                  className="h-8 w-8 text-foreground drop-shadow-[0_0_10px_color-mix(in_oklch,var(--foreground)_22%,transparent)]"
                   fill="currentColor"
                   stroke="currentColor"
                 />

--- a/apps/web/components/review-card-context-menu-frame.tsx
+++ b/apps/web/components/review-card-context-menu-frame.tsx
@@ -35,7 +35,7 @@ export default function ReviewCardContextMenuFrame({
   return (
     <ContextMenu>
       <ContextMenuTrigger asChild>
-        <div className="h-full">{children}</div>
+        <div className="kocteau-review-card-frame h-full">{children}</div>
       </ContextMenuTrigger>
       <ReviewCardContextMenu
         reviewId={reviewId}

--- a/apps/web/components/review-card-interaction-bar.tsx
+++ b/apps/web/components/review-card-interaction-bar.tsx
@@ -32,7 +32,7 @@ export default function ReviewCardInteractionBar({
   viewer = null,
 }: ReviewCardInteractionBarProps) {
   return (
-    <div className="flex items-center gap-0.5">
+    <div className="inline-flex items-center gap-0.5 rounded-full bg-[color-mix(in_oklch,var(--foreground)_7%,transparent)] p-1">
       <ReviewLikeButton
         reviewId={review.id}
         initialCount={review.likes_count}

--- a/apps/web/components/review-card.tsx
+++ b/apps/web/components/review-card.tsx
@@ -1,7 +1,7 @@
 import type { ComponentPropsWithoutRef, ReactNode } from "react";
 import Link from "next/link";
-import { Star } from "@/components/ui/icons";
 import { Badge } from "@/components/ui/badge";
+import { Star } from "@/components/ui/icons";
 import EntityCoverImage from "@/components/entity-cover-image";
 import ReviewCardBody from "@/components/review-card-body";
 import UserAvatar from "@/components/user-avatar";
@@ -231,6 +231,49 @@ export function ReviewCardEntityCover({
   );
 }
 
+function ReviewRatingStars({ rating, className }: { rating: number; className?: string }) {
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-1 text-foreground tabular-nums",
+        className,
+      )}
+      aria-label={`Rating ${rating.toFixed(1)} out of 5`}
+    >
+      <span className="flex items-center gap-0.5" aria-hidden="true">
+        {Array.from({ length: 5 }).map((_, index) => {
+          const starNumber = index + 1;
+          const fillPercent =
+            rating >= starNumber ? 100 : rating >= starNumber - 0.5 ? 50 : 0;
+
+          return (
+            <span key={starNumber} className="relative block size-2.5 overflow-hidden sm:size-3 md:size-3.5">
+              <Star
+                className="absolute inset-0 size-full text-muted-foreground/30"
+                fill="none"
+                stroke="currentColor"
+              />
+              <span
+                className="absolute inset-y-0 left-0 overflow-hidden"
+                style={{ width: `${fillPercent}%` }}
+              >
+                <Star
+                  className="size-2.5 text-foreground sm:size-3 md:size-3.5"
+                  fill="currentColor"
+                  stroke="currentColor"
+                />
+              </span>
+            </span>
+          );
+        })}
+      </span>
+      <span className="text-[11px] font-medium leading-none text-muted-foreground/86 sm:text-[11.5px] md:text-xs">
+        {rating.toFixed(1)}
+      </span>
+    </div>
+  );
+}
+
 export default function ReviewCard({
   review,
   entity,
@@ -264,7 +307,7 @@ export default function ReviewCard({
     <article
       {...articleProps}
       className={cn(
-        "kocteau-review-card relative isolate overflow-hidden rounded-[var(--kocteau-radius-card)]",
+        "kocteau-review-card kocteau-review-card-editorial relative isolate overflow-hidden rounded-[var(--kocteau-radius-card)]",
         reviewHref && "cursor-pointer",
         featured && "kocteau-review-card-featured",
         className,
@@ -318,12 +361,9 @@ export default function ReviewCard({
           </div>
 
           {showRatingBadge || headerActions ? (
-            <div className="flex shrink-0 items-center gap-2">
-              {showRatingBadge ? (
-                <div className="inline-flex h-6 items-center gap-1.5 whitespace-nowrap rounded-full bg-background/38 px-2 text-[11px] font-medium tabular-nums text-foreground/92 shadow-[inset_0_1px_0_rgba(255,255,255,0.045)] md:bg-background/28">
-                  <Star className="size-3.5 fill-current text-amber-300" />
-                  {review.rating.toFixed(1)}
-                </div>
+            <div className="flex shrink-0 items-center gap-3 pr-1">
+              {showRatingBadge && !isCoverLedEntity ? (
+                <ReviewRatingStars rating={review.rating} className="hidden sm:flex" />
               ) : null}
               {headerActions ? (
                 <div data-prevent-review-link="true" className="relative z-[2] flex items-center">
@@ -335,33 +375,40 @@ export default function ReviewCard({
         </div>
 
         {isCoverLedEntity ? (
-          <div
-            className={cn(
-              "grid grid-cols-[5.75rem_minmax(0,1fr)] items-start gap-3.5 sm:grid-cols-[7.25rem_minmax(0,1fr)] lg:grid-cols-[7.75rem_minmax(0,1fr)] lg:gap-4",
-              featured && "grid-cols-[6.25rem_minmax(0,1fr)] sm:grid-cols-[8rem_minmax(0,1fr)] lg:grid-cols-[8.5rem_minmax(0,1fr)]",
-            )}
-          >
-            <div className="min-w-0">
-              {slots?.entityCover ?? <ReviewCardEntityCover entity={entity} priority={featured} />}
+          <>
+            <div
+              className={cn(
+                "grid grid-cols-[5.75rem_minmax(0,1fr)] items-center gap-3.5 sm:grid-cols-[7.25rem_minmax(0,1fr)] lg:grid-cols-[7.75rem_minmax(0,1fr)] lg:gap-4",
+                featured && "grid-cols-[6.25rem_minmax(0,1fr)] sm:grid-cols-[8rem_minmax(0,1fr)] lg:grid-cols-[8.5rem_minmax(0,1fr)]",
+              )}
+            >
+              <div className="min-w-0">
+                {slots?.entityCover ?? <ReviewCardEntityCover entity={entity} priority={featured} />}
+              </div>
+
+              <div className="flex min-w-0 items-center justify-start self-center">
+                <div className={cn("min-w-0 max-w-[26rem]", usesBalancedCopy ? "space-y-2.5" : "space-y-3")}>
+                  {slots?.entity ?? (
+                    <ReviewCardEntitySummary
+                      entity={entity}
+                      mode="cover"
+                      tone={copyTone}
+                      headingLevel={entityHeadingLevel}
+                    />
+                  )}
+                  {showRatingBadge ? (
+                    <ReviewRatingStars rating={review.rating} className="mt-2" />
+                  ) : null}
+                </div>
+              </div>
             </div>
 
-            <div className={cn("min-w-0 self-start", usesBalancedCopy ? "space-y-2.5" : "space-y-3")}>
-              {slots?.entity ?? (
-                <ReviewCardEntitySummary
-                  entity={entity}
-                  mode="cover"
-                  tone={copyTone}
-                  headingLevel={entityHeadingLevel}
-                />
-              )}
-
+            <div className={cn("space-y-2", usesBalancedCopy ? "pt-0.5" : "pt-1")}>
               {hasTitle ? (
                 <h3
                   className={cn(
-                    "text-foreground/92",
-                    usesBalancedCopy
-                      ? "text-[0.9rem] font-medium leading-5 sm:text-[0.95rem]"
-                      : "text-[0.94rem] font-medium leading-5 sm:text-[0.98rem]",
+                    "font-serif text-pretty font-semibold leading-tight text-foreground",
+                    usesBalancedCopy ? "text-[1.02rem] sm:text-[1.12rem]" : "text-[1.12rem] sm:text-[1.24rem]",
                   )}
                 >
                   {review.title}
@@ -373,17 +420,17 @@ export default function ReviewCard({
                   body={review.body}
                   clampLines={bodyClampLines}
                   className={cn(
-                    "font-serif text-pretty text-foreground/86",
+                    "font-sans text-pretty text-foreground/84",
                     usesBalancedCopy
-                      ? "text-[14.5px] leading-[1.68] sm:text-[14.95px]"
-                      : "text-[14.8px] leading-[1.64] sm:text-[15.1px]",
+                      ? "text-[14px] leading-[1.62] sm:text-[14.45px]"
+                      : "text-[14.35px] leading-[1.6] sm:text-[14.8px]",
                   )}
                 />
               ) : (
                 <p className="text-[13.5px] leading-6 text-muted-foreground/78">Only a rating was left for this track.</p>
               )}
             </div>
-          </div>
+          </>
         ) : (
           <>
             {showEntity ? slots?.entity ?? <ReviewCardEntitySummary entity={entity} mode={entityMode} /> : null}
@@ -398,7 +445,7 @@ export default function ReviewCard({
               <ReviewCardBody
                 body={review.body}
                 clampLines={bodyClampLines}
-                className="font-serif text-[14.95px] leading-[1.64] text-pretty text-foreground/84"
+                className="font-sans text-[14.45px] leading-[1.6] text-pretty text-foreground/84"
               />
             ) : (
               <p className="text-sm text-muted-foreground/78">Only a rating was left for this track.</p>
@@ -409,7 +456,7 @@ export default function ReviewCard({
         {footer ? (
           <div
             data-prevent-review-link="true"
-            className="relative z-[2] flex items-center justify-between gap-3 pt-0.5"
+            className="relative z-[2] flex w-full items-center gap-3 pt-0.5"
           >
             {footer}
           </div>

--- a/apps/web/components/review-route-cards.tsx
+++ b/apps/web/components/review-route-cards.tsx
@@ -308,7 +308,7 @@ function RoutedReviewCard({
   return (
     <ContextMenu>
       <ContextMenuTrigger asChild>
-        <div className="h-full">{card}</div>
+        <div className="kocteau-review-card-frame h-full">{card}</div>
       </ContextMenuTrigger>
       <ReviewCardContextMenu
         reviewId={review.id}


### PR DESCRIPTION
## What changed

- Refined review cards into a flatter editorial layout.
- Replaced the circular rating badge with responsive white rating stars under the track artist.
- Updated compose rating stars to use white fills without button-like backgrounds.
- Added flat 2D separators between review cards.
- Kept review actions compact inside a soft pill surface.

## Why

The review card experiment looked stronger without a heavy card container, but the circular rating competed visually with the track metadata. Moving the rating into a small star row keeps the card more music-native and easier to scan.

## Testing

- [ ] Ran `pnpm check`
- [ ] Added screenshots or a short recording for visible web UI changes
- [x] Confirmed this does not touch auth, Supabase, recommendations, analytics, CI, or release behavior

Also ran:

```text
pnpm --filter web lint
pnpm --filter web build
git diff --check
```

## Changelog impact

No manual `CHANGELOG.md` edit is required. Release Please generates release notes from PR titles and squash commits.

- [x] User-facing web change
- [ ] Developer experience or documentation change
- [ ] Internal-only change

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refined review cards into a flatter editorial layout with white star ratings and subtle separators to improve scan-ability and reduce visual weight.

- **New Features**
  - Added `.kocteau-review-card-editorial` to remove card chrome and introduce 1px separators between cards.
  - Replaced the circular rating badge with a compact white star row:
    - Shown under the artist for cover-led entities; in the header for others (hidden on small screens).
  - Simplified `RatingStars` to transparent controls with white fills and a soft glow; ARIA labels preserved.
  - Made the interaction bar a compact rounded pill.
  - Introduced `.kocteau-review-card-frame` and `.kocteau-review-card-list-item` wrappers to enable separators in lists and context menus.
  - Tuned typography and spacing (serif titles, sans body, tighter sizes/leading).

<sup>Written for commit 746f72b069597d73055b8c966bc6f6556adcbee4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/francozeta/kocteau/pull/98?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Display rating stars on review cards with numeric ratings.

* **Style**
  * Improved visual styling and spacing throughout review cards.
  * Enhanced interaction bar with refined rounded background appearance.
  * Optimized review card layout and presentation for better visual hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->