### PR TITLE
perf(db): bound recommendation candidate scoring

### DIFF
--- a/supabase/migrations/20260722174307_bound_recommendation_candidates.sql
+++ b/supabase/migrations/20260722174307_bound_recommendation_candidates.sql
@@ -1,0 +1,281 @@
+-- Bound the amount of work performed by the personalized feed without
+-- changing its public contract. Candidate generation remains local and
+-- explainable; the existing scoring and diversity rules run only after the
+-- pool has been capped.
+--
+-- SECURITY DEFINER is intentional: the read-only RPC combines protected
+-- viewer signals across several RLS tables. It derives the viewer exclusively
+-- from auth.uid(), accepts no viewer id, uses an empty search_path, and is
+-- executable only by authenticated users.
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '90s';
+
+CREATE OR REPLACE FUNCTION public.get_recommended_review_ids(
+  p_limit integer DEFAULT 8,
+  p_cursor_score numeric DEFAULT NULL,
+  p_cursor_created_at timestamp with time zone DEFAULT NULL,
+  p_cursor_id uuid DEFAULT NULL
+)
+RETURNS TABLE (
+  review_id uuid,
+  score numeric,
+  reason text,
+  created_at timestamp with time zone
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+WITH viewer AS MATERIALIZED (
+  SELECT auth.uid() AS user_id
+),
+bounded AS (
+  SELECT greatest(1, least(coalesce(p_limit, 8), 30)) AS page_limit
+),
+candidate_budget AS (
+  SELECT greatest(480, least(720, page_limit * 24)) AS candidate_limit
+  FROM bounded
+),
+explicit_preferences AS (
+  SELECT
+    upt.tag_id,
+    sum(upt.weight) AS preference_weight
+  FROM public.user_preference_tags upt
+  JOIN viewer v ON v.user_id = upt.user_id
+  GROUP BY upt.tag_id
+),
+positive_entities AS (
+  SELECT
+    entity_id,
+    sum(signal_weight) AS signal_weight
+  FROM (
+    SELECT r.entity_id, greatest(0.2, r.rating / 5.0) * 1.6 AS signal_weight
+    FROM public.reviews r
+    JOIN viewer v ON v.user_id = r.author_id
+    WHERE r.rating >= 3.5
+
+    UNION ALL
+
+    SELECT r.entity_id, 1.15 AS signal_weight
+    FROM public.review_likes rl
+    JOIN public.reviews r ON r.id = rl.review_id
+    JOIN viewer v ON v.user_id = rl.user_id
+
+    UNION ALL
+
+    SELECT r.entity_id, 1.35 AS signal_weight
+    FROM public.review_bookmarks rb
+    JOIN public.reviews r ON r.id = rb.review_id
+    JOIN viewer v ON v.user_id = rb.user_id
+
+    UNION ALL
+
+    SELECT eb.entity_id, 1.25 AS signal_weight
+    FROM public.entity_bookmarks eb
+    JOIN viewer v ON v.user_id = eb.user_id
+  ) signals
+  GROUP BY entity_id
+),
+negative_entities AS (
+  SELECT DISTINCT r.entity_id
+  FROM public.reviews r
+  JOIN viewer v ON v.user_id = r.author_id
+  WHERE r.rating <= 2
+),
+inferred_preferences AS (
+  SELECT
+    ept.tag_id,
+    sum(least(pe.signal_weight, 4) * ept.weight * 0.7) AS preference_weight
+  FROM positive_entities pe
+  JOIN public.entity_preference_tags ept ON ept.entity_id = pe.entity_id
+  GROUP BY ept.tag_id
+),
+taste_profile AS (
+  SELECT
+    tag_id,
+    least(sum(preference_weight), 6) AS preference_weight
+  FROM (
+    SELECT tag_id, preference_weight
+    FROM explicit_preferences
+
+    UNION ALL
+
+    SELECT tag_id, preference_weight
+    FROM inferred_preferences
+  ) preferences
+  GROUP BY tag_id
+),
+followed_authors AS (
+  SELECT pf.following_id AS author_id
+  FROM public.profile_follows pf
+  JOIN viewer v ON v.user_id = pf.follower_id
+),
+affinity_authors AS (
+  SELECT
+    author_id,
+    least(sum(signal_weight), 5) AS affinity_weight
+  FROM (
+    SELECT r.author_id, 1.15 AS signal_weight
+    FROM public.review_likes rl
+    JOIN public.reviews r ON r.id = rl.review_id
+    JOIN viewer v ON v.user_id = rl.user_id
+    WHERE r.author_id <> v.user_id
+
+    UNION ALL
+
+    SELECT r.author_id, 1.35 AS signal_weight
+    FROM public.review_bookmarks rb
+    JOIN public.reviews r ON r.id = rb.review_id
+    JOIN viewer v ON v.user_id = rb.user_id
+    WHERE r.author_id <> v.user_id
+  ) authors
+  GROUP BY author_id
+),
+candidate_reviews AS MATERIALIZED (
+  SELECT r.*
+  FROM public.reviews r
+  CROSS JOIN viewer v
+  WHERE v.user_id IS NOT NULL
+    AND r.author_id <> v.user_id
+    AND r.created_at >= now() - interval '365 days'
+  ORDER BY r.created_at DESC, r.id DESC
+  LIMIT (SELECT candidate_limit FROM candidate_budget)
+),
+entity_taste AS (
+  SELECT
+    r.id AS review_id,
+    least(sum(tp.preference_weight * ept.weight), 6) AS entity_taste_score
+  FROM candidate_reviews r
+  JOIN public.entity_preference_tags ept ON ept.entity_id = r.entity_id
+  JOIN taste_profile tp ON tp.tag_id = ept.tag_id
+  GROUP BY r.id
+),
+author_taste AS (
+  SELECT
+    r.id AS review_id,
+    least(sum(tp.preference_weight * upt.weight), 4) AS author_taste_score
+  FROM candidate_reviews r
+  JOIN public.user_preference_tags upt ON upt.user_id = r.author_id
+  JOIN taste_profile tp ON tp.tag_id = upt.tag_id
+  GROUP BY r.id
+),
+scored AS (
+  SELECT
+    r.id,
+    r.author_id,
+    r.entity_id,
+    r.created_at,
+    coalesce(et.entity_taste_score, 0) AS entity_taste_score,
+    coalesce(at.author_taste_score, 0) AS author_taste_score,
+    CASE WHEN fa.author_id IS NOT NULL THEN 1 ELSE 0 END AS follow_score,
+    coalesce(pe.signal_weight, 0) AS familiar_entity_score,
+    coalesce(aa.affinity_weight, 0) AS author_affinity_score,
+    CASE WHEN ne.entity_id IS NOT NULL THEN 1 ELSE 0 END AS negative_entity_score,
+    CASE
+      WHEN char_length(trim(coalesce(r.body, ''))) >= 280 THEN 0.85
+      WHEN char_length(trim(coalesce(r.body, ''))) >= 120 THEN 0.55
+      WHEN nullif(trim(coalesce(r.body, '')), '') IS NOT NULL THEN 0.3
+      WHEN nullif(trim(coalesce(r.title, '')), '') IS NOT NULL THEN 0.12
+      ELSE 0
+    END AS review_depth_score,
+    (
+      coalesce(et.entity_taste_score, 0) * 1.75
+      + coalesce(at.author_taste_score, 0) * 0.9
+      + CASE WHEN fa.author_id IS NOT NULL THEN 2.25 ELSE 0 END
+      + least(coalesce(pe.signal_weight, 0), 4) * 1.15
+      + coalesce(aa.affinity_weight, 0) * 0.6
+      + greatest(0, r.rating - 3) * 0.22
+      + ln(1 + greatest(r.likes_count, 0)) * 0.22
+      + ln(1 + greatest(r.comments_count, 0)) * 0.24
+      + (1 / (1 + greatest(extract(epoch FROM (now() - r.created_at)) / 86400, 0) / 21.0))
+      - CASE WHEN ne.entity_id IS NOT NULL THEN 2.4 ELSE 0 END
+    ) AS base_score
+  FROM candidate_reviews r
+  LEFT JOIN entity_taste et ON et.review_id = r.id
+  LEFT JOIN author_taste at ON at.review_id = r.id
+  LEFT JOIN followed_authors fa ON fa.author_id = r.author_id
+  LEFT JOIN positive_entities pe ON pe.entity_id = r.entity_id
+  LEFT JOIN affinity_authors aa ON aa.author_id = r.author_id
+  LEFT JOIN negative_entities ne ON ne.entity_id = r.entity_id
+),
+diversified AS (
+  SELECT
+    scored.*,
+    row_number() OVER (
+      PARTITION BY scored.author_id
+      ORDER BY (scored.base_score + scored.review_depth_score) DESC, scored.created_at DESC, scored.id DESC
+    ) AS author_rank,
+    row_number() OVER (
+      PARTITION BY scored.entity_id
+      ORDER BY (scored.base_score + scored.review_depth_score) DESC, scored.created_at DESC, scored.id DESC
+    ) AS entity_rank
+  FROM scored
+),
+finalized AS (
+  SELECT
+    d.id,
+    d.created_at,
+    round(greatest(
+      d.base_score
+      + d.review_depth_score
+      - greatest(d.author_rank - 1, 0) * 0.55
+      - greatest(d.entity_rank - 1, 0) * 0.95,
+      0
+    )::numeric, 4) AS final_score,
+    CASE
+      WHEN d.entity_taste_score >= greatest(
+        d.author_taste_score,
+        d.follow_score,
+        d.familiar_entity_score,
+        d.author_affinity_score,
+        0.01
+      ) THEN 'entity_taste'
+      WHEN d.author_taste_score > 0 THEN 'taste_match'
+      WHEN d.follow_score > 0 THEN 'following'
+      WHEN d.familiar_entity_score > 0 THEN 'familiar_entity'
+      WHEN d.author_affinity_score > 0 THEN 'author_affinity'
+      ELSE 'popular_recent'
+    END AS reason
+  FROM diversified d
+)
+SELECT
+  f.id AS review_id,
+  f.final_score AS score,
+  f.reason,
+  f.created_at
+FROM finalized f
+CROSS JOIN bounded b
+WHERE (
+    p_cursor_score IS NULL
+    OR f.final_score < p_cursor_score
+    OR (
+      f.final_score = p_cursor_score
+      AND p_cursor_created_at IS NOT NULL
+      AND f.created_at < p_cursor_created_at
+    )
+    OR (
+      f.final_score = p_cursor_score
+      AND p_cursor_created_at IS NOT NULL
+      AND f.created_at = p_cursor_created_at
+      AND p_cursor_id IS NOT NULL
+      AND f.id < p_cursor_id
+    )
+  )
+ORDER BY f.final_score DESC, f.created_at DESC, f.id DESC
+LIMIT (SELECT page_limit + 1 FROM bounded);
+$$;
+
+COMMENT ON FUNCTION public.get_recommended_review_ids(integer, numeric, timestamp with time zone, uuid)
+  IS 'Returns an explainable, cursor-paginated For You feed ranked over a bounded candidate pool.';
+
+REVOKE ALL ON FUNCTION public.get_recommended_review_ids(integer, numeric, timestamp with time zone, uuid)
+  FROM PUBLIC, anon;
+
+GRANT EXECUTE ON FUNCTION public.get_recommended_review_ids(integer, numeric, timestamp with time zone, uuid)
+  TO authenticated;
+
+COMMIT;

--- a/supabase/tests/database/recommendation_pipeline.test.sql
+++ b/supabase/tests/database/recommendation_pipeline.test.sql
@@ -1,0 +1,306 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+
+select extensions.plan(9);
+
+insert into auth.users (
+  id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at
+)
+values
+  (
+    '10000000-0000-4000-8000-000000000001',
+    'authenticated',
+    'authenticated',
+    'recommendation-viewer@example.invalid',
+    '',
+    now(),
+    '{"provider":"email","providers":["email"]}',
+    '{}',
+    now(),
+    now()
+  ),
+  (
+    '10000000-0000-4000-8000-000000000002',
+    'authenticated',
+    'authenticated',
+    'recommendation-followed@example.invalid',
+    '',
+    now(),
+    '{"provider":"email","providers":["email"]}',
+    '{}',
+    now(),
+    now()
+  ),
+  (
+    '10000000-0000-4000-8000-000000000003',
+    'authenticated',
+    'authenticated',
+    'recommendation-entity-taste@example.invalid',
+    '',
+    now(),
+    '{"provider":"email","providers":["email"]}',
+    '{}',
+    now(),
+    now()
+  ),
+  (
+    '10000000-0000-4000-8000-000000000004',
+    'authenticated',
+    'authenticated',
+    'recommendation-author-taste@example.invalid',
+    '',
+    now(),
+    '{"provider":"email","providers":["email"]}',
+    '{}',
+    now(),
+    now()
+  );
+
+update public.profiles
+set
+  username = 'rec_test_' || right(id::text, 1),
+  onboarded = true,
+  taste_onboarded = true
+where id in (
+  '10000000-0000-4000-8000-000000000001',
+  '10000000-0000-4000-8000-000000000002',
+  '10000000-0000-4000-8000-000000000003',
+  '10000000-0000-4000-8000-000000000004'
+);
+
+insert into public.entities (
+  id,
+  type,
+  provider,
+  provider_id,
+  title,
+  artist_name
+)
+values
+  (
+    '20000001-0000-4000-8000-000000000001',
+    'track',
+    'test',
+    'recommendation-entity-taste',
+    'Entity taste fixture',
+    'Kocteau tests'
+  ),
+  (
+    '20000002-0000-4000-8000-000000000002',
+    'track',
+    'test',
+    'recommendation-own-review',
+    'Own review fixture',
+    'Kocteau tests'
+  ),
+  (
+    '20000003-0000-4000-8000-000000000003',
+    'track',
+    'test',
+    'recommendation-author-signals',
+    'Author signals fixture',
+    'Kocteau tests'
+  );
+
+insert into public.preference_tags (
+  id,
+  kind,
+  slug,
+  label,
+  is_featured
+)
+values (
+  '30000000-0000-4000-8000-000000000001',
+  'genre',
+  'recommendation-test-genre',
+  'Recommendation test genre',
+  false
+);
+
+insert into public.user_preference_tags (user_id, tag_id, weight, source)
+values
+  (
+    '10000000-0000-4000-8000-000000000001',
+    '30000000-0000-4000-8000-000000000001',
+    1,
+    'onboarding'
+  ),
+  (
+    '10000000-0000-4000-8000-000000000004',
+    '30000000-0000-4000-8000-000000000001',
+    1,
+    'onboarding'
+  );
+
+insert into public.entity_preference_tags (entity_id, tag_id, source, weight)
+values (
+  '20000001-0000-4000-8000-000000000001',
+  '30000000-0000-4000-8000-000000000001',
+  'manual',
+  1
+);
+
+insert into public.profile_follows (follower_id, following_id)
+values (
+  '10000000-0000-4000-8000-000000000001',
+  '10000000-0000-4000-8000-000000000002'
+);
+
+insert into public.reviews (
+  id,
+  author_id,
+  entity_id,
+  rating,
+  title,
+  body,
+  created_at,
+  updated_at
+)
+values
+  (
+    '40000001-0000-4000-8000-000000000001',
+    '10000000-0000-4000-8000-000000000001',
+    '20000002-0000-4000-8000-000000000002',
+    4.5,
+    'Own review',
+    'The viewer should never receive this review as a recommendation.',
+    now() - interval '1 hour',
+    now() - interval '1 hour'
+  ),
+  (
+    '40000002-0000-4000-8000-000000000002',
+    '10000000-0000-4000-8000-000000000002',
+    '20000003-0000-4000-8000-000000000003',
+    4.5,
+    'Followed author',
+    'This review exists to preserve the followed-author explanation.',
+    now() - interval '2 hours',
+    now() - interval '2 hours'
+  ),
+  (
+    '40000003-0000-4000-8000-000000000003',
+    '10000000-0000-4000-8000-000000000003',
+    '20000001-0000-4000-8000-000000000001',
+    4.5,
+    'Entity taste',
+    'This review exists to preserve the entity-taste explanation.',
+    now() - interval '3 hours',
+    now() - interval '3 hours'
+  ),
+  (
+    '40000004-0000-4000-8000-000000000004',
+    '10000000-0000-4000-8000-000000000004',
+    '20000003-0000-4000-8000-000000000003',
+    4.5,
+    'Author taste',
+    'This review exists to preserve the author-taste explanation.',
+    now() - interval '4 hours',
+    now() - interval '4 hours'
+  ),
+  (
+    '40000005-0000-4000-8000-000000000005',
+    '10000000-0000-4000-8000-000000000003',
+    '20000002-0000-4000-8000-000000000002',
+    4.5,
+    'Expired review',
+    'This old review should stay outside the recommendation window.',
+    now() - interval '366 days',
+    now() - interval '366 days'
+  );
+
+select extensions.ok(
+  has_function_privilege(
+    'authenticated',
+    'public.get_recommended_review_ids(integer,numeric,timestamp with time zone,uuid)',
+    'EXECUTE'
+  ),
+  'authenticated users can execute the recommendation RPC'
+);
+
+select extensions.ok(
+  not has_function_privilege(
+    'anon',
+    'public.get_recommended_review_ids(integer,numeric,timestamp with time zone,uuid)',
+    'EXECUTE'
+  ),
+  'anonymous users cannot execute the recommendation RPC'
+);
+
+set local "request.jwt.claim.sub" = '';
+
+select extensions.is_empty(
+  'select * from public.get_recommended_review_ids(8, null, null, null)',
+  'a missing viewer produces no personalized recommendations'
+);
+
+set local "request.jwt.claim.sub" = '10000000-0000-4000-8000-000000000001';
+
+select extensions.ok(
+  not exists (
+    select 1
+    from public.get_recommended_review_ids(30, null, null, null)
+    where review_id = '40000001-0000-4000-8000-000000000001'
+  ),
+  'the viewer own review is excluded'
+);
+
+select extensions.is(
+  (
+    select reason
+    from public.get_recommended_review_ids(30, null, null, null)
+    where review_id = '40000003-0000-4000-8000-000000000003'
+  ),
+  'entity_taste',
+  'entity taste remains the strongest explanation'
+);
+
+select extensions.is(
+  (
+    select reason
+    from public.get_recommended_review_ids(30, null, null, null)
+    where review_id = '40000002-0000-4000-8000-000000000002'
+  ),
+  'following',
+  'followed authors retain a clear explanation'
+);
+
+select extensions.is(
+  (
+    select reason
+    from public.get_recommended_review_ids(30, null, null, null)
+    where review_id = '40000004-0000-4000-8000-000000000004'
+  ),
+  'taste_match',
+  'author taste retains a clear explanation'
+);
+
+select extensions.ok(
+  not exists (
+    select 1
+    from public.get_recommended_review_ids(30, null, null, null)
+    where review_id = '40000005-0000-4000-8000-000000000005'
+  ),
+  'reviews older than the editorial window are excluded'
+);
+
+select extensions.ok(
+  (
+    select count(*)
+    from public.get_recommended_review_ids(999, null, null, null)
+  ) <= 31,
+  'the public page size stays bounded'
+);
+
+select * from extensions.finish();
+
+rollback;


### PR DESCRIPTION
## Summary
- bound `For You` candidate scoring to the newest 480–720 eligible reviews before personalization
- preserve the existing RPC signature, scoring weights, recommendation reasons, diversity penalties, and cursor ordering
- harden the read-only `SECURITY DEFINER` function with an empty search path and explicit authenticated-only execution
- add transactional pgTAP coverage for access, own-review exclusion, reason precedence, editorial recency, and page bounds

## Performance
- current production fixture: identical IDs, scores, reasons, and order
- warm tiny fixture: effectively neutral (~8.4 ms before and after)
- rolled-back 1,000-review fixture: 28.37 ms → 16.71 ms (~41% faster)

## Verification
- `pnpm --filter web lint`
- `pnpm --filter web build`
- linked migration dry-run
- linked SQL migration + pgTAP fixture inside `BEGIN` / `ROLLBACK`
- Supabase performance advisor: no issues
- `git diff --cached --check`

## Notes
- the Docker-backed `supabase test db --linked` wrapper was unavailable because Docker Desktop is stopped; the same pgTAP SQL completed directly against the linked database and rolled back all fixtures
- no migration was applied directly to production from this branch

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds For You candidate scoring to the newest 480–720 reviews before personalization, keeping the RPC contract and ranking logic unchanged. Cuts scoring time by ~41% on a 1k‑review fixture with no visible feed changes.

- **New Features**
  - Bound candidate pool in `public.get_recommended_review_ids(...)` while preserving weights, reasons, diversity penalties, and cursor ordering.
  - Hardened read-only `SECURITY DEFINER` RPC: empty `search_path`, EXECUTE only for `authenticated`, viewer from `auth.uid()` only.
  - Added transactional pgTAP tests for access control, own-review exclusion, reason precedence, 365‑day recency window, and page bounds.

<sup>Written for commit 85c181fdbd9e0a287d50bb7546ff939cf8f3e5ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/francozeta/kocteau/pull/141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added personalized review recommendations based on interests, follows, familiarity, engagement, and content quality.
  * Recommendations include explanation labels and support cursor-based pagination.
  * Results prioritize recent reviews and exclude outdated or self-authored content.

* **Security**
  * Restricted recommendation access to authenticated users.

* **Tests**
  * Added coverage for personalization, access control, exclusions, explanation labels, and result limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->