### PR TITLE
fix(starter): feature imported starter tracks

### DIFF
--- a/apps/web/lib/apple-music/starter-source-sql.ts
+++ b/apps/web/lib/apple-music/starter-source-sql.ts
@@ -225,7 +225,7 @@ matched_starter_tracks AS (
     'What does ' || coalesce(incoming.matched_title, incoming.title) || ' open up for you?',
     ${sqlString(getStarterEditorialNote(importResult.playlist.title))},
     true,
-    false,
+    true,
     incoming.source_position,
     now()
   FROM matched_incoming incoming
@@ -238,6 +238,7 @@ matched_starter_tracks AS (
     prompt = coalesce(public.starter_tracks.prompt, EXCLUDED.prompt),
     editorial_note = coalesce(public.starter_tracks.editorial_note, EXCLUDED.editorial_note),
     is_active = true,
+    is_featured = true,
     sort_order = EXCLUDED.sort_order,
     updated_at = now()
   RETURNING id, provider_id

--- a/supabase/scripts/generated/apple-vert-starter-sync.sql
+++ b/supabase/scripts/generated/apple-vert-starter-sync.sql
@@ -2005,7 +2005,7 @@ matched_starter_tracks AS (
     'What does ' || coalesce(incoming.matched_title, incoming.title) || ' open up for you?',
     'Selected from Vért.',
     true,
-    false,
+    true,
     incoming.source_position,
     now()
   FROM matched_incoming incoming
@@ -2018,6 +2018,7 @@ matched_starter_tracks AS (
     prompt = coalesce(public.starter_tracks.prompt, EXCLUDED.prompt),
     editorial_note = coalesce(public.starter_tracks.editorial_note, EXCLUDED.editorial_note),
     is_active = true,
+    is_featured = true,
     sort_order = EXCLUDED.sort_order,
     updated_at = now()
   RETURNING id, provider_id

--- a/supabase/scripts/maintenance/starter-featured-backfill.sql
+++ b/supabase/scripts/maintenance/starter-featured-backfill.sql
@@ -1,0 +1,28 @@
+-- Kocteau starter featured backfill.
+-- Run this in the Supabase SQL Editor when a curated starter source should
+-- become visible across starter rails immediately.
+--
+-- This does not create tracks or tags. It only marks active starter tracks as
+-- featured so current rails can use the full curated pool.
+
+BEGIN;
+
+WITH updated AS (
+  UPDATE public.starter_tracks track
+  SET
+    is_featured = true,
+    updated_at = now()
+  WHERE track.is_active = true
+    AND track.is_featured = false
+  RETURNING track.id
+)
+SELECT count(*) AS newly_featured_tracks
+FROM updated;
+
+COMMIT;
+
+SELECT
+  count(*) FILTER (WHERE is_active = true) AS active_tracks,
+  count(*) FILTER (WHERE is_active = true AND is_featured = true) AS featured_tracks,
+  count(*) FILTER (WHERE is_active = true AND is_featured = false) AS active_unfeatured_tracks
+FROM public.starter_tracks;


### PR DESCRIPTION
## What changed

- Marked imported Apple Music starter tracks as featured by default during insert/upsert.
- Added a maintenance backfill to feature existing active starter tracks.
- Kept the generated Apple Music starter sync SQL aligned with the same featured behavior.

## Why

Imported curated source picks could stay active but unfeatured, which kept them from appearing reliably in starter rails. This makes curated starter sources visible across the app immediately.

## Testing

- [ ] Ran `pnpm check` (not verified on this historical PR)
- [ ] Added screenshots or a short recording for visible web UI changes (N/A: SQL/import behavior)
- [ ] Confirmed this does not touch auth, Supabase, recommendations, analytics, CI, or release behavior (touches starter data behavior)

## Changelog impact

No manual `CHANGELOG.md` edit is required. Release Please generates release notes from PR titles and squash commits.

- [x] User-facing web change
- [ ] Developer experience or documentation change
- [ ] Internal-only change