### PR TITLE
docs: define knowledge layer and atlas direction

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@
 - [MVP baseline](./mvp.md): current product loop, scope, and out-of-scope guardrails.
 - [Web roadmap](./web-roadmap.md): phased web product direction and execution order.
 - [Discovery and curation](./discovery-curation.md): hybrid recommendation philosophy, signal contract, starter curation, and future RFC lanes.
+- [Knowledge Layer and Atlas](./knowledge-layer.md): source policy, taste taxonomy, Atlas direction, and Eve's public discovery role.
 - [Public backlog](./backlog.md): issue-ready work, maintainer-led work, and future RFC backlog.
 
 ## Setup And Operations

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -53,6 +53,7 @@ These are the next useful moves after enabling public contribution.
 | P0 | Confirm the `v0.2.0` tag and GitHub Release are created after the release PR merges. | ready | `chore`, `area:ci` |
 | P0 | Pin the public repository description, topics, website URL, and social preview image in GitHub settings. | ready | `docs`, `area:docs` |
 | P0 | Make recommendations visible on track pages so new visitors can see "what to hear next." | done | `feature`, `area:web`, `area:recommendations` |
+| P0 | Land the Knowledge Layer source policy and clean the current taste taxonomy so genres, moods, scenes, styles, eras, and formats have clear boundaries. | in progress ([#124](https://github.com/francozeta/kocteau/issues/124), [#125](https://github.com/francozeta/kocteau/issues/125)) | `docs`, `area:supabase`, `area:recommendations`, `needs maintainer decision` |
 | P0 | Fix desktop scroll dead zones so the page still scrolls when the pointer is over the secondary rail or empty desktop space. | done | `fix`, `area:web`, `area:ui` |
 | P0 | Make review cards open their review detail route without breaking like, save, or comment actions. | done | `feature`, `area:web`, `area:ui` |
 | P0 | Fix mobile toast placement so feedback is centered and clears the bottom navigation. | ready | `fix`, `area:web`, `area:ui` |
@@ -61,6 +62,8 @@ These are the next useful moves after enabling public contribution.
 | P1 | Add a short "first contribution path" section to the README with links to good first issues. | ready | `docs`, `area:docs`, `good first issue` |
 | P1 | Open discovery and curation issues from `docs/discovery-curation.md` with clear owner lanes. | done | `docs`, `area:recommendations`, `needs maintainer decision` |
 | P1 | Add a private track library signal on track pages. | in progress | `feature`, `area:web`, `area:supabase`, `area:recommendations` |
+| P1 | Design public Atlas tag pages that help listeners explore genres, moods, scenes, and styles without turning the product into a generic wiki. | needs design ([#126](https://github.com/francozeta/kocteau/issues/126)) | `feature`, `design`, `area:web`, `area:recommendations` |
+| P1 | Design Eve route lanes around discovery intent: Continue, Go deeper, Take a stranger path, Travel back, and Travel forward. | needs design ([#127](https://github.com/francozeta/kocteau/issues/127)) | `feature`, `design`, `area:web`, `area:recommendations`, `needs maintainer decision` |
 | P1 | Add an editable taste preferences path after onboarding. | needs design | `feature`, `area:web`, `area:recommendations` |
 | P1 | Add a mobile social discovery carousel near review detail pages. | needs design ([#90](https://github.com/francozeta/kocteau/issues/90)) | `feature`, `area:web`, `area:ui` |
 | P1 | Design a listener-facing candidate finder for similar songs that feels curated rather than chart-driven. | needs design ([#89](https://github.com/francozeta/kocteau/issues/89)) | `feature`, `area:web`, `area:recommendations` |
@@ -818,21 +821,50 @@ Do this after the public flow has real usage.
 
 These ideas are not ready for implementation issues yet. They are useful prompts for contributors who want to help with product research, design notes, or RFC drafts.
 
+### Knowledge Layer Source Policy
+
+GitHub issue: [#124](https://github.com/francozeta/kocteau/issues/124)
+
+Suggested issue: `docs: define Kocteau Knowledge Layer source policy`
+
+- Separate canonical facts from editorial knowledge.
+- Use MusicBrainz, Deezer, Discogs, Wikidata, and Kocteau signals by strength rather than choosing one source of truth.
+- Keep `preference_tags` as the current product-facing vocabulary while the richer entity/relationship layer is designed.
+- Do not let Eve invent genres as facts. Eve can draft editorial knowledge when the evidence is visible.
+
+Suggested labels: `docs`, `area:recommendations`, `area:supabase`, `needs maintainer decision`
+
+### Preference Tag Taxonomy Cleanup
+
+GitHub issue: [#125](https://github.com/francozeta/kocteau/issues/125)
+
+Suggested issue: `chore(supabase): clean preference tag taxonomy for Knowledge Layer`
+
+- Move obvious misclassified tags into the right `preference_kind`.
+- Merge duplicate aliases into canonical tags without losing starter, entity, or user relationships.
+- Keep the current `preference_tags` table as the product-facing vocabulary until the richer Knowledge Layer schema is designed.
+- Do not change auth, RLS, recommendation scoring, or analytics behavior in the cleanup.
+
+Suggested labels: `chore`, `area:supabase`, `area:recommendations`, `needs maintainer decision`
+
 ### Taste Graph
 
-Suggested RFC: `rfc: define a manual taste graph for entity relationships`
+Suggested RFC: `rfc: define Kocteau Knowledge Layer relationships`
 
-- Explore a small `entity_relationships` model before embeddings.
-- Relationship examples: similar texture, influence, same scene, contrast pick, gateway recommendation.
-- Focus on explainability for track pages, Explore, and future For You tuning.
+- Explore a small entity/relationship model before embeddings.
+- Relationship examples: `belongs_to`, `influenced_by`, `sounds_like`, `gateway_to`, `opposite_of`, `emerged_from`, and `evolved_into`.
+- Focus on explainability for track pages, Atlas, Explore, and future For You tuning.
 
-Suggested labels: `rfc`, `area:recommendations`, `area:product`, `needs maintainer decision`
+Suggested labels: `docs`, `area:recommendations`, `area:supabase`, `needs maintainer decision`
 
 ### Taste Atlas
 
-Suggested RFC: `rfc: design Kocteau Taste Atlas`
+GitHub issue: [#126](https://github.com/francozeta/kocteau/issues/126)
 
-- Explore an interactive discovery surface where listeners can start from a track, artist, tag, or mood and move through nearby recommendations.
+Suggested issue: `feat(web): design public Atlas discovery pages`
+
+- Atlas is not a wiki. A wiki answers "what is this?" Atlas should ask "how do you want to explore?"
+- Explore an interactive discovery surface where listeners can start from a track, artist, tag, or mood and move through nearby discovery paths.
 - Treat the first version as an editorial and explainable graph, not as a black-box algorithm.
 - Use Kocteau signals first: starter tags, entity tags, reviews, saves, follows, curator relationships, and underexposed tracks.
 - Let the surface ask for simple taste feedback such as closer, stranger, softer, darker, deeper cut, or skip.
@@ -840,7 +872,20 @@ Suggested RFC: `rfc: design Kocteau Taste Atlas`
 - Keep the first implementation web-first with TypeScript, Supabase, and existing recommendation data. Do not add a separate runtime, Rust worker, vector system, or heavy graph engine until usage proves the need.
 - Avoid fake activity, fake affinity, or pretending Kocteau has learned more than the current data supports.
 
-Suggested labels: `rfc`, `area:recommendations`, `area:product`, `area:web`, `needs maintainer decision`
+Suggested labels: `feature`, `design`, `area:web`, `area:recommendations`, `needs design review`, `needs maintainer decision`
+
+### Eve Routes
+
+GitHub issue: [#127](https://github.com/francozeta/kocteau/issues/127)
+
+Suggested issue: `feat(eve): design explainable public discovery routes`
+
+- Eve should act as a discovery director, not as a generic music chatbot.
+- Start from listener intent: Continue, Go deeper, Take a stranger path, Travel back, Travel forward, and Why it matters.
+- Route explanations must cite visible evidence such as shared tags, starter curation, reviews, library signals, external metadata, or curator-approved relationships.
+- Keep generated language compact and editorial. The value should be in the path, not a long AI verdict.
+
+Suggested labels: `feature`, `design`, `area:web`, `area:recommendations`, `needs design review`, `needs maintainer decision`
 
 ### Cover Color Signals
 

--- a/docs/discovery-curation.md
+++ b/docs/discovery-curation.md
@@ -10,6 +10,12 @@ The guiding principle is:
 Amplify taste, not engagement.
 ```
 
+The next discovery principle is:
+
+```text
+Kocteau does not recommend music. Kocteau teaches people how to discover it.
+```
+
 This document gives maintainers and contributors a shared map for recommendation, analytics, editorial curation, and future discovery work. It is intentionally phased so the product can improve without turning into a heavy algorithm project too early.
 
 ## Current Baseline
@@ -69,16 +75,23 @@ Content can enter discovery from:
 - underexposed tracks
 - future editorial candidate queues
 
-### 2. Canonical Taste Layer
+### 2. Knowledge Layer
 
-Kocteau should treat its taste vocabulary as the source of meaning:
+Kocteau should treat its taste vocabulary as the first product-facing slice of a broader Knowledge Layer:
 
 - `preference_tags`
 - `user_preference_tags`
 - `entity_preference_tags`
 - `starter_track_tags`
 
-Deezer is a metadata source. Kocteau defines taste meaning.
+External catalogs identify and enrich. Kocteau explains and routes.
+
+Separate canonical facts from editorial knowledge:
+
+- canonical facts: genre, release date, country, label, aliases, provider IDs
+- editorial knowledge: mood, scene framing, style, gateway paths, deep cuts, stranger paths, and why a pick belongs
+
+For the full source policy and Atlas direction, see [Knowledge Layer and Atlas](./knowledge-layer.md).
 
 ### 3. Ranking And Routing
 
@@ -327,6 +340,17 @@ Track pages should start with a lightweight `More to hear` module:
 - show a short reason for every recommendation
 - avoid pretending sparse data is personalized
 
+The user-facing language should evolve away from generic recommendation labels and toward discovery intent:
+
+- `Continue`
+- `Go deeper`
+- `Take a stranger path`
+- `Travel back`
+- `Travel forward`
+- `Why it matters`
+
+The question is not only "what is similar?" The product question is "how do you want to explore?"
+
 This phase should also introduce a listener-facing candidate finder. The model mirrors Starter Studio, but the user job is different: a listener is not curating the starter catalog; they are asking Kocteau for a better next path from something they already like, read, saved, or searched.
 
 The listener candidate finder should support seeds such as:
@@ -433,6 +457,8 @@ Do not index the whole Deezer catalog for color. Kocteau should only analyze mus
 
 Design a native Kocteau discovery surface that lets listeners move through taste relationships instead of only scrolling a feed or searching directly.
 
+Atlas is not a wiki. A wiki primarily answers "what is this?" Atlas should ask "how do you want to explore?"
+
 The first version should be a small, explainable atlas:
 
 - starts from a track, artist, tag, mood, or curated starter pick
@@ -451,6 +477,29 @@ Engineering constraints:
 - keep the graph explainable enough for maintainers to inspect why two entities are connected
 
 This phase should wait until feed tuning has a baseline and the existing health checks can show whether discovery changes improve review creation, saves, and useful exploration.
+
+### Phase 9B: Eve Routes
+
+Eve should become the voice that turns Knowledge Layer evidence into public discovery paths.
+
+The first listener-facing Eve route should start from a track, artist, or tag and return a compact set of intent lanes:
+
+- `Continue`: the closest next listen
+- `Go deeper`: a less obvious but connected route
+- `Take a stranger path`: a surprising route with one shared thread
+- `Travel back`: an older influence, era, or scene route
+- `Travel forward`: a newer descendant or modern echo
+
+Each route needs evidence, not mystique:
+
+- shared tags
+- starter curation
+- reviews
+- saved/library signals
+- external metadata
+- curator-approved relationships
+
+Do not expose Eve as a generic music chatbot. Eve's product job is to direct exploration with visible criteria.
 
 ### Future Research
 

--- a/docs/knowledge-layer.md
+++ b/docs/knowledge-layer.md
@@ -1,0 +1,230 @@
+# Kocteau Knowledge Layer And Atlas
+
+[Docs index](./README.md) | [Discovery and curation](./discovery-curation.md) | [Public backlog](./backlog.md)
+
+Kocteau should not feel like another recommendation engine. The product promise is:
+
+```text
+Kocteau does not recommend music. Kocteau teaches people how to discover it.
+```
+
+The Knowledge Layer is the system that makes that promise real. It separates music facts from editorial judgment, gives Eve evidence to explain discovery paths, and gives Atlas enough structure to feel like exploration rather than a static wiki.
+
+## Product Boundaries
+
+Use these names as working architecture, not necessarily user-facing labels:
+
+| Layer | Role |
+| --- | --- |
+| Kocteau | Public music review, discovery, and taste expression product. |
+| Atlas | Public exploration surface for genres, moods, scenes, artists, tracks, and routes. |
+| Eve | Discovery director that turns structured evidence into human paths. |
+| Studio | Maintainer-facing curation desk for starter picks, tags, candidates, and review queues. |
+| Kura | Internal operating-system idea for curation. Do not expose this name until it earns product clarity. |
+
+Atlas is not a wiki. A wiki answers "what is this?" Atlas asks "how do you want to explore?"
+
+## Canonical Facts vs Editorial Knowledge
+
+Do not treat every label as a tag with the same authority. Kocteau needs two different classes of knowledge.
+
+### Canonical Facts
+
+Canonical facts are externally verifiable or metadata-derived:
+
+- genre
+- release date and era
+- country or region
+- label
+- artist membership
+- duration
+- provider IDs
+- official aliases
+
+These do not need taste approval to exist, but they do need source quality and deduplication.
+
+### Editorial Knowledge
+
+Editorial knowledge is where Kocteau becomes its own product:
+
+- mood
+- style
+- scene framing
+- gateway artist
+- deep cut
+- stranger path
+- beginner-friendly route
+- late-night context
+- rainy-room context
+- why a pick belongs here
+
+These are not objective music facts. They should come from Kocteau curation, reviews, starter picks, trusted community behavior, or Eve drafts that a human can inspect.
+
+## Source Policy
+
+No single source should own Kocteau's music knowledge.
+
+```text
+MusicBrainz \
+Deezer      \
+Discogs      -> Canonical Entity -> Kocteau Knowledge Layer
+Wikidata    /
+Kocteau    /
+```
+
+Use sources by strength:
+
+| Source | Good for | Avoid relying on it for |
+| --- | --- | --- |
+| MusicBrainz | canonical entities, releases, credits, aliases, broad tags | mood, popularity, visual identity |
+| Deezer | playable catalog, covers, track search, artist/album context | final taste meaning |
+| Discogs | styles, labels, release culture, physical/catalog context | user-facing recommendations by itself |
+| Wikidata | countries, dates, aliases, broad relationships | nuanced music taste |
+| Kocteau | reviews, starter picks, human signals, editorial routes | raw catalog completeness |
+
+The product rule is:
+
+```text
+External sources identify and enrich. Kocteau explains and routes.
+```
+
+## Current Taste Vocabulary
+
+The current `preference_tags` table remains the product-facing vocabulary for now. Treat it as a bridge toward the Knowledge Layer.
+
+| Kind | Meaning | Rule |
+| --- | --- | --- |
+| `genre` | Broad canonical music category | Should come from external consensus or strong music taxonomy. |
+| `mood` | Listener feeling | Editorial Kocteau language. |
+| `scene` | Cultural, geographic, temporal, or community context | Editorial or researched context. |
+| `style` | Production, texture, arrangement, or sonic language | Editorial descriptor, not a genre dump. |
+| `era` | Release period or temporal route | Prefer metadata-derived decade tags. |
+| `format` | Release/listening context | Prefer metadata-derived or curator-confirmed values. |
+
+Examples:
+
+- `Dream pop` belongs in `genre`.
+- `Dreamy` belongs in `mood`.
+- `Jangle pop` belongs in `genre`.
+- `Wavy synths` belongs in `style`.
+- `Spanish New Wave` belongs in `scene`.
+- `Deep cuts` belongs in `format`.
+
+## Discovery Intent
+
+Eve should not start from "what should I recommend?" It should start from:
+
+```text
+How does this listener want to explore?
+```
+
+V0 intent lanes:
+
+| Intent | User-facing language | Job |
+| --- | --- | --- |
+| Continue | Continue | Find the closest natural next listen. |
+| Go deeper | Go deeper | Move into less obvious but still connected material. |
+| Stranger path | Take a stranger path | Preserve a thread while increasing surprise. |
+| Travel back | Travel back | Move to older influence, era, or scene context. |
+| Travel forward | Travel forward | Move toward descendants, newer scenes, or modern echoes. |
+| Story | Why it matters | Explain context without becoming a long essay. |
+
+These lanes should feel like editorial decisions, not algorithm labels.
+
+## Atlas V0
+
+Atlas should begin as public, indexable exploration pages powered by existing data:
+
+- tag pages such as `/atlas/dream-pop`
+- mood pages such as `/atlas/nocturnal`
+- scene pages such as `/atlas/spanish-new-wave`
+- future artist and route pages when entity depth is ready
+
+Each Atlas page should eventually show:
+
+- a short definition
+- starter picks
+- reviewed tracks
+- nearby tags
+- Eve route lanes
+- human reviews that explain the sound
+
+Do not build a large generic encyclopedia first. Start with the pages that help a listener find what to hear next.
+
+## Eve Contract
+
+Eve is a discovery director, not a generic chat assistant.
+
+Eve may:
+
+- infer likely discovery intent from surface context
+- draft editorial tags for curator review
+- propose route lanes from structured evidence
+- explain why two entities are connected
+- identify missing tags or relationships
+
+Eve must not:
+
+- invent genres as facts
+- publish production metadata without review
+- hide the basis of a recommendation
+- act like a final music authority
+- replace reviews or human taste
+
+Every user-facing Eve route should be explainable from at least one of:
+
+- shared tags
+- starter curation
+- reviews
+- saved/library signals
+- external metadata
+- curator-approved relationships
+
+## Data Direction
+
+The future model should move toward explicit entities and relationships:
+
+```text
+Entity
+  Artist
+  Album
+  Track
+  Genre
+  Mood
+  Style
+  Scene
+  Era
+  Format
+  Label
+
+Relationship
+  belongs_to
+  influenced_by
+  sounds_like
+  gateway_to
+  opposite_of
+  emerged_from
+  evolved_into
+```
+
+Do not introduce a graph engine yet. The first version can live in Postgres with typed relationship tables, readable SQL, and clear evidence fields.
+
+## Immediate Cleanup
+
+The first cleanup pass should:
+
+- move `dreamy` from `genre` to `mood`
+- move `ambient-techno`, `jangle-pop`, and `intelligent-dance-music-idm` into `genre`
+- merge old era aliases such as `seventies` into `1970s`
+- merge `live-sessions` into `live-recordings`
+- keep existing starter, entity, and user tag relations intact
+
+This keeps today's product working while making the next public Atlas/Eve work less messy.
+
+After applying the cleanup migration, run:
+
+```sql
+-- supabase/scripts/maintenance/knowledge-layer-tag-cleanup-check.sql
+```
+
+Every returned row should have `ok = true`.

--- a/supabase/migrations/20260627010620_knowledge_layer_tag_cleanup.sql
+++ b/supabase/migrations/20260627010620_knowledge_layer_tag_cleanup.sql
@@ -1,3 +1,121 @@
+-- Kocteau Knowledge Layer tag cleanup.
+--
+-- This migration keeps `preference_tags` as the current product-facing taste
+-- vocabulary while cleaning obvious taxonomy drift:
+-- - canonical facts stay as genres, eras, and formats
+-- - editorial descriptors stay as moods, scenes, and styles
+-- - duplicate era/format aliases are merged without losing existing relations
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '90s';
+
+CREATE OR REPLACE FUNCTION pg_temp.merge_preference_tag(
+  p_from_slug text,
+  p_to_slug text
+)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_from_id uuid;
+  v_to_id uuid;
+BEGIN
+  SELECT id INTO v_from_id
+  FROM public.preference_tags
+  WHERE slug = p_from_slug
+  FOR UPDATE;
+
+  SELECT id INTO v_to_id
+  FROM public.preference_tags
+  WHERE slug = p_to_slug
+  FOR UPDATE;
+
+  IF v_from_id IS NULL OR v_to_id IS NULL OR v_from_id = v_to_id THEN
+    RETURN;
+  END IF;
+
+  INSERT INTO public.starter_track_tags (
+    starter_track_id,
+    tag_id,
+    weight,
+    created_at
+  )
+  SELECT
+    starter_track_id,
+    v_to_id,
+    weight,
+    created_at
+  FROM public.starter_track_tags
+  WHERE tag_id = v_from_id
+  ON CONFLICT (starter_track_id, tag_id)
+  DO UPDATE SET
+    weight = greatest(public.starter_track_tags.weight, EXCLUDED.weight);
+
+  DELETE FROM public.starter_track_tags
+  WHERE tag_id = v_from_id;
+
+  INSERT INTO public.entity_preference_tags (
+    entity_id,
+    tag_id,
+    source,
+    weight,
+    created_at,
+    updated_at
+  )
+  SELECT
+    entity_id,
+    v_to_id,
+    source,
+    weight,
+    created_at,
+    updated_at
+  FROM public.entity_preference_tags
+  WHERE tag_id = v_from_id
+  ON CONFLICT (entity_id, tag_id)
+  DO UPDATE SET
+    source = CASE
+      WHEN public.entity_preference_tags.source = 'manual'
+        THEN public.entity_preference_tags.source
+      ELSE EXCLUDED.source
+    END,
+    weight = greatest(public.entity_preference_tags.weight, EXCLUDED.weight),
+    updated_at = greatest(public.entity_preference_tags.updated_at, EXCLUDED.updated_at);
+
+  DELETE FROM public.entity_preference_tags
+  WHERE tag_id = v_from_id;
+
+  INSERT INTO public.user_preference_tags (
+    user_id,
+    tag_id,
+    source,
+    weight,
+    created_at,
+    updated_at
+  )
+  SELECT
+    user_id,
+    v_to_id,
+    source,
+    weight,
+    created_at,
+    updated_at
+  FROM public.user_preference_tags
+  WHERE tag_id = v_from_id
+  ON CONFLICT (user_id, tag_id, source)
+  DO UPDATE SET
+    weight = greatest(public.user_preference_tags.weight, EXCLUDED.weight),
+    updated_at = greatest(public.user_preference_tags.updated_at, EXCLUDED.updated_at);
+
+  DELETE FROM public.user_preference_tags
+  WHERE tag_id = v_from_id;
+
+  DELETE FROM public.preference_tags
+  WHERE id = v_from_id;
+END;
+$$;
+
 INSERT INTO public.preference_tags (
   kind,
   slug,
@@ -7,6 +125,8 @@ INSERT INTO public.preference_tags (
   sort_order
 )
 VALUES
+  -- Canonical genre facts. Genres should map to broad external or consensus
+  -- music categories; more subjective texture belongs in mood/style/scene.
   ('genre', 'indie-rock', 'Indie rock', 'Guitar-led independent rock traditions, from college radio to modern indie rooms.', true, 20),
   ('genre', 'shoegaze', 'Shoegaze', 'Dense guitar wash, blurred vocals, and immersive distortion.', true, 30),
   ('genre', 'dream-pop', 'Dream pop', 'Weightless guitars, blurred edges, and melodic drift.', true, 40),
@@ -40,6 +160,8 @@ VALUES
   ('genre', 'house', 'House', 'Four-on-the-floor club music rooted in Chicago, disco, and dance culture.', false, 360),
   ('genre', 'techno', 'Techno', 'Electronic dance music built around machine rhythm, repetition, and futurist pressure.', false, 370),
   ('genre', 'classical', 'Classical', 'Western art music traditions, composition, and long-form interpretation.', false, 380),
+
+  -- Editorial knowledge. These do not need external genre authority.
   ('mood', 'intimate', 'Intimate', 'Close-mic detail, private-room writing, and vulnerable delivery.', true, 10),
   ('mood', 'melancholic', 'Melancholic', 'For songs that sit with longing instead of rushing past it.', true, 20),
   ('mood', 'nostalgic', 'Nostalgic', 'Music that looks backward without becoming only retro.', true, 30),
@@ -60,6 +182,7 @@ VALUES
   ('mood', 'noisy', 'Noisy', 'Distortion, abrasion, or overloaded texture used as expression.', true, 210),
   ('mood', 'chaotic', 'Chaotic', 'Unstable, overloaded, or deliberately disorienting energy.', true, 220),
   ('mood', 'trippy', 'Trippy', 'Psychedelic perception, warped space, or altered-state movement.', true, 440),
+
   ('scene', 'club', 'Club', 'Dancefloor context, DJ culture, and room-centered energy.', true, 20),
   ('scene', 'sad-dancefloor', 'Sad dancefloor', 'Dance music with melancholy or emotional afterglow.', true, 70),
   ('scene', 'grunge-era', 'Grunge era', 'Early-90s alternative guitar culture and its surrounding mood.', true, 84),
@@ -72,6 +195,7 @@ VALUES
   ('scene', 'crate-digging', 'Crate digging', 'Records that reward catalog digging, sampling memory, or collector routes.', true, 410),
   ('scene', 'underground', 'Underground', 'Music circulating through smaller rooms, scenes, or non-mainstream channels.', true, 420),
   ('scene', 'rainy-room', 'Rainy room', 'Small-room, gray-window atmosphere for slower listening.', true, 430),
+
   ('style', 'lo-fi', 'Lo-fi', 'Rougher fidelity, tape grain, or imperfect recording texture.', false, 10),
   ('style', 'hi-fi', 'Hi-fi', 'Clean, detailed, and polished sonic presentation.', false, 20),
   ('style', 'sample-based', 'Sample-based', 'Built from sampled fragments, loops, or collage logic.', false, 50),
@@ -85,6 +209,7 @@ VALUES
   ('style', 'bass-heavy', 'Bass heavy', 'Low-end pressure, bass movement, or bassline identity.', true, 170),
   ('style', 'vocal-forward', 'Vocal forward', 'Voice as the clear emotional or structural center.', true, 180),
   ('style', 'tropical', 'Tropical', 'Warm rhythmic color, island-adjacent texture, or humid brightness.', true, 350),
+
   ('era', 'pre-1970s', 'Pre-1970s', 'Older catalog, standards, early scenes, and records that feel outside the modern cycle.', true, 380),
   ('era', '1970s', '1970s', 'Analog rooms, disco, punk, soul, dub, and early electronic edges.', true, 390),
   ('era', '1980s', '1980s', 'Drum machines, synth gloss, post-punk shadows, and pop becoming cinematic.', true, 400),
@@ -93,6 +218,7 @@ VALUES
   ('era', '2010s', '2010s', 'Streaming-era scenes, bedroom production, and genre borders getting softer.', true, 430),
   ('era', '2020s', '2020s', 'Recent records shaping the current Kocteau listening shelf.', true, 440),
   ('era', 'current', 'Current', 'New and near-current releases that should stay close to the feed.', true, 450),
+
   ('format', 'singles', 'Singles', 'One-track statements, hooks, and quick entry points.', true, 500),
   ('format', 'eps', 'EPs', 'Short-form releases with enough shape to show an artist direction.', true, 510),
   ('format', 'album-focused', 'Album-focused', 'Records that make more sense when heard as a full body of work.', true, 520),
@@ -108,3 +234,12 @@ DO UPDATE SET
   description = EXCLUDED.description,
   is_featured = EXCLUDED.is_featured,
   sort_order = EXCLUDED.sort_order;
+
+SELECT pg_temp.merge_preference_tag('seventies', '1970s');
+SELECT pg_temp.merge_preference_tag('eighties', '1980s');
+SELECT pg_temp.merge_preference_tag('nineties', '1990s');
+SELECT pg_temp.merge_preference_tag('two-thousands', '2000s');
+SELECT pg_temp.merge_preference_tag('twenty-tens', '2010s');
+SELECT pg_temp.merge_preference_tag('live-sessions', 'live-recordings');
+
+COMMIT;

--- a/supabase/scripts/maintenance/knowledge-layer-tag-cleanup-check.sql
+++ b/supabase/scripts/maintenance/knowledge-layer-tag-cleanup-check.sql
@@ -1,0 +1,59 @@
+-- Verify the Knowledge Layer preference tag cleanup after applying
+-- 20260627010620_knowledge_layer_tag_cleanup.sql.
+
+WITH expected_kinds(slug, expected_kind) AS (
+  VALUES
+    ('dreamy', 'mood'::public.preference_kind),
+    ('ambient-techno', 'genre'::public.preference_kind),
+    ('jangle-pop', 'genre'::public.preference_kind),
+    ('intelligent-dance-music-idm', 'genre'::public.preference_kind),
+    ('1970s', 'era'::public.preference_kind),
+    ('1980s', 'era'::public.preference_kind),
+    ('1990s', 'era'::public.preference_kind),
+    ('2000s', 'era'::public.preference_kind),
+    ('2010s', 'era'::public.preference_kind),
+    ('live-recordings', 'format'::public.preference_kind)
+),
+alias_slugs(slug) AS (
+  VALUES
+    ('seventies'),
+    ('eighties'),
+    ('nineties'),
+    ('two-thousands'),
+    ('twenty-tens'),
+    ('live-sessions')
+),
+kind_checks AS (
+  SELECT
+    expected_kinds.slug,
+    expected_kinds.expected_kind::text AS expected_kind,
+    preference_tags.kind::text AS actual_kind,
+    preference_tags.id IS NOT NULL AS exists
+  FROM expected_kinds
+  LEFT JOIN public.preference_tags
+    ON preference_tags.slug = expected_kinds.slug
+),
+alias_checks AS (
+  SELECT
+    alias_slugs.slug,
+    preference_tags.id IS NULL AS removed
+  FROM alias_slugs
+  LEFT JOIN public.preference_tags
+    ON preference_tags.slug = alias_slugs.slug
+)
+SELECT
+  'kind_check' AS check_type,
+  slug,
+  expected_kind,
+  actual_kind,
+  exists AND expected_kind = actual_kind AS ok
+FROM kind_checks
+UNION ALL
+SELECT
+  'alias_removed' AS check_type,
+  slug,
+  'missing' AS expected_kind,
+  CASE WHEN removed THEN 'missing' ELSE 'present' END AS actual_kind,
+  removed AS ok
+FROM alias_checks
+ORDER BY check_type, slug;


### PR DESCRIPTION
## What changed

## Why

## Testing

- [ ] Ran `pnpm check`
- [ ] Added screenshots or a short recording for visible web UI changes
- [ ] Confirmed this does not touch auth, Supabase, recommendations, analytics, CI, or release behavior

## Changelog impact

No manual `CHANGELOG.md` edit is required. Release Please generates release notes from PR titles and squash commits.

- [ ] User-facing web change
- [ ] Developer experience or documentation change
- [ ] Internal-only change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Knowledge Layer and Atlas direction page, with clearer discovery guidance and intent-based exploration paths.
  * Expanded catalog and discovery surfaces with updated tag groupings and new route-based browsing concepts.

* **Bug Fixes**
  * Cleaned up duplicate and outdated preference tags so categories and labels are more consistent across the app.
  * Improved tag mappings and ordering to better reflect the current catalog.

* **Documentation**
  * Updated product docs to clarify discovery principles, Atlas positioning, and the role of intent-driven recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->