### PR TITLE
feat(supabase): add entity curation copilot workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,11 @@ packages/*/.env.*.local
 supabase/.temp/
 supabase/.branches/
 
+# Local agent tooling
+.agents/
+skills-lock.json
+my-agent/
+
 # Vercel
 .vercel/
 apps/*/.vercel/

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@
 
 - [Release automation](./maintainers/release.md): Release Please, changelog flow, and release smoke checks.
 - [Supabase maintainer workflow](./maintainers/supabase-workflow.md): versioned Supabase Cloud migration flow for maintainers.
+- [Eve curation copilot](./maintainers/eve-curation-copilot.md): local-only assisted entity tagging with human review.
 - [GitHub rules](./maintainers/github-rules.md): repository settings, branch protection, labels, and Actions permissions.
 
 ## Interface Craft
@@ -36,4 +37,4 @@
 - New contributor: read [CONTRIBUTING.md](../CONTRIBUTING.md), then [local development](./setup/local-development.md), then [public backlog](./backlog.md).
 - Product/design contributor: read [MVP baseline](./mvp.md), [web roadmap](./web-roadmap.md), and [interface craft rules](./ai/interface-craft-rules.md).
 - Recommendation or analytics contributor: read [discovery and curation](./discovery-curation.md), [operations](./operations.md), and the sensitive-system notes in [public backlog](./backlog.md).
-- Maintainer: read [operations](./operations.md), [Supabase maintainer workflow](./maintainers/supabase-workflow.md), [release automation](./maintainers/release.md), and [GitHub rules](./maintainers/github-rules.md).
+- Maintainer: read [operations](./operations.md), [Supabase maintainer workflow](./maintainers/supabase-workflow.md), [Eve curation copilot](./maintainers/eve-curation-copilot.md), [release automation](./maintainers/release.md), and [GitHub rules](./maintainers/github-rules.md).

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -100,6 +100,7 @@ This plan makes Kocteau learn from human taste without requiring an AI provider 
 | 3 | Add collection tags and intent labels so grouped tracks have explainable meaning. | blocked | `feature`, `area:recommendations`, `area:supabase` |
 | 4 | Derive track relationships from repeated co-curation, reviews, and collection meaning. | blocked | `feature`, `area:recommendations`, `needs maintainer decision` |
 | 5 | Show `Why this?` explanations only when backed by real product signals. | blocked | `feature`, `area:web`, `area:recommendations`, `area:analytics` |
+| 6 | Add a local-only Eve curation copilot for entity tags and metadata drafts. | in progress | `feature`, `area:recommendations`, `area:supabase`, `area:maintenance` |
 
 Acceptance criteria for the loop:
 
@@ -108,6 +109,7 @@ Acceptance criteria for the loop:
 - Recommendation logic can read collection membership without treating every collection as equal.
 - Known artists remain allowed, but weak popularity-only signals should not dominate discovery.
 - Any future AI step drafts metadata or explanations for human review instead of writing directly to production recommendation tables.
+- Eve-assisted curation stays local-only until usage limits, approvals, and Studio UX are proven.
 
 ## Ready for First Contributors
 

--- a/docs/discovery-curation.md
+++ b/docs/discovery-curation.md
@@ -397,7 +397,8 @@ The first implementation should stay simple:
 The AI posture is future-ready, not AI-dependent:
 
 - Today, Kocteau can use SQL, tags, reviews, saves, follows, and collections.
-- Later, an AI service can summarize collection intent, propose tags, or draft explanation copy.
+- Eve or another AI assistant can summarize collection intent, propose tags, score mainstream/discovery fit, or draft explanation copy.
+- The first AI-assisted implementation should stay local-only: export safe entity data, draft suggestions, require maintainer review, then apply SQL manually.
 - AI should never write directly to production recommendation tables without maintainer review.
 - User-facing explanations should cite product signals, not hidden model confidence.
 

