### PR TITLE
feat(web): add public atlas tag pages

### DIFF
--- a/apps/web/app/(main)/atlas/[slug]/page.tsx
+++ b/apps/web/app/(main)/atlas/[slug]/page.tsx
@@ -1,0 +1,248 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import EntityCoverImage from "@/components/entity-cover-image";
+import PrefetchLink from "@/components/prefetch-link";
+import { ArrowLeft, ArrowRight, Music2 } from "@/components/ui/icons";
+import { createPageMetadata } from "@/lib/metadata";
+import {
+  getAtlasTagPage,
+  type AtlasStarterPick,
+  type AtlasTag,
+} from "@/lib/queries/atlas";
+import { buildEntityCanonicalPath } from "@/lib/seo-routes";
+import { preferenceKindLabels } from "@/lib/taste";
+
+export const revalidate = 1800;
+
+type AtlasTagRouteProps = {
+  params: Promise<{ slug: string }>;
+};
+
+type IntentLane = {
+  label: string;
+  description: string;
+  href: string;
+};
+
+export async function generateMetadata({
+  params,
+}: AtlasTagRouteProps): Promise<Metadata> {
+  const { slug } = await params;
+  const atlasPage = await getAtlasTagPage(slug);
+
+  if (!atlasPage) {
+    return createPageMetadata({
+      title: "Atlas",
+      description: "Explore Kocteau's taste signals.",
+      path: `/atlas/${slug}`,
+      noIndex: true,
+    });
+  }
+
+  const description =
+    atlasPage.tag.description ??
+    `Explore ${atlasPage.tag.label} through Kocteau starter picks and nearby taste signals.`;
+
+  return createPageMetadata({
+    title: `${atlasPage.tag.label} Atlas`,
+    description,
+    path: `/atlas/${atlasPage.tag.slug}`,
+  });
+}
+
+function buildIntentLanes(tag: AtlasTag, relatedTags: AtlasTag[]): IntentLane[] {
+  const sameKind = relatedTags.find((item) => item.kind === tag.kind);
+  const otherKind = relatedTags.find((item) => item.kind !== tag.kind);
+  const deeper = relatedTags.find(
+    (item) => item.starterPickCount > 0 && item.id !== sameKind?.id,
+  );
+
+  return [
+    {
+      label: "Continue",
+      description: sameKind
+        ? `Stay close through ${sameKind.label}.`
+        : `Stay close to ${tag.label}.`,
+      href: sameKind ? `/atlas/${sameKind.slug}` : `/search?q=${encodeURIComponent(tag.label)}`,
+    },
+    {
+      label: "Go deeper",
+      description: deeper
+        ? `Use ${deeper.label} as the next shelf.`
+        : "Open the starter shelf behind this signal.",
+      href: deeper ? `/atlas/${deeper.slug}` : `/search?q=${encodeURIComponent(tag.label)}`,
+    },
+    {
+      label: "Take a stranger path",
+      description: otherKind
+        ? `Keep one thread and move toward ${otherKind.label}.`
+        : "Move outward from this signal into Kocteau's wider map.",
+      href: otherKind ? `/atlas/${otherKind.slug}` : "/atlas",
+    },
+  ];
+}
+
+function StarterPickRow({ pick }: { pick: AtlasStarterPick }) {
+  const trackPath = buildEntityCanonicalPath({
+    provider: pick.provider,
+    provider_id: pick.provider_id,
+    type: pick.type,
+    title: pick.title,
+    artist_name: pick.artist_name,
+  });
+  const supportingCopy = pick.prompt ?? pick.editorial_note;
+
+  return (
+    <PrefetchLink
+      href={trackPath}
+      className="group grid min-h-[5.75rem] grid-cols-[4.4rem_minmax(0,1fr)_auto] items-center gap-3 rounded-[1rem] bg-[var(--kocteau-surface)] px-3 py-3 shadow-[var(--kocteau-shadow-card)] transition-[background-color,box-shadow] duration-150 ease-[var(--kocteau-ease)] hover:bg-[var(--kocteau-surface-raised)] hover:shadow-[var(--kocteau-shadow-card-hover)] sm:grid-cols-[5rem_minmax(0,1fr)_auto] sm:gap-4 sm:px-4"
+    >
+      <EntityCoverImage
+        src={pick.cover_url}
+        alt={pick.title}
+        sizes="80px"
+        quality={70}
+        className="size-16 rounded-[0.78rem] bg-muted sm:size-18"
+        iconClassName="size-5"
+      />
+
+      <div className="min-w-0 space-y-1">
+        <h2 className="line-clamp-1 text-sm font-semibold text-foreground sm:text-base">
+          {pick.title}
+        </h2>
+        <p className="line-clamp-1 text-xs text-muted-foreground sm:text-sm">
+          {pick.artist_name ?? "Unknown artist"}
+        </p>
+        {supportingCopy ? (
+          <p className="line-clamp-1 max-w-2xl text-xs leading-5 text-muted-foreground/82">
+            {supportingCopy}
+          </p>
+        ) : null}
+      </div>
+
+      <ArrowRight className="size-4 text-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-foreground" />
+    </PrefetchLink>
+  );
+}
+
+function RelatedTagLink({ tag }: { tag: AtlasTag }) {
+  return (
+    <PrefetchLink
+      href={`/atlas/${tag.slug}`}
+      className="inline-flex min-h-8 items-center gap-2 whitespace-nowrap rounded-full bg-[var(--kocteau-surface-control)] px-3 text-xs font-medium text-foreground/88 transition-colors hover:bg-[var(--kocteau-surface-control-hover)] hover:text-foreground"
+    >
+      <span className="text-muted-foreground">{preferenceKindLabels[tag.kind]}</span>
+      <span>{tag.label}</span>
+    </PrefetchLink>
+  );
+}
+
+export default async function AtlasTagPage({ params }: AtlasTagRouteProps) {
+  const { slug } = await params;
+  const atlasPage = await getAtlasTagPage(slug);
+
+  if (!atlasPage) {
+    notFound();
+  }
+
+  const { tag, picks, relatedTags } = atlasPage;
+  const intentLanes = buildIntentLanes(tag, relatedTags);
+
+  return (
+    <section className="mx-auto flex w-full max-w-5xl flex-col gap-8 pb-16 lg:mx-0 lg:max-w-none">
+      <header className="space-y-6 border-b border-border/22 pb-6">
+        <PrefetchLink
+          href="/atlas"
+          className="group inline-flex items-center gap-2 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <ArrowLeft className="size-3.5 transition-transform group-hover:-translate-x-0.5" />
+          Atlas
+        </PrefetchLink>
+
+        <div className="flex flex-col gap-5 sm:flex-row sm:items-end sm:justify-between">
+          <div className="max-w-3xl space-y-3">
+            <p className="text-xs font-medium text-muted-foreground">
+              {preferenceKindLabels[tag.kind]}
+            </p>
+            <h1 className="text-balance font-serif text-4xl font-semibold tracking-normal text-foreground sm:text-5xl">
+              {tag.label}
+            </h1>
+            <p className="max-w-2xl text-pretty text-sm leading-6 text-muted-foreground sm:text-[0.95rem]">
+              {tag.description ??
+                "A Kocteau taste signal for finding records through context, not only similarity."}
+            </p>
+          </div>
+
+          <PrefetchLink
+            href={`/search?q=${encodeURIComponent(tag.label)}`}
+            className="inline-flex min-h-10 items-center justify-center rounded-full bg-foreground px-4 text-sm font-semibold text-background transition-[transform,background-color] duration-150 ease-[var(--kocteau-ease)] hover:bg-foreground/90 active:scale-[0.98]"
+          >
+            Find tracks
+          </PrefetchLink>
+        </div>
+      </header>
+
+      <section className="space-y-3">
+        <h2 className="text-sm font-semibold text-foreground">Routes</h2>
+        <div className="grid gap-2 sm:grid-cols-3">
+          {intentLanes.map((lane) => (
+            <PrefetchLink
+              key={lane.label}
+              href={lane.href}
+              className="group min-h-[5.5rem] rounded-[1rem] bg-[var(--kocteau-surface)] p-4 shadow-[var(--kocteau-shadow-card)] transition-[background-color,box-shadow] duration-150 ease-[var(--kocteau-ease)] hover:bg-[var(--kocteau-surface-raised)] hover:shadow-[var(--kocteau-shadow-card-hover)]"
+            >
+              <span className="flex items-center justify-between gap-3 text-sm font-semibold text-foreground">
+                {lane.label}
+                <ArrowRight className="size-3.5 text-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-foreground" />
+              </span>
+              <p className="mt-2 text-pretty text-xs leading-5 text-muted-foreground">
+                {lane.description}
+              </p>
+            </PrefetchLink>
+          ))}
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <div className="flex items-center justify-between gap-4">
+          <h2 className="text-sm font-semibold text-foreground">Starter picks</h2>
+          {picks.length > 0 ? (
+            <span className="text-xs text-muted-foreground">
+              Curated from Studio
+            </span>
+          ) : null}
+        </div>
+
+        {picks.length > 0 ? (
+          <div className="grid gap-2.5">
+            {picks.map((pick) => (
+              <StarterPickRow key={pick.id} pick={pick} />
+            ))}
+          </div>
+        ) : (
+          <div className="flex min-h-36 flex-col items-center justify-center rounded-[1rem] bg-[var(--kocteau-surface)] px-6 py-8 text-center shadow-[var(--kocteau-shadow-card)]">
+            <Music2 className="mb-3 size-5 text-muted-foreground" />
+            <h2 className="text-sm font-semibold text-foreground">
+              No starter picks yet
+            </h2>
+            <p className="mt-1 max-w-sm text-pretty text-xs leading-5 text-muted-foreground">
+              This signal is in the vocabulary, but it still needs an editorial
+              shelf before it can guide discovery.
+            </p>
+          </div>
+        )}
+      </section>
+
+      {relatedTags.length > 0 ? (
+        <section className="space-y-3">
+          <h2 className="text-sm font-semibold text-foreground">Nearby signals</h2>
+          <div className="scroll-mask-x no-scrollbar -mx-1 flex gap-2 overflow-x-auto px-1 pb-1">
+            {relatedTags.map((relatedTag) => (
+              <RelatedTagLink key={relatedTag.id} tag={relatedTag} />
+            ))}
+          </div>
+        </section>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/app/(main)/atlas/page.tsx
+++ b/apps/web/app/(main)/atlas/page.tsx
@@ -1,0 +1,125 @@
+import type { Metadata } from "next";
+import PrefetchLink from "@/components/prefetch-link";
+import { ArrowRight } from "@/components/ui/icons";
+import { createPageMetadata } from "@/lib/metadata";
+import { getAtlasTags, type AtlasTag } from "@/lib/queries/atlas";
+import {
+  groupPreferenceTags,
+  preferenceKindDescriptions,
+  preferenceKindLabels,
+  preferenceKindOrder,
+} from "@/lib/taste";
+import { cn } from "@/lib/utils";
+
+export const revalidate = 1800;
+
+export const metadata: Metadata = createPageMetadata({
+  title: "Atlas",
+  description:
+    "Explore Kocteau music taste vocabulary through genres, moods, scenes, styles, eras, and formats.",
+  path: "/atlas",
+});
+
+function AtlasTagLink({ tag }: { tag: AtlasTag }) {
+  const hasStarterPicks = tag.starterPickCount > 0;
+
+  return (
+    <PrefetchLink
+      href={`/atlas/${tag.slug}`}
+      className={cn(
+        "group inline-flex min-h-9 items-center gap-2 whitespace-nowrap rounded-full px-3.5 text-sm font-medium leading-none transition-[background-color,color,opacity] duration-150 ease-[var(--kocteau-ease)]",
+        hasStarterPicks
+          ? "bg-[var(--kocteau-surface-control)] text-foreground hover:bg-[var(--kocteau-surface-control-hover)]"
+          : "bg-foreground/[0.035] text-muted-foreground hover:bg-foreground/[0.06] hover:text-foreground/82",
+      )}
+    >
+      <span>{tag.label}</span>
+      {hasStarterPicks ? (
+        <span
+          aria-hidden="true"
+          className="h-1.5 w-1.5 rounded-full bg-foreground/38 transition-colors group-hover:bg-foreground/55"
+        />
+      ) : null}
+    </PrefetchLink>
+  );
+}
+
+export default async function AtlasPage() {
+  const tags = await getAtlasTags();
+  const groupedTags = groupPreferenceTags(tags);
+  const featuredTags = tags
+    .filter((tag) => tag.is_featured && tag.starterPickCount > 0)
+    .slice(0, 12);
+
+  return (
+    <section className="mx-auto flex w-full max-w-5xl flex-col gap-8 pb-16 lg:mx-0 lg:max-w-none">
+      <header className="border-b border-border/22 pb-6 sm:pb-7">
+        <div className="max-w-3xl space-y-3">
+          <p className="text-xs font-medium text-muted-foreground">Atlas</p>
+          <h1 className="text-balance font-serif text-4xl font-semibold tracking-normal text-foreground sm:text-5xl">
+            Start with a sound, a room, or a feeling.
+          </h1>
+          <p className="max-w-2xl text-pretty text-sm leading-6 text-muted-foreground sm:text-[0.95rem]">
+            Kocteau Atlas is a public map of the signals behind discovery:
+            genres, moods, scenes, styles, eras, and listening formats that
+            point toward something worth hearing next.
+          </p>
+        </div>
+      </header>
+
+      {featuredTags.length > 0 ? (
+        <section className="space-y-3">
+          <div className="flex items-center justify-between gap-4">
+            <h2 className="text-sm font-semibold text-foreground">
+              Starter-backed signals
+            </h2>
+            <PrefetchLink
+              href="/search"
+              className="group hidden items-center gap-1.5 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground sm:inline-flex"
+            >
+              Explore tracks
+              <ArrowRight className="size-3.5 transition-transform group-hover:translate-x-0.5" />
+            </PrefetchLink>
+          </div>
+          <div className="scroll-mask-x no-scrollbar -mx-1 flex gap-2 overflow-x-auto px-1 pb-1">
+            {featuredTags.map((tag) => (
+              <AtlasTagLink key={tag.id} tag={tag} />
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      <div className="divide-y divide-border/18">
+        {preferenceKindOrder.map((kind) => {
+          const kindTags = groupedTags.get(kind) ?? [];
+
+          if (kindTags.length === 0) {
+            return null;
+          }
+
+          return (
+            <section
+              key={kind}
+              className="grid gap-4 py-6 first:pt-0 sm:grid-cols-[minmax(10rem,14rem)_minmax(0,1fr)] sm:gap-8"
+            >
+              <div className="space-y-1.5">
+                <h2 className="text-base font-semibold text-foreground">
+                  {preferenceKindLabels[kind]}
+                </h2>
+                <p className="text-pretty text-xs leading-5 text-muted-foreground">
+                  {preferenceKindDescriptions[kind]}
+                </p>
+              </div>
+
+              <div className="flex flex-wrap gap-2">
+                {kindTags.map((tag) => (
+                  <AtlasTagLink key={tag.id} tag={tag} />
+                ))}
+              </div>
+            </section>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -29,11 +29,16 @@ type SitemapReview = {
   entities: SitemapEntity | SitemapEntity[] | null;
 };
 
+type SitemapPreferenceTag = {
+  slug: string;
+  created_at: string;
+};
+
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const metadataBase = getMetadataBase();
   const supabase = supabasePublic();
   const now = new Date();
-  const [profilesResult, reviewsResult] = await Promise.all([
+  const [profilesResult, reviewsResult, atlasTagsResult] = await Promise.all([
     supabase
       .from("profiles")
       .select("username, created_at, updated_at")
@@ -60,10 +65,15 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       `)
       .order("updated_at", { ascending: false })
       .limit(5000),
+    supabase
+      .from("preference_tags")
+      .select("slug, created_at")
+      .order("sort_order", { ascending: true }),
   ]);
 
   const profiles = (profilesResult.data ?? []) as SitemapProfile[];
   const reviews = (reviewsResult.data ?? []) as SitemapReview[];
+  const atlasTags = (atlasTagsResult.data ?? []) as SitemapPreferenceTag[];
   const reviewedTracks = new Map<
     string,
     {
@@ -119,6 +129,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: "daily",
       priority: 0.65,
     },
+    {
+      url: new URL("/atlas", metadataBase).toString(),
+      lastModified: now,
+      changeFrequency: "weekly",
+      priority: 0.62,
+    },
     ...helpRoutes.map((route) => ({
       url: new URL(route.href, metadataBase).toString(),
       lastModified: now,
@@ -158,5 +174,18 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     priority: 0.8,
   }));
 
-  return [...staticRoutes, ...reviewRoutes, ...trackRoutes, ...profileRoutes];
+  const atlasRoutes: MetadataRoute.Sitemap = atlasTags.map((tag) => ({
+    url: new URL(`/atlas/${tag.slug}`, metadataBase).toString(),
+    lastModified: new Date(tag.created_at),
+    changeFrequency: "weekly",
+    priority: 0.54,
+  }));
+
+  return [
+    ...staticRoutes,
+    ...reviewRoutes,
+    ...trackRoutes,
+    ...profileRoutes,
+    ...atlasRoutes,
+  ];
 }

--- a/apps/web/components/app-sidebar.tsx
+++ b/apps/web/components/app-sidebar.tsx
@@ -177,6 +177,12 @@ export default function AppSidebar({
       isActive: pathname.startsWith("/search") || pathname.startsWith("/track"),
     },
     {
+      title: "Atlas",
+      url: "/atlas",
+      icon: KocteauStarterIcon,
+      isActive: pathname.startsWith("/atlas"),
+    },
+    {
       title: "Feedback",
       url: FEEDBACK_URL,
       icon: ChatCircleTextIcon,

--- a/apps/web/lib/queries/atlas.ts
+++ b/apps/web/lib/queries/atlas.ts
@@ -1,0 +1,236 @@
+import "server-only";
+
+import { cache } from "react";
+import type { PreferenceKind, PreferenceTag } from "@/lib/taste";
+import { preferenceKindOrder } from "@/lib/taste";
+import type { Tables } from "@/lib/supabase/database.types";
+import { supabasePublic } from "@/lib/supabase/public";
+
+type StarterTrackRow = Pick<
+  Tables<"starter_tracks">,
+  | "id"
+  | "provider"
+  | "provider_id"
+  | "type"
+  | "title"
+  | "artist_name"
+  | "cover_url"
+  | "deezer_url"
+  | "prompt"
+  | "editorial_note"
+  | "is_featured"
+  | "sort_order"
+  | "created_at"
+>;
+
+type StarterTrackTagRow = Pick<
+  Tables<"starter_track_tags">,
+  "starter_track_id" | "tag_id" | "weight"
+>;
+
+export type AtlasTag = PreferenceTag & {
+  starterPickCount: number;
+};
+
+export type AtlasStarterPick = StarterTrackRow & {
+  tagWeight: number;
+};
+
+export type AtlasTagPage = {
+  tag: AtlasTag;
+  picks: AtlasStarterPick[];
+  relatedTags: AtlasTag[];
+};
+
+const tagSelect =
+  "id, kind, slug, label, description, is_featured, sort_order, created_at";
+const starterTrackSelect =
+  "id, provider, provider_id, type, title, artist_name, cover_url, deezer_url, prompt, editorial_note, is_featured, sort_order, created_at";
+
+function compareTags(first: Pick<AtlasTag, "kind" | "sort_order" | "label">, second: Pick<AtlasTag, "kind" | "sort_order" | "label">) {
+  const firstKind = preferenceKindOrder.indexOf(first.kind);
+  const secondKind = preferenceKindOrder.indexOf(second.kind);
+
+  if (firstKind !== secondKind) {
+    return firstKind - secondKind;
+  }
+
+  if (first.sort_order !== second.sort_order) {
+    return first.sort_order - second.sort_order;
+  }
+
+  return first.label.localeCompare(second.label);
+}
+
+function compareRelatedTags(activeKind: PreferenceKind) {
+  return (first: AtlasTag, second: AtlasTag) => {
+    const firstSameKind = first.kind === activeKind ? 0 : 1;
+    const secondSameKind = second.kind === activeKind ? 0 : 1;
+
+    if (firstSameKind !== secondSameKind) {
+      return firstSameKind - secondSameKind;
+    }
+
+    if (first.starterPickCount !== second.starterPickCount) {
+      return second.starterPickCount - first.starterPickCount;
+    }
+
+    if (first.is_featured !== second.is_featured) {
+      return first.is_featured ? -1 : 1;
+    }
+
+    return compareTags(first, second);
+  };
+}
+
+export const getAtlasTags = cache(async (): Promise<AtlasTag[]> => {
+  const supabase = supabasePublic();
+  const [tagsResult, starterTracksResult] = await Promise.all([
+    supabase
+      .from("preference_tags")
+      .select(tagSelect)
+      .order("sort_order", { ascending: true })
+      .order("label", { ascending: true })
+      .returns<PreferenceTag[]>(),
+    supabase
+      .from("starter_tracks")
+      .select("id")
+      .eq("is_active", true)
+      .returns<Array<Pick<Tables<"starter_tracks">, "id">>>(),
+  ]);
+
+  if (tagsResult.error) {
+    console.error("[atlas.getAtlasTags] tags query failed", {
+      code: tagsResult.error.code ?? null,
+      message: tagsResult.error.message ?? null,
+    });
+
+    return [];
+  }
+
+  if (starterTracksResult.error) {
+    console.error("[atlas.getAtlasTags] starter track query failed", {
+      code: starterTracksResult.error.code ?? null,
+      message: starterTracksResult.error.message ?? null,
+    });
+  }
+
+  const activeStarterTrackIds = (starterTracksResult.data ?? []).map((track) => track.id);
+  const tagCounts = new Map<string, number>();
+
+  if (activeStarterTrackIds.length > 0) {
+    const tagLinksResult = await supabase
+      .from("starter_track_tags")
+      .select("tag_id, starter_track_id")
+      .in("starter_track_id", activeStarterTrackIds)
+      .returns<Array<Pick<StarterTrackTagRow, "tag_id" | "starter_track_id">>>();
+
+    if (tagLinksResult.error) {
+      console.error("[atlas.getAtlasTags] tag link query failed", {
+        code: tagLinksResult.error.code ?? null,
+        message: tagLinksResult.error.message ?? null,
+      });
+    }
+
+    for (const row of tagLinksResult.data ?? []) {
+      tagCounts.set(row.tag_id, (tagCounts.get(row.tag_id) ?? 0) + 1);
+    }
+  }
+
+  return (tagsResult.data ?? [])
+    .map((tag) => ({
+      ...tag,
+      starterPickCount: tagCounts.get(tag.id) ?? 0,
+    }))
+    .sort(compareTags);
+});
+
+export const getAtlasTagPage = cache(async (slug: string): Promise<AtlasTagPage | null> => {
+  const tags = await getAtlasTags();
+  const tag = tags.find((item) => item.slug === slug);
+
+  if (!tag) {
+    return null;
+  }
+
+  const picks = await getStarterPicksForAtlasTag(tag.id, 12);
+  const relatedTags = tags
+    .filter((item) => item.id !== tag.id)
+    .filter((item) => item.kind === tag.kind || item.starterPickCount > 0)
+    .sort(compareRelatedTags(tag.kind))
+    .slice(0, 14);
+
+  return {
+    tag,
+    picks,
+    relatedTags,
+  };
+});
+
+async function getStarterPicksForAtlasTag(
+  tagId: string,
+  limit: number,
+): Promise<AtlasStarterPick[]> {
+  const supabase = supabasePublic();
+  const requestedLimit = Math.max(1, Math.min(limit, 24));
+  const tagLinksResult = await supabase
+    .from("starter_track_tags")
+    .select("starter_track_id, tag_id, weight")
+    .eq("tag_id", tagId)
+    .order("weight", { ascending: false })
+    .limit(requestedLimit * 3)
+    .returns<StarterTrackTagRow[]>();
+
+  if (tagLinksResult.error) {
+    console.error("[atlas.getStarterPicksForAtlasTag] tag links query failed", {
+      code: tagLinksResult.error.code ?? null,
+      message: tagLinksResult.error.message ?? null,
+    });
+
+    return [];
+  }
+
+  const tagLinks = tagLinksResult.data ?? [];
+  const starterTrackIds = tagLinks.map((row) => row.starter_track_id);
+
+  if (starterTrackIds.length === 0) {
+    return [];
+  }
+
+  const tracksResult = await supabase
+    .from("starter_tracks")
+    .select(starterTrackSelect)
+    .in("id", starterTrackIds)
+    .eq("is_active", true)
+    .returns<StarterTrackRow[]>();
+
+  if (tracksResult.error) {
+    console.error("[atlas.getStarterPicksForAtlasTag] starter tracks query failed", {
+      code: tracksResult.error.code ?? null,
+      message: tracksResult.error.message ?? null,
+    });
+
+    return [];
+  }
+
+  const tracksById = new Map((tracksResult.data ?? []).map((track) => [track.id, track]));
+
+  return tagLinks
+    .flatMap((row) => {
+      const track = tracksById.get(row.starter_track_id);
+
+      return track ? [{ ...track, tagWeight: row.weight }] : [];
+    })
+    .sort((first, second) => {
+      if (first.tagWeight !== second.tagWeight) {
+        return second.tagWeight - first.tagWeight;
+      }
+
+      if (first.is_featured !== second.is_featured) {
+        return first.is_featured ? -1 : 1;
+      }
+
+      return first.sort_order - second.sort_order;
+    })
+    .slice(0, requestedLimit);
+}

--- a/apps/web/lib/taste.ts
+++ b/apps/web/lib/taste.ts
@@ -34,8 +34,8 @@ export const preferenceKindDescriptions = {
   format: "How you tend to listen.",
 } satisfies Record<PreferenceKind, string>;
 
-export function groupPreferenceTags(tags: PreferenceTag[]) {
-  const grouped = new Map<PreferenceKind, PreferenceTag[]>();
+export function groupPreferenceTags<T extends PreferenceTag>(tags: T[]) {
+  const grouped = new Map<PreferenceKind, T[]>();
 
   for (const kind of preferenceKindOrder) {
     grouped.set(kind, []);

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -62,7 +62,7 @@ These are the next useful moves after enabling public contribution.
 | P1 | Add a short "first contribution path" section to the README with links to good first issues. | ready | `docs`, `area:docs`, `good first issue` |
 | P1 | Open discovery and curation issues from `docs/discovery-curation.md` with clear owner lanes. | done | `docs`, `area:recommendations`, `needs maintainer decision` |
 | P1 | Add a private track library signal on track pages. | in progress | `feature`, `area:web`, `area:supabase`, `area:recommendations` |
-| P1 | Design public Atlas tag pages that help listeners explore genres, moods, scenes, and styles without turning the product into a generic wiki. | needs design ([#126](https://github.com/francozeta/kocteau/issues/126)) | `feature`, `design`, `area:web`, `area:recommendations` |
+| P1 | Design public Atlas tag pages that help listeners explore genres, moods, scenes, and styles without turning the product into a generic wiki. | in progress ([#126](https://github.com/francozeta/kocteau/issues/126)) | `feature`, `design`, `area:web`, `area:recommendations` |
 | P1 | Design Eve route lanes around discovery intent: Continue, Go deeper, Take a stranger path, Travel back, and Travel forward. | needs design ([#127](https://github.com/francozeta/kocteau/issues/127)) | `feature`, `design`, `area:web`, `area:recommendations`, `needs maintainer decision` |
 | P1 | Add an editable taste preferences path after onboarding. | needs design | `feature`, `area:web`, `area:recommendations` |
 | P1 | Add a mobile social discovery carousel near review detail pages. | needs design ([#90](https://github.com/francozeta/kocteau/issues/90)) | `feature`, `area:web`, `area:ui` |

--- a/docs/knowledge-layer.md
+++ b/docs/knowledge-layer.md
@@ -151,6 +151,13 @@ Each Atlas page should eventually show:
 
 Do not build a large generic encyclopedia first. Start with the pages that help a listener find what to hear next.
 
+Current phase 1 implementation:
+
+- `/atlas` lists the current `preference_tags` vocabulary by kind.
+- `/atlas/[slug]` explains one signal, links nearby signals, and shows active starter picks attached through `starter_track_tags`.
+- The surface is intentionally read-only and powered by existing public tables.
+- Eve route language appears as directional lanes, but there is no AI generation or graph engine in this phase.
+
 ## Eve Contract
 
 Eve is a discovery director, not a generic chat assistant.


### PR DESCRIPTION
## What changed

Added public Atlas V0:
- `/atlas`
- `/atlas/[slug]`
- Atlas query layer over `preference_tags`, `starter_track_tags`, and `starter_tracks`
- Atlas links in desktop sidebar
- Atlas routes in sitemap
- Knowledge Layer docs/backlog updated

## Why

To make Kocteau discovery visible publicly through genres, moods, scenes, styles, eras, and formats without building a heavy graph engine yet.

## Testing

- [x] Ran `pnpm check`
- [x] Added screenshots or a short recording for visible web UI changes
- [x] Confirmed this does not touch auth, Supabase, recommendations, analytics, CI, or release behavior

## Changelog impact

No manual `CHANGELOG.md` edit is required. Release Please generates release notes from PR titles and squash commits.

- [x] User-facing web change
- [x] Developer experience or documentation change
- [ ] Internal-only change

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds public Atlas at `/atlas` and `/atlas/[slug]` to explore Kocteau taste signals with starter-backed picks. Includes a server query layer, a sidebar link, sitemap coverage, and docs updates.

- New Features
  - Atlas index: lists tags by kind and highlights featured tags with active starter picks.
  - Tag page: shows description, “Routes” lanes (Continue, Go deeper, Take a stranger path), starter picks, and nearby signals.
  - Query layer: cached server functions over `preference_tags`, `starter_track_tags`, and `starter_tracks` with 30‑min revalidate.
  - Navigation + SEO: adds “Atlas” to the desktop sidebar and includes `/atlas` and tag pages in the sitemap.

<sup>Written for commit 0e6bf2b80c5b2c47bc605c8182d1d2a6cee5a858. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/francozeta/kocteau/pull/129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new **Atlas** section in the app, including an index page and individual tag pages.
  * Atlas pages now show related paths, starter picks, and nearby signals for easier discovery.
  * Added Atlas links to the main sidebar and sitemap for better navigation and search visibility.

* **Bug Fixes**
  * Missing Atlas tags now return a proper not-found experience.
  * Atlas pages now generate clearer page metadata, including no-index handling for unavailable content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->