### PR TITLE
feat(web): tune track recommendations

### DIFF
--- a/apps/web/lib/deezer-candidate-source.ts
+++ b/apps/web/lib/deezer-candidate-source.ts
@@ -8,12 +8,14 @@ import {
   type DeezerArtistResult,
   type DeezerTrackResult,
 } from "@/lib/deezer";
-import type { StarterCandidateSource } from "@/lib/starter/candidates";
 
-export type DeezerCandidateSeedArtist = Pick<
+export type DeezerCandidateContextArtist = Pick<
   DeezerArtistResult,
   "id" | "name" | "fan_count"
 >;
+export type DeezerCandidateSourceMode = "related" | "related-seed" | "deep-cut";
+
+type DeezerCandidateSeedArtist = DeezerCandidateContextArtist;
 
 function dedupeArtists(artists: DeezerArtistResult[]) {
   const seenArtistIds = new Set<string>();
@@ -136,15 +138,19 @@ export async function getCandidateSourceTracks({
   query,
   limit,
   seedArtist,
+  contextArtist,
 }: {
-  mode: StarterCandidateSource;
+  mode: DeezerCandidateSourceMode;
   query: string;
   limit: number;
   seedArtist?: DeezerCandidateSeedArtist | null;
+  contextArtist?: DeezerCandidateContextArtist | null;
 }) {
+  const candidateArtist = contextArtist ?? seedArtist;
+
   if (mode === "deep-cut") {
-    return getDeepCutTracks({ query, limit, seedArtist });
+    return getDeepCutTracks({ query, limit, seedArtist: candidateArtist });
   }
 
-  return getRelatedSeedTracks({ query, limit, seedArtist });
+  return getRelatedSeedTracks({ query, limit, seedArtist: candidateArtist });
 }

--- a/apps/web/lib/queries/track-recommendations.ts
+++ b/apps/web/lib/queries/track-recommendations.ts
@@ -2,7 +2,7 @@ import "server-only";
 
 import {
   getCandidateSourceTracks,
-  type DeezerCandidateSeedArtist,
+  type DeezerCandidateContextArtist,
 } from "@/lib/deezer-candidate-source";
 import {
   getDeezerErrorDetails,
@@ -10,15 +10,13 @@ import {
   type DeezerTrackResult,
 } from "@/lib/deezer";
 import { measureServerTask } from "@/lib/perf";
-import { getPublicStarterTracks } from "@/lib/queries/starter";
 import type { EntityTasteTag } from "@/lib/queries/entities";
 import {
-  getTrackRecommendationSeedLabel,
+  getTrackRecommendationQueryLabel,
   selectTrackRecommendationGroups,
   type TrackRecommendationCandidate,
   type TrackRecommendationGroup,
 } from "@/lib/recommendations/track-recommendation-ranking";
-import { buildStarterCandidateTracks } from "@/lib/starter/candidates";
 import { supabasePublic } from "@/lib/supabase/public";
 import { buildEntityCanonicalPath } from "@/lib/seo-routes";
 
@@ -64,7 +62,9 @@ type TrackRecommendationOptions = {
 
 const defaultRecommendationLimit = 18;
 
-function getSeedArtistFromTrack(track: DeezerTrackResult | null): DeezerCandidateSeedArtist | null {
+function getContextArtistFromTrack(
+  track: DeezerTrackResult | null,
+): DeezerCandidateContextArtist | null {
   if (!track?.artist_id || !track.artist_name) {
     return null;
   }
@@ -84,6 +84,71 @@ function getSignalMatchReason(labels: string[]) {
   }
 
   return `Also tagged ${primaryLabel.toLowerCase()}.`;
+}
+
+function getNumber(value: number | null | undefined) {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function isObviousCatalogCandidate(track: DeezerTrackResult) {
+  const rank = getNumber(track.rank);
+  const fanCount = getNumber(track.artist_fan_count);
+
+  return rank !== null && fanCount !== null && rank >= 900_000 && fanCount >= 750_000;
+}
+
+function getDeezerCandidateScore(track: DeezerTrackResult) {
+  const rank = getNumber(track.rank);
+  const fanCount = getNumber(track.artist_fan_count);
+  let score = 50;
+
+  if (fanCount !== null) {
+    if (fanCount <= 25_000) {
+      score += 18;
+    } else if (fanCount <= 250_000) {
+      score += 10;
+    } else if (fanCount >= 1_000_000) {
+      score -= 18;
+    }
+  }
+
+  if (rank !== null) {
+    if (rank <= 150_000) {
+      score += 8;
+    } else if (rank >= 750_000) {
+      score -= 14;
+    }
+  }
+
+  return score;
+}
+
+function getDeezerCandidateReason(track: DeezerTrackResult) {
+  const fanCount = getNumber(track.artist_fan_count);
+
+  if (fanCount !== null && fanCount <= 250_000) {
+    return "Nearby track with a quieter artist profile.";
+  }
+
+  return "Nearby track outside the obvious lane.";
+}
+
+function mapDeezerRelatedCandidate(track: DeezerTrackResult): TrackRecommendationCandidate {
+  return {
+    id: `deezer-related:${track.provider_id}`,
+    provider: "deezer",
+    provider_id: track.provider_id,
+    type: "track",
+    title: track.title,
+    artist_name: track.artist_name,
+    cover_url: track.cover_url,
+    deezer_url: track.deezer_url,
+    href: `/track/deezer/${track.provider_id}`,
+    reason: getDeezerCandidateReason(track),
+    source: "deezer-related",
+    sourceLabel: "Nearby",
+    score: getDeezerCandidateScore(track),
+  };
 }
 
 async function getLocalSignalCandidates({
@@ -200,95 +265,37 @@ async function getLocalSignalCandidates({
     }));
 }
 
-function mapDeezerCandidate({
-  candidate,
-  sourceLabel,
-}: {
-  candidate: ReturnType<typeof buildStarterCandidateTracks>[number];
-  sourceLabel: string;
-}): TrackRecommendationCandidate {
-  return {
-    id: candidate.candidate_id,
-    provider: "deezer",
-    provider_id: candidate.provider_id,
-    type: "track",
-    title: candidate.title,
-    artist_name: candidate.artist_name,
-    cover_url: candidate.cover_url,
-    deezer_url: candidate.deezer_url,
-    href: `/track/deezer/${candidate.provider_id}`,
-    reason: candidate.reason,
-    source: "related-seed",
-    sourceLabel,
-    score: candidate.score,
-  };
-}
-
 async function getDeezerCandidateRecommendations({
   currentProviderId,
   query,
   limit,
-  seedArtist,
+  contextArtist,
 }: {
   currentProviderId: string;
   query: string;
   limit: number;
-  seedArtist: DeezerCandidateSeedArtist | null;
+  contextArtist: DeezerCandidateContextArtist | null;
 }) {
   const sourceTracks = await getCandidateSourceTracks({
-    mode: "related-seed",
+    mode: "related",
     query,
     limit: Math.max(limit * 3, 12),
-    seedArtist,
+    contextArtist,
   });
-  const candidates = buildStarterCandidateTracks({
-    source: "related-seed",
-    seedLabel: sourceTracks.seedLabel,
-    tracks: sourceTracks.tracks,
-    existingProviderIds: new Set([currentProviderId]),
-    limit: Math.max(limit * 2, 12),
-  });
+  const seenProviderIds = new Set([currentProviderId]);
 
-  return candidates.map((candidate) =>
-    mapDeezerCandidate({
-      candidate,
-      sourceLabel: "Related",
-    }),
-  );
-}
+  return sourceTracks.tracks
+    .filter((track) => {
+      if (seenProviderIds.has(track.provider_id)) {
+        return false;
+      }
 
-async function getEditorialFallbackCandidates({
-  currentEntityId,
-  currentProviderId,
-  limit,
-}: {
-  currentEntityId?: string | null;
-  currentProviderId: string;
-  limit: number;
-}) {
-  const tracks = await getPublicStarterTracks({
-    limit: Math.max(limit * 2, 8),
-    seed: currentEntityId ?? currentProviderId,
-    contextKey: `track:${currentEntityId ?? currentProviderId}`,
-  });
-
-  return tracks
-    .filter((track) => track.provider_id !== currentProviderId)
-    .map((track) => ({
-      id: track.id,
-      provider: "deezer" as const,
-      provider_id: track.provider_id,
-      type: "track" as const,
-      title: track.title,
-      artist_name: track.artist_name,
-      cover_url: track.cover_url,
-      deezer_url: track.deezer_url,
-      href: `/track/deezer/${track.provider_id}`,
-      reason: "A curated starter pick from Kocteau.",
-      source: "editorial-fallback" as const,
-      sourceLabel: "Curated",
-      score: track.score,
-    }));
+      seenProviderIds.add(track.provider_id);
+      return !isObviousCatalogCandidate(track);
+    })
+    .map(mapDeezerRelatedCandidate)
+    .sort((left, right) => right.score - left.score)
+    .slice(0, Math.max(limit * 2, 12));
 }
 
 async function resolveRecommendationLinks(groups: TrackRecommendationGroup[]) {
@@ -354,7 +361,7 @@ export async function getTrackRecommendations({
     "getTrackRecommendations",
     async () => {
       const requestedLimit = Math.max(1, Math.min(limit, 24));
-      const [seedTrack, localSignalCandidates] = await Promise.all([
+      const [catalogTrack, localSignalCandidates] = await Promise.all([
         getDeezerTrack(currentProviderId).catch(() => null),
         getLocalSignalCandidates({
           currentEntityId,
@@ -363,38 +370,29 @@ export async function getTrackRecommendations({
           limit: requestedLimit,
         }),
       ]);
-      const seedArtist = getSeedArtistFromTrack(seedTrack);
-      const seedLabel = getTrackRecommendationSeedLabel({
+      const contextArtist = getContextArtistFromTrack(catalogTrack);
+      const queryLabel = getTrackRecommendationQueryLabel({
         title,
-        artistName: seedArtist?.name ?? artistName,
+        artistName: contextArtist?.name ?? artistName,
       });
-      const [relatedCandidates, editorialFallbackCandidates] =
-        await Promise.all([
-          getDeezerCandidateRecommendations({
-            currentProviderId,
-            query: seedLabel,
-            limit: requestedLimit,
-            seedArtist,
-          }).catch((error) => {
-            console.warn("[track-recommendations.deezer] using editorial fallback", {
-              currentProviderId,
-              ...getDeezerErrorDetails(error),
-            });
+      const relatedCandidates = await getDeezerCandidateRecommendations({
+        currentProviderId,
+        query: queryLabel,
+        limit: requestedLimit,
+        contextArtist,
+      }).catch((error) => {
+        console.warn("[track-recommendations.deezer] skipped related candidates", {
+          currentProviderId,
+          ...getDeezerErrorDetails(error),
+        });
 
-            return [];
-          }),
-          getEditorialFallbackCandidates({
-            currentEntityId,
-            currentProviderId,
-            limit: requestedLimit,
-          }),
-        ]);
+        return [];
+      });
 
       const groups = selectTrackRecommendationGroups({
         currentProviderId,
         relatedCandidates,
         localSignalCandidates,
-        editorialFallbackCandidates,
         perGroupLimit: requestedLimit,
       });
 

--- a/apps/web/lib/recommendations/track-recommendation-ranking.test.ts
+++ b/apps/web/lib/recommendations/track-recommendation-ranking.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import {
-  getTrackRecommendationSeedLabel,
+  getTrackRecommendationQueryLabel,
   selectTrackRecommendationGroups,
   type TrackRecommendationCandidate,
 } from "./track-recommendation-ranking.ts";
@@ -11,6 +11,8 @@ function candidate(
   providerId: string,
   source: TrackRecommendationCandidate["source"],
   href = `/track/deezer/${providerId}`,
+  artistName = "Nearby Artist",
+  score = 50,
 ): TrackRecommendationCandidate {
   return {
     id: `${source}-${providerId}`,
@@ -18,21 +20,21 @@ function candidate(
     provider_id: providerId,
     type: "track",
     title: `Track ${providerId}`,
-    artist_name: "Seed Artist",
+    artist_name: artistName,
     cover_url: null,
     deezer_url: null,
     href,
     reason: "Related lane, quieter profile.",
     source,
-    sourceLabel: source === "editorial-fallback" ? "Curated" : "Related",
-    score: 50,
+    sourceLabel: source === "local-signal" ? "Kocteau signal" : "Nearby",
+    score,
   };
 }
 
 describe("track recommendation ranking", () => {
-  it("uses the artist name as the Deezer seed label when available", () => {
+  it("uses the artist name as the Deezer query label when available", () => {
     assert.equal(
-      getTrackRecommendationSeedLabel({
+      getTrackRecommendationQueryLabel({
         title: "The Cure",
         artistName: "Olivia Rodrigo",
       }),
@@ -44,14 +46,13 @@ describe("track recommendation ranking", () => {
     const groups = selectTrackRecommendationGroups({
       currentProviderId: "current",
       relatedCandidates: [
-        candidate("current", "related-seed"),
-        candidate("same", "related-seed"),
+        candidate("current", "deezer-related"),
+        candidate("same", "deezer-related"),
       ],
       localSignalCandidates: [
         candidate("same", "local-signal", "/track/local-entity"),
         candidate("local-only", "local-signal", "/track/local-only"),
       ],
-      editorialFallbackCandidates: [],
       perGroupLimit: 6,
     });
 
@@ -64,36 +65,33 @@ describe("track recommendation ranking", () => {
     );
   });
 
-  it("uses editorial fallback when related candidates are empty", () => {
-    const fallbackGroups = selectTrackRecommendationGroups({
+  it("does not fill track recommendations with editorial fallbacks", () => {
+    const groups = selectTrackRecommendationGroups({
       currentProviderId: "current",
       relatedCandidates: [],
       localSignalCandidates: [],
-      editorialFallbackCandidates: [candidate("fallback", "editorial-fallback")],
       perGroupLimit: 6,
     });
 
-    assert.equal(fallbackGroups.length, 1);
-    assert.equal(fallbackGroups[0]?.id, "fallback");
-    assert.deepEqual(
-      fallbackGroups.flatMap((group) =>
-        group.recommendations.map((track) => track.provider_id),
-      ),
-      ["fallback"],
-    );
+    assert.deepEqual(groups, []);
+  });
 
-    const candidateGroups = selectTrackRecommendationGroups({
+  it("keeps related candidates diverse before filling repeated artists", () => {
+    const groups = selectTrackRecommendationGroups({
       currentProviderId: "current",
-      relatedCandidates: [candidate("related", "related-seed")],
+      relatedCandidates: [
+        candidate("same-1", "deezer-related", "/track/deezer/same-1", "Same Artist", 100),
+        candidate("same-2", "deezer-related", "/track/deezer/same-2", "Same Artist", 95),
+        candidate("same-3", "deezer-related", "/track/deezer/same-3", "Same Artist", 90),
+        candidate("other-1", "deezer-related", "/track/deezer/other-1", "Other Artist", 70),
+      ],
       localSignalCandidates: [],
-      editorialFallbackCandidates: [candidate("fallback", "editorial-fallback")],
-      perGroupLimit: 6,
+      perGroupLimit: 3,
     });
 
-    assert.deepEqual(candidateGroups.map((group) => group.id), ["related"]);
     assert.deepEqual(
-      candidateGroups.flatMap((group) => group.recommendations.map((track) => track.provider_id)),
-      ["related"],
+      groups.flatMap((group) => group.recommendations.map((track) => track.provider_id)),
+      ["same-1", "same-2", "other-1"],
     );
   });
 });

--- a/apps/web/lib/recommendations/track-recommendation-ranking.ts
+++ b/apps/web/lib/recommendations/track-recommendation-ranking.ts
@@ -1,7 +1,4 @@
-export type TrackRecommendationSource =
-  | "local-signal"
-  | "related-seed"
-  | "editorial-fallback";
+export type TrackRecommendationSource = "local-signal" | "deezer-related";
 
 export type TrackRecommendationCandidate = {
   id: string;
@@ -20,7 +17,7 @@ export type TrackRecommendationCandidate = {
 };
 
 export type TrackRecommendationGroup = {
-  id: "related" | "fallback";
+  id: "related";
   label: string;
   description: string;
   recommendations: TrackRecommendationCandidate[];
@@ -30,17 +27,20 @@ type SelectTrackRecommendationGroupsOptions = {
   currentProviderId: string;
   relatedCandidates: TrackRecommendationCandidate[];
   localSignalCandidates: TrackRecommendationCandidate[];
-  editorialFallbackCandidates: TrackRecommendationCandidate[];
   perGroupLimit?: number;
 };
 
 const sourcePriority: Record<TrackRecommendationSource, number> = {
   "local-signal": 4,
-  "related-seed": 3,
-  "editorial-fallback": 1,
+  "deezer-related": 3,
 };
 
-export function getTrackRecommendationSeedLabel({
+const sourceScoreBonus: Record<TrackRecommendationSource, number> = {
+  "local-signal": 18,
+  "deezer-related": 10,
+};
+
+export function getTrackRecommendationQueryLabel({
   title,
   artistName,
 }: {
@@ -54,6 +54,57 @@ export function getTrackRecommendationSeedLabel({
 
 function getCandidateKey(candidate: TrackRecommendationCandidate) {
   return `${candidate.provider}:${candidate.type}:${candidate.provider_id}`;
+}
+
+function getArtistKey(candidate: TrackRecommendationCandidate) {
+  return candidate.artist_name?.trim().toLowerCase() || "unknown";
+}
+
+function getStableExplorationBonus(
+  candidate: TrackRecommendationCandidate,
+  currentProviderId: string,
+) {
+  const key = `${currentProviderId}:${candidate.provider_id}`;
+  let hash = 0;
+
+  for (let index = 0; index < key.length; index += 1) {
+    hash = (hash * 31 + key.charCodeAt(index)) % 997;
+  }
+
+  return (hash % 13) / 2;
+}
+
+function getExperimentalScore(candidate: TrackRecommendationCandidate, currentProviderId: string) {
+  return (
+    candidate.score +
+    sourceScoreBonus[candidate.source] +
+    getStableExplorationBonus(candidate, currentProviderId)
+  );
+}
+
+function diversifyByArtist(
+  candidates: TrackRecommendationCandidate[],
+  limit: number,
+) {
+  const selected: TrackRecommendationCandidate[] = [];
+  const deferred: TrackRecommendationCandidate[] = [];
+  const artistCounts = new Map<string, number>();
+  const softArtistLimit = 2;
+
+  candidates.forEach((candidate) => {
+    const artistKey = getArtistKey(candidate);
+    const artistCount = artistCounts.get(artistKey) ?? 0;
+
+    if (artistCount < softArtistLimit) {
+      selected.push(candidate);
+      artistCounts.set(artistKey, artistCount + 1);
+      return;
+    }
+
+    deferred.push(candidate);
+  });
+
+  return [...selected, ...deferred].slice(0, limit);
 }
 
 function selectCandidates({
@@ -89,24 +140,25 @@ function selectCandidates({
       }
     });
 
-  return Array.from(bestByKey.values())
-    .sort((left, right) => {
-      const priorityDelta = sourcePriority[right.source] - sourcePriority[left.source];
+  const ranked = Array.from(bestByKey.values()).sort((left, right) => {
+    const scoreDelta =
+      getExperimentalScore(right, currentProviderId) -
+      getExperimentalScore(left, currentProviderId);
 
-      if (priorityDelta !== 0) {
-        return priorityDelta;
-      }
+    if (scoreDelta !== 0) {
+      return scoreDelta;
+    }
 
-      return right.score - left.score;
-    })
-    .slice(0, limit);
+    return sourcePriority[right.source] - sourcePriority[left.source];
+  });
+
+  return diversifyByArtist(ranked, limit);
 }
 
 export function selectTrackRecommendationGroups({
   currentProviderId,
   relatedCandidates,
   localSignalCandidates,
-  editorialFallbackCandidates,
   perGroupLimit = 6,
 }: SelectTrackRecommendationGroupsOptions): TrackRecommendationGroup[] {
   const limit = Math.max(1, Math.min(perGroupLimit, 24));
@@ -117,22 +169,7 @@ export function selectTrackRecommendationGroups({
   });
 
   if (related.length === 0) {
-    const fallback = selectCandidates({
-      candidates: editorialFallbackCandidates,
-      currentProviderId,
-      limit,
-    });
-
-    return fallback.length > 0
-      ? [
-          {
-            id: "fallback",
-            label: "Curated starters",
-            description: "Editorial picks while this track gathers signals.",
-            recommendations: fallback,
-          },
-        ]
-      : [];
+    return [];
   }
 
   const groups: Array<TrackRecommendationGroup | null> = [


### PR DESCRIPTION
## What changed

- Removed Starter Picks as the fallback source for track page “More like this”.
- Decoupled track recommendations from the starter candidate ranking helper.
- Added a dedicated Deezer-related recommendation source for track pages.
- Added experimental scoring and soft artist diversity so recommendations feel less predictable.

## Why

Track pages should not recycle the same small Starter Picks catalog. This keeps Starter Picks in editorial rails/surfaces while letting track pages recommend nearby music through local Kocteau signals and filtered Deezer candidates.

## Testing

- [ ] Ran `pnpm check`
- [ ] Added screenshots or a short recording for visible web UI changes
- [ ] Confirmed this does not touch auth, Supabase, recommendations, analytics, CI, or release behavior

Ran instead:
- `node --test apps/web/lib/recommendations/track-recommendation-ranking.test.ts`
- `pnpm --filter web lint`
- `git diff --check`
- `pnpm --filter web build`

This PR intentionally touches recommendation behavior.

## Changelog impact

No manual `CHANGELOG.md` edit is required. Release Please generates release notes from PR titles and squash commits.

- [x] User-facing web change
- [ ] Developer experience or documentation change
- [ ] Internal-only change

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tune “More like this” on track pages to use Deezer-related candidates instead of Starter Picks, with new scoring and soft artist diversity for fresher, less predictable results.

- **New Features**
  - Added a `deezer-related` source with context-artist support and “Nearby” labeling.
  - New scoring blends Deezer rank, artist fan count, and a stable exploration bonus.
  - Filters out obvious catalog tracks; favors quieter profiles where relevant.
  - Soft artist diversity (max ~2 per artist before repeats) to keep results varied.

- **Refactors**
  - Removed Starter Picks fallback and decoupled from starter candidate helpers.
  - Replaced seed label with `getTrackRecommendationQueryLabel` and “context artist” types.
  - Simplified groups to a single “related” group; no editorial fallback when empty.
  - Updated tests and selection logic to prioritize local signals and new related scoring.

<sup>Written for commit 42f26e6fb97812dd8f09b90763a39753ad61e583. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/francozeta/kocteau/pull/101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Refactor**
* Refactored track recommendation system to improve artist diversity in recommendations.
* Enhanced candidate scoring and filtering logic for better recommendation quality.
* Updated recommendation source management and selection pipeline.

**Tests**
* Updated recommendation system test suite to align with behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->