### PR TITLE
perf(routing): isolate public home from feed

### DIFF
--- a/apps/web/app/(auth)/onboarding/page.tsx
+++ b/apps/web/app/(auth)/onboarding/page.tsx
@@ -64,7 +64,7 @@ export default async function OnboardingPage({
       redirect(appendInternalNext("/onboarding/taste", nextPath));
     }
 
-    redirect(nextPath ?? "/");
+    redirect(nextPath ?? "/feed");
   }
 
   return <ProfileOnboardingFlow initialProfile={profile ?? undefined} nextPath={nextPath} />;

--- a/apps/web/app/(auth)/onboarding/taste/page.tsx
+++ b/apps/web/app/(auth)/onboarding/taste/page.tsx
@@ -51,7 +51,7 @@ export default async function TasteOnboardingPage({
   }
 
   if (profile?.taste_onboarded && !isEditMode) {
-    redirect(nextPath ?? "/");
+    redirect(nextPath ?? "/feed");
   }
 
   const [{ data: tags }, { data: selectedTags }] = await Promise.all([

--- a/apps/web/app/(home)/page.tsx
+++ b/apps/web/app/(home)/page.tsx
@@ -2,28 +2,21 @@ import { HydrationBoundary, dehydrate } from "@tanstack/react-query";
 
 import ReactQueryProvider from "@/app/providers/react-query-provider";
 import { circular, redaction } from "@/app/landing-fonts";
-import AppShell from "@/components/app-shell";
-import { OnboardingWelcomeFromUrl } from "@/components/auth/onboarding-welcome-dialog";
-import FeedReviewList from "@/components/feed-review-list";
-import FeedViewTabs from "@/components/feed-view-tabs";
 import GuestHeader from "@/components/guest-header";
 import GuestHome from "@/components/guest-home";
 import JsonLd from "@/components/json-ld";
-import { getCurrentUser, getCurrentViewerProfile } from "@/lib/auth/server";
-import { isFeedView } from "@/lib/feed-view";
 import { createPageMetadata } from "@/lib/metadata";
 import { measureServerTask } from "@/lib/perf";
-import { getFeedPage, getFeedViewerState } from "@/lib/queries/feed";
-import {
-  getPublicStarterTracks,
-  getStarterTracksForSurface,
-} from "@/lib/queries/starter";
+import { getFeedPage } from "@/lib/queries/feed";
+import { getPublicStarterTracks } from "@/lib/queries/starter";
 import { createServerQueryClient } from "@/lib/react-query/server";
 import {
   buildFeedPageJsonLd,
   buildHomePageJsonLd,
 } from "@/lib/structured-data";
 import { feedKeys, type FeedInfiniteQueryData } from "@/queries/feed";
+
+export const revalidate = 300;
 
 export const metadata = createPageMetadata({
   title: "Music reviews from real listeners",
@@ -32,164 +25,80 @@ export const metadata = createPageMetadata({
   path: "/",
 });
 
-export default async function HomePage({
-  searchParams,
-}: {
-  searchParams: Promise<{ view?: string; welcome?: string }>;
-}) {
-  const params = await searchParams;
-  const requestedView =
-    isFeedView(params.view) && params.view !== "latest" ? params.view : null;
-  const user = await measureServerTask("getHomeViewer", getCurrentUser, {
-    route: "/",
-  });
-  const activeView = user ? requestedView ?? "for-you" : "latest";
-  const tabActiveView = activeView === "latest" ? "for-you" : activeView;
-
-  const starterTracksPromise = user?.id
-    ? getStarterTracksForSurface({
-        viewerId: user.id,
-        limit: 6,
-        surface: "home",
-        contextKey: "home",
-      })
-    : getPublicStarterTracks({ limit: 6, contextKey: "home" });
-
-  const [publicBundle, starterTracks, viewerProfile] = await measureServerTask(
-    "getHomePrimaryData",
+export default async function HomePage() {
+  const [publicBundle, starterTracks] = await measureServerTask(
+    "getPublicHomeData",
     () =>
       Promise.all([
         getFeedPage({
-          view: activeView,
-          viewerId: user?.id,
+          view: "latest",
+          limit: 3,
           includeActiveUsers: false,
+          revalidateSeconds: 5 * 60,
         }),
-        starterTracksPromise,
-        user ? getCurrentViewerProfile() : Promise.resolve(null),
+        getPublicStarterTracks({ limit: 6, contextKey: "home" }),
       ]),
-    {
-      route: "/",
-      view: activeView,
-      authenticated: Boolean(user),
-    },
+    { route: "/" },
   );
 
-  const viewerState =
-    user?.id && publicBundle.feed.length > 0
-      ? await getFeedViewerState(
-          user.id,
-          publicBundle.feed.map((review) => review.id),
-        )
-      : {
-          likedReviewIds: new Set<string>(),
-          bookmarkedReviewIds: new Set<string>(),
-        };
-
-  const feedData = {
-    feed: publicBundle.feed.map((review) => ({
-      ...review,
-      viewer_has_liked: viewerState.likedReviewIds.has(review.id),
-      viewer_has_bookmarked: viewerState.bookmarkedReviewIds.has(review.id),
-    })),
+  const recentPage = {
+    ...publicBundle,
     activeUsers: [],
-    nextCursor: publicBundle.nextCursor,
-    view: publicBundle.view,
-    requiresAuth:
-      (activeView === "following" || activeView === "for-you") && !user,
-  };
-
-  const guestRecentPage = {
-    ...feedData,
-    feed: feedData.feed.slice(0, 3),
     nextCursor: null,
+    requiresAuth: false,
   };
-  const hydratedFeedData = user ? feedData : guestRecentPage;
   const queryClient = createServerQueryClient();
 
-  queryClient.setQueryData(feedKeys.bundle(activeView), hydratedFeedData);
-  queryClient.setQueryData<FeedInfiniteQueryData>(feedKeys.infinite(activeView), {
-    pages: [hydratedFeedData],
+  queryClient.setQueryData(feedKeys.bundle("latest"), recentPage);
+  queryClient.setQueryData<FeedInfiniteQueryData>(feedKeys.infinite("latest"), {
+    pages: [recentPage],
     pageParams: [null],
   });
 
   const feedStructuredData = buildFeedPageJsonLd(
-    feedData.feed
-      .flatMap((review) => {
-        const entity = review.entities;
-        const author = review.author;
+    recentPage.feed.flatMap((review) => {
+      const entity = review.entities;
+      const author = review.author;
 
-        if (!entity?.id || !author?.username) {
-          return [];
-        }
+      if (!entity?.id || !author?.username) {
+        return [];
+      }
 
-        return [
-          {
-            reviewId: review.id,
-            reviewTitle: review.title,
-            reviewBody: review.body,
-            rating: review.rating,
-            entity: {
-              id: entity.id,
-              provider: entity.provider,
-              providerId: entity.provider_id,
-              type: entity.type,
-              title: entity.title,
-              artistName: entity.artist_name,
-              coverUrl: entity.cover_url,
-            },
-            author: {
-              username: author.username,
-              displayName: author.display_name,
-            },
+      return [
+        {
+          reviewId: review.id,
+          reviewTitle: review.title,
+          reviewBody: review.body,
+          rating: review.rating,
+          entity: {
+            id: entity.id,
+            provider: entity.provider,
+            providerId: entity.provider_id,
+            type: entity.type,
+            title: entity.title,
+            artistName: entity.artist_name,
+            coverUrl: entity.cover_url,
           },
-        ];
-      })
-      .slice(0, 10),
+          author: {
+            username: author.username,
+            displayName: author.display_name,
+          },
+        },
+      ];
+    }),
   );
-  const homeStructuredData = buildHomePageJsonLd();
-
-  if (user) {
-    return (
-      <AppShell variant="feed">
-        <HydrationBoundary state={dehydrate(queryClient)}>
-          <JsonLd data={homeStructuredData} id="home-page-structured-data" />
-          <JsonLd data={feedStructuredData} id="home-structured-data" />
-          {params.welcome === "kocteau" ? <OnboardingWelcomeFromUrl /> : null}
-          <section className="mx-auto w-full max-w-5xl space-y-5 sm:space-y-6 lg:mx-0 lg:max-w-none lg:space-y-4">
-            <div className="lg:hidden">
-              <FeedViewTabs activeView={tabActiveView} fullWidth />
-            </div>
-            <div className="hidden justify-start lg:flex">
-              <FeedViewTabs activeView={tabActiveView} />
-            </div>
-            <div className="space-y-4">
-              <FeedReviewList
-                view={activeView}
-                initialPage={feedData}
-                isAuthenticated
-                viewer={viewerProfile}
-                starterTracks={starterTracks}
-                showReviewCta={false}
-              />
-            </div>
-          </section>
-        </HydrationBoundary>
-      </AppShell>
-    );
-  }
 
   return (
     <ReactQueryProvider>
-      <div className={`${circular.variable} ${redaction.variable} kocteau-guest-typography min-h-svh overflow-x-clip bg-[var(--kocteau-shell)] text-foreground`}>
+      <div
+        className={`${circular.variable} ${redaction.variable} kocteau-guest-typography min-h-svh overflow-x-clip bg-[var(--kocteau-shell)] text-foreground`}
+      >
         <GuestHeader />
         <main className="pt-15 sm:pt-16">
           <HydrationBoundary state={dehydrate(queryClient)}>
-            <JsonLd data={homeStructuredData} id="home-page-structured-data" />
+            <JsonLd data={buildHomePageJsonLd()} id="home-page-structured-data" />
             <JsonLd data={feedStructuredData} id="home-structured-data" />
-            <GuestHome
-              recentPage={guestRecentPage}
-              starterTracks={starterTracks}
-            />
+            <GuestHome recentPage={recentPage} starterTracks={starterTracks} />
           </HydrationBoundary>
         </main>
       </div>

--- a/apps/web/app/(main)/feed/page.tsx
+++ b/apps/web/app/(main)/feed/page.tsx
@@ -1,0 +1,114 @@
+import { HydrationBoundary, dehydrate } from "@tanstack/react-query";
+import { redirect } from "next/navigation";
+
+import { OnboardingWelcomeFromUrl } from "@/components/auth/onboarding-welcome-dialog";
+import FeedReviewList from "@/components/feed-review-list";
+import FeedViewTabs from "@/components/feed-view-tabs";
+import { getCurrentUser, getCurrentViewerProfile } from "@/lib/auth/server";
+import { isFeedView, type FeedView } from "@/lib/feed-view";
+import { createPageMetadata } from "@/lib/metadata";
+import { measureServerTask } from "@/lib/perf";
+import { getFeedPage, getFeedViewerState } from "@/lib/queries/feed";
+import { getStarterTracksForSurface } from "@/lib/queries/starter";
+import { createServerQueryClient } from "@/lib/react-query/server";
+import { feedKeys, type FeedInfiniteQueryData } from "@/queries/feed";
+
+export const dynamic = "force-dynamic";
+
+export const metadata = createPageMetadata({
+  title: "Feed",
+  description: "Your Kocteau music review feed.",
+  path: "/feed",
+  noIndex: true,
+});
+
+function getAuthenticatedFeedView(value: string | undefined): FeedView {
+  return isFeedView(value) && value !== "latest" ? value : "for-you";
+}
+
+export default async function FeedPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ view?: string; welcome?: string }>;
+}) {
+  const [params, user] = await Promise.all([
+    searchParams,
+    measureServerTask("getFeedViewer", getCurrentUser, { route: "/feed" }),
+  ]);
+
+  if (!user) {
+    redirect("/login?next=/feed");
+  }
+
+  const activeView = getAuthenticatedFeedView(params.view);
+  const [feedPage, starterTracks, viewerProfile] = await measureServerTask(
+    "getAuthenticatedFeedData",
+    () =>
+      Promise.all([
+        getFeedPage({
+          view: activeView,
+          viewerId: user.id,
+          includeActiveUsers: false,
+        }),
+        getStarterTracksForSurface({
+          viewerId: user.id,
+          limit: 6,
+          surface: "home",
+          contextKey: "home",
+        }),
+        getCurrentViewerProfile(),
+      ]),
+    { route: "/feed", view: activeView },
+  );
+  const viewerState =
+    feedPage.feed.length > 0
+      ? await getFeedViewerState(
+          user.id,
+          feedPage.feed.map((review) => review.id),
+        )
+      : {
+          likedReviewIds: new Set<string>(),
+          bookmarkedReviewIds: new Set<string>(),
+        };
+  const feedData = {
+    ...feedPage,
+    activeUsers: [],
+    feed: feedPage.feed.map((review) => ({
+      ...review,
+      viewer_has_liked: viewerState.likedReviewIds.has(review.id),
+      viewer_has_bookmarked: viewerState.bookmarkedReviewIds.has(review.id),
+    })),
+    requiresAuth: false,
+  };
+  const queryClient = createServerQueryClient();
+
+  queryClient.setQueryData(feedKeys.bundle(activeView), feedData);
+  queryClient.setQueryData<FeedInfiniteQueryData>(feedKeys.infinite(activeView), {
+    pages: [feedData],
+    pageParams: [null],
+  });
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      {params.welcome === "kocteau" ? <OnboardingWelcomeFromUrl /> : null}
+      <section className="mx-auto w-full max-w-5xl space-y-5 sm:space-y-6 lg:mx-0 lg:max-w-none lg:space-y-4">
+        <div className="lg:hidden">
+          <FeedViewTabs activeView={activeView} fullWidth />
+        </div>
+        <div className="hidden justify-start lg:flex">
+          <FeedViewTabs activeView={activeView} />
+        </div>
+        <div className="space-y-4">
+          <FeedReviewList
+            view={activeView}
+            initialPage={feedData}
+            isAuthenticated
+            viewer={viewerProfile}
+            starterTracks={starterTracks}
+            showReviewCta={false}
+          />
+        </div>
+      </section>
+    </HydrationBoundary>
+  );
+}

--- a/apps/web/app/(main)/library/page.tsx
+++ b/apps/web/app/(main)/library/page.tsx
@@ -108,7 +108,7 @@ export default async function LibraryPage() {
               </EmptyHeader>
               <CardContent className="p-0 pt-2">
                 <PrefetchLink
-                  href="/"
+                  href="/feed"
                   queryWarmup={{ kind: "feed" }}
                   className="inline-flex items-center gap-2 text-sm font-medium text-foreground"
                 >

--- a/apps/web/app/(main)/track/page.tsx
+++ b/apps/web/app/(main)/track/page.tsx
@@ -45,7 +45,7 @@ export default async function TrackIndexPage() {
               Explore
             </Link>
             <PrefetchLink
-              href="/"
+              href="/feed"
               queryWarmup={{ kind: "feed" }}
               className={cn(buttonVariants({ variant: "ghost", size: "sm" }), "rounded-full")}
             >

--- a/apps/web/app/api/feed/route.ts
+++ b/apps/web/app/api/feed/route.ts
@@ -1,22 +1,15 @@
 import { NextResponse } from "next/server";
+import { getCurrentUser } from "@/lib/auth/server";
 import { isFeedView } from "@/lib/feed-view";
 import { getFeedPage, getFeedViewerState } from "@/lib/queries/feed";
 import { getViewerFollowingProfileIds } from "@/lib/queries/profile-follows";
 import { measureServerTask } from "@/lib/perf";
-import { supabaseServer } from "@/lib/supabase/server";
 
 async function getFeedResponse(req: Request) {
   const url = new URL(req.url);
   const viewParam = url.searchParams.get("view") ?? undefined;
   const cursor = url.searchParams.get("cursor");
-  const userPromise = (async () => {
-    const supabase = await supabaseServer();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-    return user;
-  })();
-  const user = await userPromise;
+  const user = await getCurrentUser();
   const activeView = isFeedView(viewParam) ? viewParam : user ? "for-you" : "latest";
   const bundle = await getFeedPage({
     view: activeView,

--- a/apps/web/app/api/preferences/taste/route.ts
+++ b/apps/web/app/api/preferences/taste/route.ts
@@ -141,5 +141,5 @@ export async function POST(req: Request) {
   revalidatePath("/");
   revalidatePath("/onboarding/taste");
 
-  return NextResponse.json({ ok: true, redirectTo: "/?welcome=kocteau" });
+  return NextResponse.json({ ok: true, redirectTo: "/feed?welcome=kocteau" });
 }

--- a/apps/web/app/robots.ts
+++ b/apps/web/app/robots.ts
@@ -8,6 +8,7 @@ export default function robots(): MetadataRoute.Robots {
     "/login",
     "/signup",
     "/onboarding",
+    "/feed",
     "/library",
     "/notifications",
     "/saved",

--- a/apps/web/components/app-sidebar.tsx
+++ b/apps/web/components/app-sidebar.tsx
@@ -166,9 +166,9 @@ export default function AppSidebar({
   const mainItems = [
     {
       title: "Feed",
-      url: "/",
+      url: profile ? "/feed" : "/",
       icon: KocteauHomeIcon,
-      isActive: pathname === "/",
+      isActive: profile ? pathname === "/feed" : pathname === "/",
     },
     {
       title: "Explore",
@@ -235,7 +235,7 @@ export default function AppSidebar({
         <SidebarHeader className="gap-2 p-2.5 group-data-[collapsible=icon]:gap-1.5 group-data-[collapsible=icon]:px-0.5 group-data-[collapsible=icon]:py-1.5">
           <div className="flex min-h-10 items-center justify-between gap-2 px-1.5 group-data-[collapsible=icon]:flex-col group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:gap-1.5 group-data-[collapsible=icon]:px-0">
             <PrefetchLink
-              href="/"
+              href={profile ? "/feed" : "/"}
               onClick={closeMobileSidebar}
               queryWarmup={{ kind: "feed" }}
               aria-label="Kocteau home"

--- a/apps/web/components/auth/otp-auth-page-client.tsx
+++ b/apps/web/components/auth/otp-auth-page-client.tsx
@@ -202,7 +202,7 @@ export default function OtpAuthPageClient({ mode }: OtpAuthPageClientProps) {
       return appendInternalNext("/onboarding/taste", nextPath);
     }
 
-    return nextPath ?? "/";
+    return nextPath ?? "/feed";
   }, [supabase]);
 
   const redirectAfterAuth = useCallback(async (options?: { retry?: boolean }) => {

--- a/apps/web/components/auth/taste-onboarding-form.tsx
+++ b/apps/web/components/auth/taste-onboarding-form.tsx
@@ -77,7 +77,7 @@ export function TasteOnboardingForm({
   const [error, setError] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
   const [redirectTo, setRedirectTo] = useState(
-    nextPath ?? (isEditMode ? "/search" : "/?welcome=kocteau"),
+    nextPath ?? (isEditMode ? "/search" : "/feed?welcome=kocteau"),
   );
   const currentStep = isEditMode ? tasteEditStep : tasteSteps[currentStepIndex];
   const totalSteps = isEditMode ? 1 : tasteSteps.length;
@@ -143,7 +143,9 @@ export function TasteOnboardingForm({
       }
 
       const nextRedirect =
-        nextPath ?? data.redirectTo ?? (isEditMode ? "/search" : "/?welcome=kocteau");
+        nextPath ??
+        data.redirectTo ??
+        (isEditMode ? "/search" : "/feed?welcome=kocteau");
 
       if (isEditMode) {
         startTransition(() => {

--- a/apps/web/components/feed-view-tabs.tsx
+++ b/apps/web/components/feed-view-tabs.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import Link from "next/link";
 import type { FeedView } from "@/lib/feed-view";
 import { cn } from "@/lib/utils";
@@ -24,10 +22,10 @@ const feedViews: Array<{
 
 function getFeedViewHref(view: FeedView) {
   if (view === "for-you") {
-    return "/";
+    return "/feed";
   }
 
-  return `/?view=${view}`;
+  return `/feed?view=${view}`;
 }
 
 type FeedViewTabsProps = {
@@ -56,6 +54,7 @@ export default function FeedViewTabs({
           <Link
             key={view.value}
             href={getFeedViewHref(view.value)}
+            prefetch={false}
             aria-current={isActive ? "page" : undefined}
             className={cn(
               "relative z-10 inline-flex h-8 items-center justify-center rounded-full px-2.5 text-[13px] font-medium text-muted-foreground/78 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/70 focus-visible:ring-offset-0",

--- a/apps/web/components/header.tsx
+++ b/apps/web/components/header.tsx
@@ -79,7 +79,7 @@ export default function Header({
       return detailHeader?.shareLabel ?? "Review";
     }
 
-    if (pathname === "/") {
+    if (pathname === "/feed") {
       return "Feed";
     }
 
@@ -118,7 +118,7 @@ export default function Header({
   function renderMobileLogoMark(label: string) {
     return (
       <PrefetchLink
-        href="/"
+        href={profile ? "/feed" : "/"}
         queryWarmup={{ kind: "feed" }}
         className="mobile-liquid-logo pointer-events-auto inline-flex size-11 items-center justify-center rounded-full"
         aria-label={`Go to feed. Current route: ${label}`}
@@ -135,8 +135,16 @@ export default function Header({
       return;
     }
 
-    router.push(isProfileDetailRoute ? "/" : isMobileReviewRoute ? "/reviews" : "/search");
-  }, [isMobileReviewRoute, isProfileDetailRoute, router]);
+    router.push(
+      isProfileDetailRoute
+        ? profile
+          ? "/feed"
+          : "/"
+        : isMobileReviewRoute
+          ? "/reviews"
+          : "/search",
+    );
+  }, [isMobileReviewRoute, isProfileDetailRoute, profile, router]);
 
   const handleShareDetail = useCallback(async () => {
     if (typeof window === "undefined") {

--- a/apps/web/components/mobile-bottom-bar.tsx
+++ b/apps/web/components/mobile-bottom-bar.tsx
@@ -72,10 +72,10 @@ export default function MobileBottomBar({ profile }: MobileBottomBarProps) {
 
   const primaryItems: NavItem[] = [
     {
-      href: "/",
+      href: profile ? "/feed" : "/",
       label: "Feed",
       icon: KocteauHomeIcon,
-      active: (current) => current === "/",
+      active: (current) => current === (profile ? "/feed" : "/"),
     },
     {
       href: "/search",

--- a/apps/web/lib/auth/post-auth-redirect.ts
+++ b/apps/web/lib/auth/post-auth-redirect.ts
@@ -50,5 +50,5 @@ export async function getPostAuthRedirect(
     return appendInternalNext("/onboarding/taste", nextPath);
   }
 
-  return nextPath ?? "/";
+  return nextPath ?? "/feed";
 }

--- a/apps/web/lib/auth/server.ts
+++ b/apps/web/lib/auth/server.ts
@@ -20,6 +20,12 @@ export type CurrentOnboardingState = {
   tasteOnboarded: boolean;
 };
 
+type CurrentViewerContext = Omit<CurrentViewerProfile, "username"> & {
+  username: string | null;
+  onboarded: boolean | null;
+  taste_onboarded: boolean | null;
+};
+
 export const getCurrentUser = cache(async () => {
   const cookieStore = await cookies();
   const hasSupabaseCookie = cookieStore
@@ -38,28 +44,7 @@ export const getCurrentUser = cache(async () => {
   return user;
 });
 
-export const getCurrentViewerProfile = cache(async (): Promise<CurrentViewerProfile | null> => {
-  const user = await getCurrentUser();
-
-  if (!user) {
-    return null;
-  }
-
-  const supabase = await supabaseServer();
-  const { data } = await supabase
-    .from("profiles")
-    .select("id, username, avatar_url, display_name, bio, spotify_url, apple_music_url, deezer_url, onboarded")
-    .eq("id", user.id)
-    .maybeSingle<CurrentViewerProfile & { onboarded: boolean | null }>();
-
-  if (!data?.username || !data.onboarded) {
-    return null;
-  }
-
-  return data;
-});
-
-export const getCurrentOnboardingState = cache(async (): Promise<CurrentOnboardingState | null> => {
+const getCurrentViewerContext = cache(async (): Promise<CurrentViewerContext | null> => {
   const user = await getCurrentUser();
 
   if (!user) {
@@ -69,36 +54,53 @@ export const getCurrentOnboardingState = cache(async (): Promise<CurrentOnboardi
   const supabase = await supabaseServer();
   const profileQuery = await supabase
     .from("profiles")
-    .select("username, onboarded, taste_onboarded")
+    .select("id, username, avatar_url, display_name, bio, spotify_url, apple_music_url, deezer_url, onboarded, taste_onboarded")
     .eq("id", user.id)
-    .maybeSingle<{
-      username: string | null;
-      onboarded: boolean | null;
-      taste_onboarded: boolean | null;
-    }>();
+    .maybeSingle<CurrentViewerContext>();
 
   if (!profileQuery.error) {
-    const profile = profileQuery.data;
-
-    return {
-      profileOnboarded: Boolean(profile?.username && profile.onboarded),
-      tasteOnboarded: profile?.taste_onboarded ?? false,
-    };
+    return profileQuery.data;
   }
 
   const fallbackQuery = await supabase
     .from("profiles")
-    .select("username, onboarded")
+    .select("id, username, avatar_url, display_name, bio, spotify_url, apple_music_url, deezer_url, onboarded")
     .eq("id", user.id)
-    .maybeSingle<{
-      username: string | null;
-      onboarded: boolean | null;
-    }>();
+    .maybeSingle<Omit<CurrentViewerContext, "taste_onboarded">>();
 
-  const fallbackProfile = fallbackQuery.data;
+  return fallbackQuery.data
+    ? { ...fallbackQuery.data, taste_onboarded: true }
+    : null;
+});
+
+export const getCurrentViewerProfile = cache(async (): Promise<CurrentViewerProfile | null> => {
+  const profile = await getCurrentViewerContext();
+
+  if (!profile?.username || !profile.onboarded) {
+    return null;
+  }
 
   return {
-    profileOnboarded: Boolean(fallbackProfile?.username && fallbackProfile.onboarded),
-    tasteOnboarded: true,
+    id: profile.id,
+    username: profile.username,
+    avatar_url: profile.avatar_url,
+    display_name: profile.display_name,
+    bio: profile.bio,
+    spotify_url: profile.spotify_url,
+    apple_music_url: profile.apple_music_url,
+    deezer_url: profile.deezer_url,
+  };
+});
+
+export const getCurrentOnboardingState = cache(async (): Promise<CurrentOnboardingState | null> => {
+  const profile = await getCurrentViewerContext();
+
+  if (!profile) {
+    return null;
+  }
+
+  return {
+    profileOnboarded: Boolean(profile.username && profile.onboarded),
+    tasteOnboarded: profile.taste_onboarded ?? false,
   };
 });

--- a/apps/web/lib/queries/feed.ts
+++ b/apps/web/lib/queries/feed.ts
@@ -62,6 +62,7 @@ type FeedPageOptions = {
   cursor?: string | null;
   limit?: number;
   includeActiveUsers?: boolean;
+  revalidateSeconds?: number;
 };
 
 const feedPageLoaders = new Map<string, () => Promise<FeedPageData>>();
@@ -414,6 +415,7 @@ export async function getFeedPage({
   cursor = null,
   limit = FEED_PAGE_SIZE,
   includeActiveUsers = false,
+  revalidateSeconds = 60,
 }: FeedPageOptions = {}) {
   if (view === "for-you") {
     return measureServerTask(
@@ -453,9 +455,18 @@ export async function getFeedPage({
     );
   }
 
+  const cacheTtlSeconds = Math.max(60, Math.min(revalidateSeconds, 60 * 60));
+
   return getOrCreateLoader(
     feedPageLoaders,
-    ["feed-page", view, cursor ?? "first", limit, includeActiveUsers],
+    [
+      "feed-page",
+      view,
+      cursor ?? "first",
+      limit,
+      includeActiveUsers,
+      cacheTtlSeconds,
+    ],
     () =>
       unstable_cache(
         async () =>
@@ -470,9 +481,16 @@ export async function getFeedPage({
               }),
             { view, cursor: Boolean(cursor), limit, includeActiveUsers },
           ),
-        ["feed-page", view, cursor ?? "first", String(limit), String(includeActiveUsers)],
+        [
+          "feed-page",
+          view,
+          cursor ?? "first",
+          String(limit),
+          String(includeActiveUsers),
+          String(cacheTtlSeconds),
+        ],
         {
-          revalidate: 60,
+          revalidate: cacheTtlSeconds,
           tags: ["feed", `feed:${view}`, "reviews", "entities", "profiles"],
         },
       ),

--- a/apps/web/lib/queries/starter.ts
+++ b/apps/web/lib/queries/starter.ts
@@ -1,13 +1,18 @@
 import "server-only";
 
+import { unstable_cache } from "next/cache";
 import { measureServerTask } from "@/lib/perf";
+import { getOrCreateLoader } from "@/lib/queries/cache-loader";
 import type { StarterSurface } from "@/lib/starter/surface";
 import {
   createStarterRotationSeed,
   rotateStarterTracks,
 } from "@/lib/starter/rotation";
 import { supabaseServer } from "@/lib/supabase/server";
+import { supabasePublic } from "@/lib/supabase/public";
 import type { StarterTrack } from "@/lib/starter";
+
+const publicStarterLoaders = new Map<string, () => Promise<StarterTrack[]>>();
 
 type PublicStarterTrackRow = Pick<
   StarterTrack,
@@ -82,55 +87,73 @@ export async function getPublicStarterTracks({
   seed?: string;
   contextKey?: string | null;
 } = {}): Promise<StarterTrack[]> {
-  return measureServerTask(
-    "getPublicStarterTracks",
-    async () => {
-      const supabase = await supabaseServer();
-      const requestedLimit = Math.max(1, Math.min(limit, 12));
-      const lookupLimit = Math.max(24, Math.min(requestedLimit * 12, 120));
-      const { data, error } = await supabase
-        .from("starter_tracks")
-        .select(`
-          id,
-          provider,
-          provider_id,
-          type,
-          title,
-          artist_name,
-          cover_url,
-          deezer_url,
-          prompt,
-          editorial_note,
-          is_featured,
-          sort_order,
-          created_at
-        `)
-        .eq("is_active", true)
-        .order("is_featured", { ascending: false })
-        .order("sort_order", { ascending: true })
-        .order("created_at", { ascending: false })
-        .limit(lookupLimit)
-        .returns<PublicStarterTrackRow[]>();
+  const requestedLimit = Math.max(1, Math.min(limit, 12));
+  const rotationSeed = `${seed ?? createStarterRotationSeed()}:${contextKey ?? "public"}`;
 
-      if (error) {
-        console.error("[starter.getPublicStarterTracks] failed", {
-          code: error.code ?? null,
-          message: error.message ?? null,
-        });
+  return getOrCreateLoader(
+    publicStarterLoaders,
+    ["public-starter-tracks", requestedLimit, rotationSeed],
+    () =>
+      unstable_cache(
+        async () =>
+          measureServerTask(
+            "getPublicStarterTracks",
+            async () => {
+              const supabase = supabasePublic();
+              const lookupLimit = Math.max(
+                24,
+                Math.min(requestedLimit * 12, 120),
+              );
+              const { data, error } = await supabase
+                .from("starter_tracks")
+                .select(`
+                  id,
+                  provider,
+                  provider_id,
+                  type,
+                  title,
+                  artist_name,
+                  cover_url,
+                  deezer_url,
+                  prompt,
+                  editorial_note,
+                  is_featured,
+                  sort_order,
+                  created_at
+                `)
+                .eq("is_active", true)
+                .order("is_featured", { ascending: false })
+                .order("sort_order", { ascending: true })
+                .order("created_at", { ascending: false })
+                .limit(lookupLimit)
+                .returns<PublicStarterTrackRow[]>();
 
-        return [];
-      }
+              if (error) {
+                console.error("[starter.getPublicStarterTracks] failed", {
+                  code: error.code ?? null,
+                  message: error.message ?? null,
+                });
 
-      const rotationSeed = `${seed ?? createStarterRotationSeed()}:${contextKey ?? "public"}`;
+                return [];
+              }
 
-      return rotateStarterTracks((data ?? []).map(mapPublicStarterTrack), rotationSeed)
-        .slice(0, requestedLimit);
-    },
-    {
-      limit,
-      contextKey,
-    },
-  );
+              return rotateStarterTracks(
+                (data ?? []).map(mapPublicStarterTrack),
+                rotationSeed,
+              ).slice(0, requestedLimit);
+            },
+            {
+              limit: requestedLimit,
+              contextKey,
+            },
+          ),
+        ["public-starter-tracks", String(requestedLimit), rotationSeed],
+        {
+          revalidate: 15 * 60,
+          tags: ["starter-tracks"],
+        },
+      ),
+  )();
 }
 
 export async function getStarterTracks({

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createServerClient } from "@supabase/ssr";
+import { isFeedView } from "@/lib/feed-view";
 import { getShortRouteId, isFullUuid } from "@/lib/seo-routes";
 import { getSupabasePublishableKey, getSupabaseUrl } from "@/lib/supabase/env";
 
@@ -37,6 +38,28 @@ function getShortIdRedirectPath(pathname: string) {
   return null;
 }
 
+function copyResponseCookies(source: NextResponse, target: NextResponse) {
+  source.cookies.getAll().forEach((cookie) => {
+    target.cookies.set(cookie);
+  });
+}
+
+function getFeedLoginRedirect(request: NextRequest, response?: NextResponse) {
+  const loginUrl = request.nextUrl.clone();
+  const nextPath = `${request.nextUrl.pathname}${request.nextUrl.search}`;
+
+  loginUrl.pathname = "/login";
+  loginUrl.search = "";
+  loginUrl.searchParams.set("next", nextPath);
+  const redirectResponse = NextResponse.redirect(loginUrl);
+
+  if (response) {
+    copyResponseCookies(response, redirectResponse);
+  }
+
+  return redirectResponse;
+}
+
 export async function proxy(request: NextRequest) {
   const response = NextResponse.next({ request });
   const pathname = request.nextUrl.pathname;
@@ -59,7 +82,9 @@ export async function proxy(request: NextRequest) {
   }
 
   const hasSbCookie = request.cookies.getAll().some((c) => c.name.startsWith("sb-"));
-  if (!hasSbCookie) return response;
+  if (!hasSbCookie) {
+    return pathname === "/feed" ? getFeedLoginRedirect(request) : response;
+  }
 
   const supabase = createServerClient(
     getSupabaseUrl(),
@@ -76,7 +101,36 @@ export async function proxy(request: NextRequest) {
     }
   );
 
-  await supabase.auth.getClaims();
+  const { data: claimsData, error: claimsError } = await supabase.auth.getClaims();
+
+  if (pathname === "/feed" && (claimsError || !claimsData?.claims?.sub)) {
+    return getFeedLoginRedirect(request, response);
+  }
+
+  if (pathname === "/" && !claimsError && claimsData?.claims?.sub) {
+    const redirectUrl = request.nextUrl.clone();
+    redirectUrl.pathname = "/feed";
+    redirectUrl.search = "";
+    const requestedView = request.nextUrl.searchParams.get("view") ?? undefined;
+
+    if (
+      isFeedView(requestedView) &&
+      requestedView !== "for-you" &&
+      requestedView !== "latest"
+    ) {
+      redirectUrl.searchParams.set("view", requestedView);
+    }
+
+    if (request.nextUrl.searchParams.get("welcome") === "kocteau") {
+      redirectUrl.searchParams.set("welcome", "kocteau");
+    }
+
+    const redirectResponse = NextResponse.redirect(redirectUrl);
+    copyResponseCookies(response, redirectResponse);
+
+    return redirectResponse;
+  }
+
   return response;
 }
 
@@ -84,7 +138,7 @@ export const config = {
   matcher: [
     {
       source:
-        "/((?!api|_next/static|_next/image|favicon.ico|robots.txt|sitemap.xml|.*opengraph-image|.*twitter-image).*)",
+        "/((?!api|monitoring|_next/static|_next/image|favicon.ico|robots.txt|sitemap.xml|.*\\.(?:svg|png|jpg|jpeg|gif|webp|avif|ico|txt|xml|woff|woff2|ttf|otf)$|.*opengraph-image|.*twitter-image).*)",
       missing: [
         { type: "header", key: "next-router-prefetch" },
         { type: "header", key: "purpose", value: "prefetch" },


### PR DESCRIPTION
## Summary
- move the authenticated feed from `/` to `/feed`
- keep `/` public and cacheable with a five-minute ISR window
- keep feed tabs as URL query state and disable automatic tab prefetch
- cache public starter picks and deduplicate profile/onboarding reads
- bypass proxy work for public assets and redirect guest `/feed` requests before rendering

## Performance result
- Next build: `/` is static/ISR (`5m`)
- Next build: `/feed` is dynamic
- warm local `/`: ~175 ms
- guest `/feed`: immediate `307` to `/login?next=/feed`

## Verification
- `pnpm --filter web lint`
- targeted ESLint for changed routing/data files
- `pnpm --filter web build`
- `git diff --check`
- local production/dev HTTP checks for `/`, `/feed`, `?view=following`, and `/logo.svg`

## Notes
This PR is stacked on `perf/observability-baseline` and should not be merged to `main` before preview feedback.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the public home and authenticated feed: `/` is now a cached public landing (ISR 5m), and the user feed moved to `/feed` with auth enforcement and fast redirects. This reduces work on guest traffic and keeps the feed dynamic.

- New Features
  - Move the authenticated feed to `/feed`; guests are redirected to `/login?next=/feed`.
  - Update navigation, onboarding, and post‑auth flows to target `/feed`.
  - Keep feed tabs in the URL query and disable tab prefetching.
  - Disallow indexing of `/feed` in `robots.txt`.

- Performance
  - Make `/` static with 5‑minute ISR and hydrate with a small “latest” feed page and public starter picks.
  - Cache public starter tracks with `unstable_cache` using `supabasePublic`, and deduplicate loaders.
  - Add `revalidateSeconds` to `getFeedPage` and key cache entries by TTL.
  - Bypass proxy work for public assets.

<sup>Written for commit a5656ff8a3c3d22ca5bdf3642e8c748d5983d1ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/francozeta/kocteau/pull/138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

