### PR TITLE
fix(web): restore starter studio build

### DIFF
--- a/apps/web/components/starter-studio-client.tsx
+++ b/apps/web/components/starter-studio-client.tsx
@@ -108,7 +108,7 @@ const starterTagLimit = 12;
 const starterCatalogPageSize = 30;
 const starterTagKinds = preferenceKindOrder;
 const starterTagKindSet = new Set<PreferenceKind>(starterTagKinds);
-const requiredEditorialKinds = ["era", "format"] as const satisfies readonly PreferenceKind[];
+const requiredEditorialKinds: readonly PreferenceKind[] = ["era", "format"];
 
 type CatalogFilter = "all" | "needs-signals" | "missing-context" | "ready" | "featured";
 type StudioSearchMode = "search" | "scout";
@@ -295,7 +295,7 @@ function StarterSignalCombobox({
         value={selectedTags}
         inputValue={inputValue}
         open={open}
-        autoHighlight="always"
+        autoHighlight
         itemToStringLabel={(tag) => tag.label}
         itemToStringValue={(tag) => tag.id}
         isItemEqualToValue={(itemValue, value) => itemValue.id === value.id}
@@ -1693,7 +1693,9 @@ export default function StarterStudioClient() {
                       selectedDraftTrack?.provider_id === track.provider_id ||
                       editingTrack?.provider_id === track.provider_id;
                     const sourceLabel =
-                      "source_label" in track ? track.source_label : null;
+                      "source_label" in track && typeof track.source_label === "string"
+                        ? track.source_label
+                        : null;
 
                     return (
                       <article


### PR DESCRIPTION
## What changed

- Restored the Starter Studio build by tightening TypeScript and prop typing around the curation UI.
- Changed `requiredEditorialKinds` to a readonly preference-kind list.
- Passed boolean `autoHighlight` into the signal comboboxes.
- Guarded starter source labels so only valid strings render in search results.

## Why

The Starter Studio polish branch was blocked by a production build/typecheck failure. This keeps the curator UI deployable without changing the product flow.

## Testing

- [x] Ran `pnpm check`
- [ ] Added screenshots or a short recording for visible web UI changes (N/A: build fix only)
- [x] Confirmed this does not touch auth, Supabase, recommendations, analytics, CI, or release behavior

## Changelog impact

No manual `CHANGELOG.md` edit is required. Release Please generates release notes from PR titles and squash commits.

- [ ] User-facing web change
- [ ] Developer experience or documentation change
- [x] Internal-only change