### PR TITLE
fix(web): align track recommendation carousel

### DIFF
--- a/apps/web/components/track-more-to-hear.tsx
+++ b/apps/web/components/track-more-to-hear.tsx
@@ -56,10 +56,8 @@ export default function TrackMoreToHear({
         ariaLabel="More like this"
         compactControls
         contentClassName="gap-3.5"
-        controlClassName="opacity-100 [--kocteau-carousel-cover-size:7.05rem]"
-        fadeClassName="kocteau-carousel-mask-r-from-tight"
-        itemClassName="basis-[7.05rem] sm:basis-[7.45rem] md:basis-[7.75rem]"
-        viewportClassName="-mr-3 pr-3"
+        controlClassName="left-2 right-2 [--kocteau-carousel-cover-size:8.05rem] lg:[--kocteau-carousel-cover-size:8.25rem]"
+        itemClassName="basis-[8.05rem] sm:basis-[8.35rem] lg:basis-[8.25rem]"
       >
         {recommendations.map((recommendation) => (
           <RecommendationTile


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Aligns the track recommendation carousel across breakpoints by increasing cover size, sizing tiles consistently, and positioning controls with equal left/right offsets. Removes the fade mask and viewport padding that caused clipping and misalignment.

<sup>Written for commit e762340c24899e82c98907d62b07fe9ce602bd6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/francozeta/kocteau/pull/104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