--- a/docs/maintainers/eve-curation-copilot.md
+++ b/docs/maintainers/eve-curation-copilot.md
@@ -1,0 +1,114 @@
+# Eve Curation Copilot
+
+[Docs index](../README.md) | [Discovery and curation](../discovery-curation.md) | [Operations](../operations.md) | [Supabase workflow](./supabase-workflow.md)
+
+Kocteau can use Eve as a local curation copilot without giving an agent direct production write access.
+
+The current workflow is intentionally conservative:
+
+```text
+Supabase export -> Eve draft -> maintainer review -> SQL Editor patch
+```
+
+Eve can help draft tags, mainstream/discovery scores, and short maintainer notes. Kocteau still keeps human review as the final publishing step.
+
+The export only includes entities with a real Kocteau curation signal: review activity, library intent, bookmark intent, starter context, or manual tags. A recently created track is not enough by itself. This keeps troll, novelty, or meme-only searches from entering the curation packet unless a human action gives them context.
+
+## Hobby Guardrails
+
+- Do not deploy this as a production Eve agent yet.
+- Do not run it from cron or background workflows.
+- Do not let it call Supabase with service-role credentials.
+- Do not auto-purchase AI Gateway credits or enable automatic top-ups.
+- Keep generated files under `tmp/`; they should not be committed.
+- Run small batches first, such as 10-20 entities.
+
+This keeps the workflow useful on a Vercel Hobby account and avoids another unexpected usage spike.
+
+## Entity Curation Flow
+
+1. Run the read-only export in the Supabase SQL Editor:
+
+```sql
+-- supabase/scripts/maintenance/entity-curation-draft-export.sql
+```
+
+2. Copy the JSON value from `entity_curation_export` into:
+
+```text
+tmp/entity-curation-export.json
+```
+
+3. Generate the curation packet:
+
+```bash
+pnpm curate:entity:draft -- --limit 20
+```
+
+This writes:
+
+```text
+tmp/entity-curation/draft-input.json
+tmp/entity-curation/draft-prompt.md
+tmp/entity-curation/draft-output-template.json
+```
+
+4. Give `draft-prompt.md` and the output template to Eve.
+
+Eve should return JSON only, using the template shape. The draft may include:
+
+- non-genre tag slugs for `mood`, `scene`, `style`, `era`, and `format`
+- genre candidates for human review
+- `mainstreamScore`
+- `discoveryFitScore`
+- confidence
+- a short maintainer-facing curation note
+
+5. Review the output manually.
+
+Save the reviewed JSON as:
+
+```text
+tmp/entity-curation/draft-output.json
+```
+
+Set:
+
+```json
+{
+  "humanReviewed": true,
+  "reviewedBy": "francozeta"
+}
+```
+
+6. Generate the SQL patch:
+
+```bash
+pnpm curate:entity:sql
+```
+
+This writes:
+
+```text
+tmp/entity-curation/apply-entity-curation-drafts.sql
+tmp/entity-curation/genre-candidates-for-review.md
+tmp/entity-curation/curation-review-report.md
+```
+
+7. Read the report, then run the SQL patch in the Supabase SQL Editor.
+
+The SQL inserts only non-genre tags into `entity_preference_tags`. It preserves existing `manual` tags and refuses unknown entity IDs or tag slugs.
+
+The applied database source is `system`, because `entity_preference_tags.source` currently accepts only `manual`, `import`, `inferred`, or `system`. Keep the Eve provenance in the review report and maintainer workflow rather than widening that database constraint before the Studio UX is proven.
+
+## Future Studio Direction
+
+The long-term UI should feel like a curation desk, not an admin grid:
+
+1. The curator selects a song.
+2. Eve proposes tags, era, format, scores, and context.
+3. The curator accepts, edits, or dismisses the suggestions.
+4. New tags can be created from a simple client-like UI.
+5. Approved metadata becomes normal Kocteau taste data.
+
+The agent prepares the desk. The maintainer keeps taste authority.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -183,6 +183,8 @@ After reviewing and filling `tmp/starter-curation/draft-output.json`, set `human
 
 This workflow is maintainer-only tooling. Outputs in `tmp/` must stay out of Git, and `--allow-unreviewed` is only for local fixture tests. Do not run generated SQL against Supabase Cloud unless the draft has been human-reviewed.
 
+For local-only Eve-assisted entity tagging, use `supabase/scripts/maintenance/entity-curation-draft-export.sql`, copy the JSON cell into `tmp/entity-curation-export.json`, then run `pnpm curate:entity:draft`. Eve or another assistant can fill `tmp/entity-curation/draft-output-template.json`, but the maintainer must review the output, set `humanReviewed` to `true`, and run `pnpm curate:entity:sql` before applying the generated SQL in Supabase. This flow inserts only non-genre tags into `entity_preference_tags`, preserves existing manual tags, and keeps genre candidates in a separate review file. See [Eve curation copilot](./maintainers/eve-curation-copilot.md).
+
 The easiest way to seed starter picks is the internal route:
 
 ```text

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "supabase:types:linked": "node supabase/scripts/generate-types.mjs --linked",
     "curate:starter:draft": "node supabase/scripts/create-starter-curation-draft.mjs",
     "curate:starter:sql": "node supabase/scripts/create-starter-curation-apply-sql.mjs",
+    "curate:entity:draft": "node supabase/scripts/create-entity-curation-draft.mjs",
+    "curate:entity:sql": "node supabase/scripts/create-entity-curation-apply-sql.mjs",
     "import:apple-playlist": "tsx apps/web/scripts/export-apple-music-playlist.ts",
     "sync:apple-starter-source": "tsx apps/web/scripts/sync-apple-starter-source.ts",
     "build": "turbo run build",

--- a/supabase/scripts/create-entity-curation-apply-sql.mjs
+++ b/supabase/scripts/create-entity-curation-apply-sql.mjs
@@ -1,0 +1,572 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+
+const repoRoot = process.cwd();
+const args = parseArgs(process.argv.slice(2));
+const inputPath = path.resolve(repoRoot, args.input ?? "tmp/entity-curation/draft-output.json");
+const outputPath = path.resolve(
+  repoRoot,
+  args.output ?? "tmp/entity-curation/apply-entity-curation-drafts.sql",
+);
+const genreReviewPath = path.resolve(
+  repoRoot,
+  args.genreOutput ?? "tmp/entity-curation/genre-candidates-for-review.md",
+);
+const reviewReportPath = path.resolve(
+  repoRoot,
+  args.reviewOutput ?? "tmp/entity-curation/curation-review-report.md",
+);
+const tagInputPath = path.resolve(repoRoot, args.tagInput ?? "tmp/entity-curation/draft-input.json");
+const maxSignals = parsePositiveInt(args.maxSignals, 8);
+const sourceLabel = normalizeSourceLabel(args.source ?? "system");
+
+if (args.help) {
+  printHelp();
+  process.exit(0);
+}
+
+let payload;
+
+try {
+  payload = JSON.parse(await fs.readFile(inputPath, "utf8"));
+} catch (error) {
+  console.error(`Could not read ${path.relative(repoRoot, inputPath)}.`);
+  console.error("This is expected right after running `pnpm curate:entity:draft`.");
+  console.error(
+    "Fill tmp/entity-curation/draft-output-template.json with Eve's reviewed JSON, then save it as tmp/entity-curation/draft-output.json."
+  );
+  console.error("Keep humanReviewed=true and reviewedBy set before generating SQL.");
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}
+
+const drafts = normalizeDrafts(payload);
+const reviewState = normalizeReviewState(payload);
+
+if (drafts.length === 0) {
+  console.error("No drafts found. Expected a JSON object with a non-empty `drafts` array.");
+  process.exit(1);
+}
+
+let availableTags = null;
+let safetyReport;
+
+try {
+  validateHumanReview(reviewState, Boolean(args.allowUnreviewed));
+  safetyReport = validateDraftSafety(drafts, { maxSignals });
+  availableTags = await validateDraftTagSlugs(drafts, tagInputPath, Boolean(args.tagInput));
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}
+
+await fs.mkdir(path.dirname(outputPath), { recursive: true });
+await fs.writeFile(outputPath, buildApplySql(drafts, reviewState, sourceLabel), "utf8");
+await fs.writeFile(genreReviewPath, buildGenreReview(drafts, availableTags), "utf8");
+await fs.writeFile(reviewReportPath, buildReviewReport(drafts, safetyReport, sourceLabel), "utf8");
+
+console.log(`Created ${path.relative(repoRoot, outputPath)}.`);
+console.log(`Created ${path.relative(repoRoot, genreReviewPath)}.`);
+console.log(`Created ${path.relative(repoRoot, reviewReportPath)}.`);
+console.log(`Drafts included: ${drafts.length}`);
+
+function parseArgs(argv) {
+  const parsed = {};
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === "--") {
+      continue;
+    }
+
+    if (arg === "--help" || arg === "-h") {
+      parsed.help = true;
+      continue;
+    }
+
+    if (arg === "--input") {
+      parsed.input = argv[index + 1];
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--output") {
+      parsed.output = argv[index + 1];
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--genre-output") {
+      parsed.genreOutput = argv[index + 1];
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--tag-input") {
+      parsed.tagInput = argv[index + 1];
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--review-output") {
+      parsed.reviewOutput = argv[index + 1];
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--max-signals") {
+      parsed.maxSignals = argv[index + 1];
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--source") {
+      parsed.source = argv[index + 1];
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--allow-unreviewed") {
+      parsed.allowUnreviewed = true;
+    }
+  }
+
+  return parsed;
+}
+
+function printHelp() {
+  console.log(`Usage:
+  pnpm curate:entity:sql
+  pnpm curate:entity:sql -- --input tmp/entity-curation/draft-output.json
+  pnpm curate:entity:sql -- --tag-input tmp/entity-curation/draft-input.json
+  pnpm curate:entity:sql -- --source system
+  pnpm curate:entity:sql -- --allow-unreviewed
+
+Input:
+  tmp/entity-curation/draft-output.json
+
+Output:
+  tmp/entity-curation/apply-entity-curation-drafts.sql
+  tmp/entity-curation/genre-candidates-for-review.md
+  tmp/entity-curation/curation-review-report.md
+
+The generated SQL:
+  - inserts existing non-genre tags into entity_preference_tags
+  - preserves existing manual tags
+  - requires humanReviewed=true and reviewedBy unless --allow-unreviewed is passed
+  - fails when an entity id or suggested tag slug is unknown
+  - does not apply genre candidates automatically
+  - writes entity_preference_tags.source as system by default because the
+    current table constraint only allows manual, import, inferred, or system
+`);
+}
+
+function parsePositiveInt(value, fallback) {
+  const parsed = Number.parseInt(value, 10);
+
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function normalizeSourceLabel(value) {
+  const label = String(value ?? "").trim();
+  const allowedSources = new Set(["manual", "import", "inferred", "system"]);
+
+  if (!allowedSources.has(label)) {
+    throw new Error("Source must be one of: manual, import, inferred, system.");
+  }
+
+  return label;
+}
+
+function normalizeReviewState(payload) {
+  return {
+    humanReviewed: payload?.humanReviewed === true || payload?.human_reviewed === true,
+    reviewedBy: nullableString(payload?.reviewedBy ?? payload?.reviewed_by),
+    reviewedAt: nullableString(payload?.reviewedAt ?? payload?.reviewed_at),
+  };
+}
+
+function validateHumanReview(reviewState, allowUnreviewed) {
+  if (allowUnreviewed) {
+    return;
+  }
+
+  if (!reviewState.humanReviewed || !reviewState.reviewedBy) {
+    throw new Error(
+      [
+        "Entity curation drafts must be human-reviewed before SQL is generated.",
+        "Set humanReviewed to true and reviewedBy to the maintainer name in draft-output.json.",
+        "Use --allow-unreviewed only for local fixture tests, not for Supabase Cloud patches.",
+      ].join("\n"),
+    );
+  }
+}
+
+function validateDraftSafety(drafts, { maxSignals }) {
+  const errors = [];
+  const warnings = [];
+  const validConfidence = new Set(["low", "medium", "high"]);
+
+  for (const draft of drafts) {
+    const signalCount = countSuggestedSignals(draft);
+
+    if (signalCount > maxSignals) {
+      errors.push(`${draft.entityId}: ${signalCount} non-genre signals exceeds max ${maxSignals}.`);
+    }
+
+    if (draft.confidence && !validConfidence.has(draft.confidence)) {
+      errors.push(`${draft.entityId}: confidence must be low, medium, or high.`);
+    }
+
+    if (draft.mainstreamScore !== null && !isScore(draft.mainstreamScore)) {
+      errors.push(`${draft.entityId}: mainstreamScore must be an integer from 0 to 100.`);
+    }
+
+    if (draft.discoveryFitScore !== null && !isScore(draft.discoveryFitScore)) {
+      errors.push(`${draft.entityId}: discoveryFitScore must be an integer from 0 to 100.`);
+    }
+
+    if (draft.curationNote && draft.curationNote.length > 240) {
+      errors.push(`${draft.entityId}: curationNote is ${draft.curationNote.length} characters; max is 240.`);
+    }
+
+    if (!draft.rationale) {
+      warnings.push(`${draft.entityId}: rationale is empty.`);
+    }
+
+    if (
+      signalCount === 0 &&
+      draft.genreCandidatesForHumanReview.length === 0 &&
+      draft.mainstreamScore === null &&
+      draft.discoveryFitScore === null
+    ) {
+      warnings.push(`${draft.entityId}: draft has no tags, genre candidates, or scores.`);
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new Error(
+      `Entity curation draft failed safety validation:\n${errors.map((error) => `- ${error}`).join("\n")}`,
+    );
+  }
+
+  return {
+    maxSignals,
+    warnings,
+  };
+}
+
+function isScore(value) {
+  return Number.isInteger(value) && value >= 0 && value <= 100;
+}
+
+function countSuggestedSignals(draft) {
+  return Object.values(draft.suggestedTagSlugs).reduce(
+    (count, slugs) => count + slugs.length,
+    0,
+  );
+}
+
+async function validateDraftTagSlugs(drafts, inputPath, isExplicitInput) {
+  let inputPayload;
+
+  try {
+    inputPayload = JSON.parse(await fs.readFile(inputPath, "utf8"));
+  } catch (error) {
+    if (!isExplicitInput && error?.code === "ENOENT") {
+      return null;
+    }
+
+    throw error;
+  }
+
+  const availableTags = normalizeAvailableTags(inputPayload.availableTags ?? {});
+  const availableEntityIds = new Set(
+    Array.isArray(inputPayload.entities)
+      ? inputPayload.entities.map((entity) => String(entity.entityId))
+      : [],
+  );
+  const errors = [];
+
+  for (const draft of drafts) {
+    if (availableEntityIds.size > 0 && !availableEntityIds.has(draft.entityId)) {
+      errors.push(`${draft.entityId}: entity id was not present in draft-input.json.`);
+    }
+
+    for (const [kind, slugs] of Object.entries(draft.suggestedTagSlugs)) {
+      const allowedSlugs = availableTags[kind] ?? new Set();
+
+      for (const slug of slugs) {
+        if (!allowedSlugs.has(slug)) {
+          errors.push(`${draft.entityId}: unknown ${kind} tag slug "${slug}".`);
+        }
+      }
+    }
+
+    const genreSlugs = availableTags.genre ?? new Set();
+
+    for (const slug of draft.genreCandidatesForHumanReview) {
+      if (!genreSlugs.has(slug)) {
+        errors.push(`${draft.entityId}: unknown genre candidate slug "${slug}".`);
+      }
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new Error(
+      `Entity curation draft failed tag validation:\n${errors.map((error) => `- ${error}`).join("\n")}`,
+    );
+  }
+
+  return availableTags;
+}
+
+function normalizeAvailableTags(availableTags) {
+  return Object.fromEntries(
+    Object.entries(availableTags).map(([kind, tags]) => [
+      kind,
+      new Set(Array.isArray(tags) ? tags.map((tag) => String(tag.slug ?? "")) : []),
+    ]),
+  );
+}
+
+function normalizeDrafts(payload) {
+  const drafts = Array.isArray(payload) ? payload : payload?.drafts;
+
+  if (!Array.isArray(drafts)) {
+    return [];
+  }
+
+  return drafts.map((draft) => ({
+    entityId: String(draft.entityId ?? draft.entity_id ?? ""),
+    suggestedTagSlugs: normalizeSuggestedTagSlugs(draft.suggestedTagSlugs ?? draft.suggested_tag_slugs),
+    genreCandidatesForHumanReview: uniqueStrings(
+      draft.genreCandidatesForHumanReview ?? draft.genre_candidates_for_human_review,
+    ),
+    mainstreamScore: normalizeNullableScore(draft.mainstreamScore ?? draft.mainstream_score),
+    discoveryFitScore: normalizeNullableScore(draft.discoveryFitScore ?? draft.discovery_fit_score),
+    confidence: nullableString(draft.confidence),
+    curationNote: nullableString(draft.curationNote ?? draft.curation_note),
+    rationale: nullableString(draft.rationale),
+  }));
+}
+
+function normalizeSuggestedTagSlugs(value) {
+  const allowedKinds = ["mood", "scene", "style", "era", "format"];
+
+  return Object.fromEntries(
+    allowedKinds.map((kind) => [kind, uniqueStrings(value?.[kind])]),
+  );
+}
+
+function uniqueStrings(value) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return Array.from(
+    new Set(
+      value
+        .map((item) => String(item ?? "").trim())
+        .filter(Boolean),
+    ),
+  );
+}
+
+function normalizeNullableScore(value) {
+  if (value === null || value === undefined || value === "") {
+    return null;
+  }
+
+  const parsed = Number(value);
+
+  return Number.isFinite(parsed) ? Math.trunc(parsed) : value;
+}
+
+function nullableString(value) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  const stringValue = String(value).trim();
+
+  return stringValue.length > 0 ? stringValue : null;
+}
+
+function buildApplySql(drafts, reviewState, source) {
+  const tagRows = drafts.flatMap((draft) =>
+    Object.values(draft.suggestedTagSlugs).flatMap((slugs) =>
+      slugs.map((slug) => ({
+        entityId: draft.entityId,
+        slug,
+      })),
+    ),
+  );
+  const uniqueEntityIds = Array.from(new Set(drafts.map((draft) => draft.entityId)));
+  const entityValues = uniqueEntityIds.map((id) => `    (${sqlString(id)}::uuid)`).join(",\n");
+  const tagValues = tagRows.length > 0
+    ? tagRows
+        .map((row) => `    (${sqlString(row.entityId)}::uuid, ${sqlString(row.slug)}::text)`)
+        .join(",\n")
+    : "    (NULL::uuid, NULL::text)";
+
+  return `-- Kocteau entity curation drafts.
+-- Reviewed by: ${reviewState.reviewedBy ?? "unknown"}
+-- Reviewed at: ${reviewState.reviewedAt ?? new Date().toISOString()}
+-- Source: ${source}
+--
+-- This script inserts non-genre entity tags only. Genre candidates are reviewed
+-- in tmp/entity-curation/genre-candidates-for-review.md and are not applied here.
+
+BEGIN;
+
+DO $$
+DECLARE
+  missing_entities text;
+  missing_tags text;
+BEGIN
+  WITH draft_entities(entity_id) AS (
+    VALUES
+${entityValues}
+  )
+  SELECT string_agg(draft_entities.entity_id::text, ', ' ORDER BY draft_entities.entity_id::text)
+  INTO missing_entities
+  FROM draft_entities
+  LEFT JOIN public.entities entity
+    ON entity.id = draft_entities.entity_id
+  WHERE entity.id IS NULL;
+
+  IF missing_entities IS NOT NULL THEN
+    RAISE EXCEPTION 'Entity curation draft contains unknown entity ids: %', missing_entities;
+  END IF;
+
+  WITH requested_tags(entity_id, slug) AS (
+    VALUES
+${tagValues}
+  )
+  SELECT string_agg(DISTINCT requested_tags.slug, ', ' ORDER BY requested_tags.slug)
+  INTO missing_tags
+  FROM requested_tags
+  LEFT JOIN public.preference_tags tag
+    ON tag.slug = requested_tags.slug
+    AND tag.kind IN ('mood', 'scene', 'style', 'era', 'format')
+  WHERE requested_tags.slug IS NOT NULL
+    AND tag.id IS NULL;
+
+  IF missing_tags IS NOT NULL THEN
+    RAISE EXCEPTION 'Entity curation draft contains unknown non-genre tag slugs: %', missing_tags;
+  END IF;
+END;
+$$;
+
+WITH requested_tags(entity_id, slug) AS (
+  VALUES
+${tagValues}
+),
+resolved_tags AS (
+  SELECT
+    requested_tags.entity_id,
+    tag.id AS tag_id
+  FROM requested_tags
+  JOIN public.preference_tags tag
+    ON tag.slug = requested_tags.slug
+    AND tag.kind IN ('mood', 'scene', 'style', 'era', 'format')
+  WHERE requested_tags.entity_id IS NOT NULL
+    AND requested_tags.slug IS NOT NULL
+)
+INSERT INTO public.entity_preference_tags (
+  entity_id,
+  tag_id,
+  weight,
+  source
+)
+SELECT
+  resolved_tags.entity_id,
+  resolved_tags.tag_id,
+  1.0,
+  ${sqlString(source)}
+FROM resolved_tags
+ON CONFLICT (entity_id, tag_id)
+DO UPDATE SET
+  source = CASE
+    WHEN public.entity_preference_tags.source = 'manual'
+      THEN public.entity_preference_tags.source
+    ELSE EXCLUDED.source
+  END,
+  weight = least(3, greatest(public.entity_preference_tags.weight, EXCLUDED.weight)),
+  updated_at = now();
+
+COMMIT;
+`;
+}
+
+function buildGenreReview(drafts) {
+  const lines = [
+    "# Entity Genre Candidates For Human Review",
+    "",
+    "These genre suggestions were not applied to Supabase.",
+    "",
+  ];
+
+  drafts.forEach((draft) => {
+    if (draft.genreCandidatesForHumanReview.length === 0) {
+      return;
+    }
+
+    lines.push(
+      `## ${draft.entityId}`,
+      "",
+      ...draft.genreCandidatesForHumanReview.map((slug) => `- ${slug}`),
+      "",
+    );
+  });
+
+  if (lines.length === 4) {
+    lines.push("No genre candidates were included.", "");
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+function buildReviewReport(drafts, safetyReport, source) {
+  const signalCounts = drafts.map(countSuggestedSignals);
+  const totalSignals = signalCounts.reduce((sum, count) => sum + count, 0);
+  const warnings = safetyReport.warnings;
+  const lines = [
+    "# Entity Curation Review Report",
+    "",
+    `Drafts: ${drafts.length}`,
+    `Total non-genre signals: ${totalSignals}`,
+    `Max non-genre signals per entity: ${safetyReport.maxSignals}`,
+    `Source: ${source}`,
+    "",
+    "## Scores",
+    "",
+    ...drafts.map((draft) => (
+      `- ${draft.entityId}: mainstream ${draft.mainstreamScore ?? "n/a"}, discovery ${draft.discoveryFitScore ?? "n/a"}, confidence ${draft.confidence ?? "n/a"}`
+    )),
+    "",
+    "## Warnings",
+    "",
+  ];
+
+  if (warnings.length === 0) {
+    lines.push("No warnings.");
+  } else {
+    warnings.forEach((warning) => lines.push(`- ${warning}`));
+  }
+
+  lines.push("");
+
+  return `${lines.join("\n")}\n`;
+}
+
+function sqlString(value) {
+  if (value === null || value === undefined) {
+    return "NULL";
+  }
+
+  return `'${String(value).replaceAll("'", "''")}'`;
+}

--- a/supabase/scripts/create-entity-curation-draft.mjs
+++ b/supabase/scripts/create-entity-curation-draft.mjs
@@ -1,0 +1,306 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+
+const repoRoot = process.cwd();
+const args = parseArgs(process.argv.slice(2));
+const inputPath = path.resolve(repoRoot, args.input ?? "tmp/entity-curation-export.json");
+const outDir = path.resolve(repoRoot, args.outDir ?? "tmp/entity-curation");
+const limit = args.limit ? Number.parseInt(args.limit, 10) : null;
+
+if (args.help) {
+  printHelp();
+  process.exit(0);
+}
+
+const rawInput = await fs.readFile(inputPath, "utf8");
+const exportPayload = normalizeExport(JSON.parse(rawInput));
+const entities = Array.isArray(exportPayload.entities) ? exportPayload.entities : [];
+const curatedEntities = entities.map(normalizeEntity).filter(hasCurationSignal);
+const selectedEntities =
+  Number.isFinite(limit) && limit > 0 ? curatedEntities.slice(0, limit) : curatedEntities;
+
+await fs.mkdir(outDir, { recursive: true });
+
+const normalizedInput = {
+  generatedAt: exportPayload.generatedAt ?? new Date().toISOString(),
+  source: exportPayload.source ?? path.basename(inputPath),
+  availableTags: normalizeAvailableTags(exportPayload.availableTags ?? {}),
+  entities: selectedEntities,
+};
+
+const prompt = buildDraftPrompt(normalizedInput);
+const template = buildOutputTemplate(normalizedInput.entities);
+
+await fs.writeFile(
+  path.join(outDir, "draft-input.json"),
+  `${JSON.stringify(normalizedInput, null, 2)}\n`,
+  "utf8",
+);
+await fs.writeFile(path.join(outDir, "draft-prompt.md"), prompt, "utf8");
+await fs.writeFile(
+  path.join(outDir, "draft-output-template.json"),
+  `${JSON.stringify(template, null, 2)}\n`,
+  "utf8",
+);
+
+console.log(`Entity curation draft packet created in ${path.relative(repoRoot, outDir)}.`);
+console.log(`Entities included: ${normalizedInput.entities.length}`);
+console.log(`Entities skipped without curation signal: ${entities.length - curatedEntities.length}`);
+
+function parseArgs(argv) {
+  const parsed = {};
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === "--help" || arg === "-h") {
+      parsed.help = true;
+      continue;
+    }
+
+    if (arg === "--input") {
+      parsed.input = argv[index + 1];
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--out-dir") {
+      parsed.outDir = argv[index + 1];
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--limit") {
+      parsed.limit = argv[index + 1];
+      index += 1;
+    }
+  }
+
+  return parsed;
+}
+
+function printHelp() {
+  console.log(`Usage:
+  pnpm curate:entity:draft
+  pnpm curate:entity:draft -- --input tmp/entity-curation-export.json --out-dir tmp/entity-curation --limit 12
+
+Input:
+  Copy the JSON value from supabase/scripts/maintenance/entity-curation-draft-export.sql
+  into tmp/entity-curation-export.json.
+
+Output:
+  tmp/entity-curation/draft-input.json
+  tmp/entity-curation/draft-prompt.md
+  tmp/entity-curation/draft-output-template.json
+`);
+}
+
+function normalizeExport(payload) {
+  if (typeof payload === "string") {
+    return normalizeExport(JSON.parse(payload));
+  }
+
+  if (Array.isArray(payload)) {
+    if (payload.length === 1 && payload[0]?.entity_curation_export) {
+      return normalizeExport(payload[0].entity_curation_export);
+    }
+
+    return {
+      entities: payload,
+      availableTags: {},
+    };
+  }
+
+  if (payload?.entity_curation_export) {
+    return normalizeExport(payload.entity_curation_export);
+  }
+
+  if (!payload || typeof payload !== "object") {
+    throw new Error("Expected an entity curation export object or array.");
+  }
+
+  return payload;
+}
+
+function normalizeAvailableTags(availableTags) {
+  return Object.fromEntries(
+    Object.entries(availableTags).map(([kind, tags]) => [
+      kind,
+      Array.isArray(tags)
+        ? tags.map((tag) => ({
+            slug: String(tag.slug ?? ""),
+            label: String(tag.label ?? tag.slug ?? ""),
+            description: tag.description ? String(tag.description) : null,
+          }))
+        : [],
+    ]),
+  );
+}
+
+function normalizeTag(tag) {
+  return {
+    kind: String(tag.kind ?? ""),
+    slug: String(tag.slug ?? ""),
+    label: String(tag.label ?? tag.slug ?? ""),
+    source: tag.source ? String(tag.source) : null,
+    weight: typeof tag.weight === "number" && Number.isFinite(tag.weight) ? tag.weight : null,
+  };
+}
+
+function normalizeEntity(entity) {
+  return {
+    entityId: String(entity.entityId ?? entity.entity_id ?? ""),
+    provider: String(entity.provider ?? ""),
+    providerId: String(entity.providerId ?? entity.provider_id ?? ""),
+    type: String(entity.type ?? "track"),
+    title: String(entity.title ?? ""),
+    artistName: entity.artistName ?? entity.artist_name ?? null,
+    deezerUrl: entity.deezerUrl ?? entity.deezer_url ?? null,
+    currentTags: Array.isArray(entity.currentTags)
+      ? entity.currentTags.map(normalizeTag)
+      : [],
+    starterTags: Array.isArray(entity.starterTags)
+      ? entity.starterTags.map(normalizeTag)
+      : [],
+    missingSignals: Array.isArray(entity.missingSignals) ? entity.missingSignals : [],
+    reviewCount: Number(entity.reviewCount ?? entity.review_count ?? 0),
+    averageRating: entity.averageRating ?? entity.average_rating ?? null,
+    bookmarkCount: Number(entity.bookmarkCount ?? entity.bookmark_count ?? 0),
+    libraryCount: Number(entity.libraryCount ?? entity.library_count ?? 0),
+    manualTagCount: Number(entity.manualTagCount ?? entity.manual_tag_count ?? 0),
+    signalScore: Number(entity.signalScore ?? entity.signal_score ?? 0),
+  };
+}
+
+function hasCurationSignal(entity) {
+  return (
+    entity.reviewCount > 0 ||
+    entity.bookmarkCount > 0 ||
+    entity.libraryCount > 0 ||
+    entity.manualTagCount > 0 ||
+    entity.starterTags.length > 0
+  );
+}
+
+function buildDraftPrompt(input) {
+  const availableTagText = Object.entries(input.availableTags)
+    .map(([kind, tags]) => {
+      const tagText = tags
+        .map((tag) => `- ${tag.slug}: ${tag.label}${tag.description ? ` - ${tag.description}` : ""}`)
+        .join("\n");
+      return `### ${kind}\n${tagText || "- No tags exported."}`;
+    })
+    .join("\n\n");
+
+  const entityText = input.entities
+    .map((entity, index) => {
+      const currentTags = entity.currentTags
+        .map((tag) => `${tag.kind}:${tag.slug}`)
+        .join(", ");
+      const starterTags = entity.starterTags
+        .map((tag) => `${tag.kind}:${tag.slug}`)
+        .join(", ");
+
+      return `### ${index + 1}. ${entity.title}${entity.artistName ? ` - ${entity.artistName}` : ""}
+- entityId: ${entity.entityId}
+- provider: ${entity.provider}
+- providerId: ${entity.providerId}
+- type: ${entity.type}
+- deezerUrl: ${entity.deezerUrl ?? "unknown"}
+- missingSignals: ${entity.missingSignals.join(", ") || "none"}
+- currentTags: ${currentTags || "none"}
+- starterTags: ${starterTags || "none"}
+- reviewCount: ${entity.reviewCount}
+- averageRating: ${entity.averageRating ?? "none"}
+- bookmarkCount: ${entity.bookmarkCount}
+- libraryCount: ${entity.libraryCount}
+- manualTagCount: ${entity.manualTagCount}
+- signalScore: ${entity.signalScore}`;
+    })
+    .join("\n\n");
+
+  return `# Kocteau Entity Curation Draft Prompt
+
+You are Kocteau's curation copilot. Help draft taste metadata for local music entities.
+
+## Role
+
+Kocteau is a human-led music review product. You are not deciding what is good or bad. You are helping a maintainer classify tracks so discovery can become more useful.
+
+## Rules
+
+- Return JSON only.
+- Use only existing tag slugs from the available tag list.
+- Do not auto-apply genre. You may suggest genre candidates, but mark them for human review.
+- Do not mark the packet as reviewed. Leave humanReviewed false until a maintainer reviews it.
+- Prefer mood, scene, style, era, and format before genre.
+- Suggest at most eight non-genre signals per entity.
+- Avoid obvious popularity worship. Known artists may still have deep cuts or strong contextual value.
+- Treat novelty, troll, or meme-coded tracks cautiously. They should not get high discoveryFitScore unless the input shows real Kocteau curation intent.
+- Use mainstreamScore from 0 to 100, where 100 means very commercially familiar.
+- Use discoveryFitScore from 0 to 100, where 100 means especially useful for Kocteau discovery.
+- Do not invent facts such as scenes, release years, or biographies if the input does not support them.
+- Use confidence: "low", "medium", or "high".
+
+## Output Shape
+
+\`\`\`json
+{
+  "humanReviewed": false,
+  "reviewedBy": "",
+  "reviewedAt": "",
+  "drafts": [
+    {
+      "entityId": "uuid",
+      "suggestedTagSlugs": {
+        "mood": ["slug"],
+        "scene": ["slug"],
+        "style": ["slug"],
+        "era": ["slug"],
+        "format": ["slug"]
+      },
+      "genreCandidatesForHumanReview": ["slug"],
+      "mainstreamScore": 35,
+      "discoveryFitScore": 82,
+      "confidence": "medium",
+      "curationNote": "short maintainer-facing note",
+      "rationale": "one short sentence explaining the choices"
+    }
+  ]
+}
+\`\`\`
+
+## Available Tags
+
+${availableTagText}
+
+## Entities
+
+${entityText}
+`;
+}
+
+function buildOutputTemplate(entities) {
+  return {
+    humanReviewed: false,
+    reviewedBy: "",
+    reviewedAt: "",
+    drafts: entities.map((entity) => ({
+      entityId: entity.entityId,
+      suggestedTagSlugs: {
+        mood: [],
+        scene: [],
+        style: [],
+        era: [],
+        format: [],
+      },
+      genreCandidatesForHumanReview: [],
+      mainstreamScore: null,
+      discoveryFitScore: null,
+      confidence: "low",
+      curationNote: "",
+      rationale: "",
+    })),
+  };
+}

--- a/supabase/scripts/maintenance/entity-curation-draft-export.sql
+++ b/supabase/scripts/maintenance/entity-curation-draft-export.sql
@@ -1,0 +1,238 @@
+-- Entity curation draft export.
+--
+-- Run from the Supabase SQL editor, then copy the JSON value from the
+-- `entity_curation_export` column into:
+--
+-- tmp/entity-curation-export.json
+--
+-- This script is read-only. It exports local track entities that have enough
+-- Kocteau signal to deserve tag/context drafting, but are missing entity tags.
+
+with available_tags as (
+  select
+    pt.kind,
+    jsonb_agg(
+      jsonb_build_object(
+        'id', pt.id,
+        'slug', pt.slug,
+        'label', pt.label,
+        'description', pt.description
+      )
+      order by pt.sort_order, pt.label
+    ) as tags
+  from public.preference_tags pt
+  where pt.kind in ('mood', 'scene', 'style', 'era', 'format', 'genre')
+  group by pt.kind
+),
+available_tag_map as (
+  select jsonb_object_agg(kind, tags order by kind) as tags_by_kind
+  from available_tags
+),
+entity_tag_summary as (
+  select
+    e.id as entity_id,
+    count(ept.tag_id) as tag_count,
+    count(ept.tag_id) filter (where ept.source = 'manual') as manual_tag_count,
+    count(ept.tag_id) filter (where pt.kind = 'genre') as genre_tag_count,
+    count(ept.tag_id) filter (where pt.kind = 'mood') as mood_tag_count,
+    count(ept.tag_id) filter (where pt.kind = 'scene') as scene_tag_count,
+    count(ept.tag_id) filter (where pt.kind = 'style') as style_tag_count,
+    count(ept.tag_id) filter (where pt.kind = 'era') as era_tag_count,
+    count(ept.tag_id) filter (where pt.kind = 'format') as format_tag_count,
+    jsonb_agg(
+      jsonb_build_object(
+        'id', pt.id,
+        'kind', pt.kind,
+        'slug', pt.slug,
+        'label', pt.label,
+        'source', ept.source,
+        'weight', ept.weight
+      )
+      order by pt.kind, pt.sort_order, pt.label
+    ) filter (where pt.id is not null) as current_tags
+  from public.entities e
+  left join public.entity_preference_tags ept
+    on ept.entity_id = e.id
+  left join public.preference_tags pt
+    on pt.id = ept.tag_id
+  group by e.id
+),
+starter_tag_summary as (
+  select
+    st.provider,
+    st.provider_id,
+    st.type,
+    jsonb_agg(
+      jsonb_build_object(
+        'kind', pt.kind,
+        'slug', pt.slug,
+        'label', pt.label
+      )
+      order by pt.kind, pt.sort_order, pt.label
+    ) filter (where pt.id is not null) as starter_tags
+  from public.starter_tracks st
+  left join public.starter_track_tags stt
+    on stt.starter_track_id = st.id
+  left join public.preference_tags pt
+    on pt.id = stt.tag_id
+  where st.is_active
+  group by st.provider, st.provider_id, st.type
+),
+review_stats as (
+  select
+    r.entity_id,
+    count(*) as review_count,
+    round(avg(r.rating)::numeric, 2) as average_rating,
+    max(r.created_at) as latest_review_at
+  from public.reviews r
+  group by r.entity_id
+),
+bookmark_stats as (
+  select
+    eb.entity_id,
+    count(*) as bookmark_count
+  from public.entity_bookmarks eb
+  group by eb.entity_id
+),
+library_stats as (
+  select
+    item.entity_id,
+    count(*) as library_count
+  from public.entity_library_items item
+  where item.item_type = 'library'
+  group by item.entity_id
+),
+entity_readiness as (
+  select
+    e.id,
+    e.provider,
+    e.provider_id,
+    e.type,
+    e.title,
+    e.artist_name,
+    e.cover_url,
+    e.deezer_url,
+    e.created_at,
+    e.updated_at,
+    coalesce(ets.tag_count, 0) as tag_count,
+    coalesce(ets.manual_tag_count, 0) as manual_tag_count,
+    coalesce(ets.genre_tag_count, 0) as genre_tag_count,
+    coalesce(ets.mood_tag_count, 0) as mood_tag_count,
+    coalesce(ets.scene_tag_count, 0) as scene_tag_count,
+    coalesce(ets.style_tag_count, 0) as style_tag_count,
+    coalesce(ets.era_tag_count, 0) as era_tag_count,
+    coalesce(ets.format_tag_count, 0) as format_tag_count,
+    coalesce(ets.current_tags, '[]'::jsonb) as current_tags,
+    coalesce(sts.starter_tags, '[]'::jsonb) as starter_tags,
+    coalesce(rs.review_count, 0) as review_count,
+    rs.average_rating,
+    rs.latest_review_at,
+    coalesce(bs.bookmark_count, 0) as bookmark_count,
+    coalesce(ls.library_count, 0) as library_count,
+    (
+      coalesce(rs.review_count, 0) * 3
+      + coalesce(ls.library_count, 0) * 2
+      + coalesce(bs.bookmark_count, 0)
+      + case when sts.starter_tags is not null then 4 else 0 end
+      + coalesce(ets.manual_tag_count, 0) * 4
+    ) as signal_score,
+    (
+      coalesce(rs.review_count, 0) > 0
+      or coalesce(ls.library_count, 0) > 0
+      or coalesce(bs.bookmark_count, 0) > 0
+      or sts.starter_tags is not null
+      or coalesce(ets.manual_tag_count, 0) > 0
+    ) as has_curation_signal
+  from public.entities e
+  left join entity_tag_summary ets
+    on ets.entity_id = e.id
+  left join starter_tag_summary sts
+    on sts.provider = e.provider
+    and sts.provider_id = e.provider_id
+    and sts.type = e.type
+  left join review_stats rs
+    on rs.entity_id = e.id
+  left join bookmark_stats bs
+    on bs.entity_id = e.id
+  left join library_stats ls
+    on ls.entity_id = e.id
+  where e.type = 'track'
+),
+entities_needing_curation as (
+  select
+    entity_readiness.*,
+    array_remove(array[
+      case when tag_count = 0 then 'any_tag' end,
+      case when era_tag_count = 0 then 'era' end,
+      case when format_tag_count = 0 then 'format' end,
+      case
+        when genre_tag_count = 0
+          and mood_tag_count = 0
+          and scene_tag_count = 0
+          and style_tag_count = 0
+          then 'genre_mood_scene_or_style'
+      end
+    ], null) as missing_signals
+  from entity_readiness
+  where has_curation_signal
+    and (
+      tag_count = 0
+      or era_tag_count = 0
+      or format_tag_count = 0
+      or (
+        genre_tag_count = 0
+        and mood_tag_count = 0
+        and scene_tag_count = 0
+        and style_tag_count = 0
+      )
+    )
+)
+select jsonb_pretty(
+  jsonb_build_object(
+    'generatedAt', now(),
+    'source', 'entity-curation-draft-export.sql',
+    'rules', jsonb_build_array(
+      'Do not auto-apply genre suggestions; genre remains human-reviewed taxonomy.',
+      'Use only existing tag slugs from availableTags.',
+      'Prefer tags backed by track identity, community signal, or starter tags.',
+      'Do not include private user data, raw review text, emails, IP addresses, or user agents.'
+    ),
+    'availableTags', coalesce((select tags_by_kind from available_tag_map), '{}'::jsonb),
+    'entities', coalesce(
+      (
+        select jsonb_agg(
+          jsonb_build_object(
+            'entityId', id,
+            'provider', provider,
+            'providerId', provider_id,
+            'type', type,
+            'title', title,
+            'artistName', artist_name,
+            'coverUrl', cover_url,
+            'deezerUrl', deezer_url,
+            'currentTags', current_tags,
+            'starterTags', starter_tags,
+            'missingSignals', missing_signals,
+            'manualTagCount', manual_tag_count,
+            'reviewCount', review_count,
+            'averageRating', average_rating,
+            'latestReviewAt', latest_review_at,
+            'bookmarkCount', bookmark_count,
+            'libraryCount', library_count,
+            'signalScore', signal_score,
+            'createdAt', created_at,
+            'updatedAt', updated_at
+          )
+          order by signal_score desc, updated_at desc, title
+        )
+        from (
+          select *
+          from entities_needing_curation
+          order by signal_score desc, updated_at desc, title
+          limit 60
+        ) scoped_entities
+      ),
+      '[]'::jsonb
+    )
+  )
+) as entity_curation_export;


### PR DESCRIPTION
## What changed

Added a maintainer-only entity curation copilot workflow for Kocteau.

- Added a read-only Supabase export for entities that need curation metadata.
- Added scripts to generate AI/Eve draft packets and reviewed SQL patches.
- Added safety validation for human review, known tag slugs, max signal count, and allowed DB sources.
- Documented the Eve curation copilot flow and linked it from maintainer docs.

## Why

This lets Kocteau scale track metadata and recommendation signals without letting AI write directly to production data. The workflow keeps human review as the final step.

## Testing

- [x] Ran `pnpm check`
- [ ] Added screenshots or a short recording for visible web UI changes
- [ ] Confirmed this does not touch auth, Supabase, recommendations, analytics, CI, or release behavior

Additional checks:
- [x] Ran `pnpm curate:entity:draft`
- [x] Ran `pnpm curate:entity:sql -- --source system`
- [x] Ran `git diff --check`

## Changelog impact

No manual `CHANGELOG.md` edit is required. Release Please generates release notes from PR titles and squash commits.

- [ ] User-facing web change
- [x] Developer experience or documentation change
- [x] Internal-only change

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a maintainer-only entity curation copilot workflow that exports safe entity data, drafts suggestions locally, enforces human review, and generates SQL patches for manual apply. This scales tagging and signals without direct writes to production.

- **New Features**
  - Read-only Supabase export for entities with real curation signals: `supabase/scripts/maintenance/entity-curation-draft-export.sql`.
  - `pnpm curate:entity:draft` builds `draft-input.json`, `draft-prompt.md`, and an output template for reviewed suggestions.
  - `pnpm curate:entity:sql` validates human review and tag slugs, limits non-genre signals, and generates:
    - `apply-entity-curation-drafts.sql`
    - `genre-candidates-for-review.md`
    - `curation-review-report.md`
  - Apply SQL inserts only non-genre tags into `entity_preference_tags`, preserves existing `manual` tags, and uses `source=system`.
  - Safety checks: requires `humanReviewed` and `reviewedBy`, verifies known tag slugs, enforces max signal count, and restricts source to `manual` | `import` | `inferred` | `system`.
  - Docs: new maintainer guide at `docs/maintainers/eve-curation-copilot.md` and links from docs index and operations; `.gitignore` updated for local agent tooling.

<sup>Written for commit 8cc2a85b70fafbc705ea8be0e73ccdce2f2b8e85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/francozeta/kocteau/pull/111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Eve Curation Copilot: a local-only assistant workflow for drafting entity tags and metadata with required manual maintainer review before application

* **Documentation**
  * Added comprehensive maintainer guide for Eve curation copilot workflow
  * Updated backlog and operational documentation with new curation automation stages

* **Chores**
  * Added `curate:entity:draft` and `curate:entity:sql` commands to build system
  * Updated configuration for local agent tooling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->