### PR TITLE
test(web): add load-readiness scenarios

### DIFF
--- a/apps/web/tests/load/kocteau.js
+++ b/apps/web/tests/load/kocteau.js
@@ -1,0 +1,256 @@
+import http from "k6/http";
+import { check, sleep } from "k6";
+
+const profile = (__ENV.K6_PROFILE || "smoke").toLowerCase();
+const baseUrl = normalizeBaseUrl(__ENV.K6_BASE_URL || "http://127.0.0.1:3000");
+const authCookie = (__ENV.K6_AUTH_COOKIE || "").trim();
+const searchQuery = (__ENV.K6_SEARCH_QUERY || "cocteau").trim();
+const explicitTrackPath = normalizePath(__ENV.K6_TRACK_PATH || "");
+const summaryPath = (__ENV.K6_SUMMARY_PATH || "").trim();
+
+const defaultHeaders = {
+  Accept: "text/html,application/xhtml+xml,application/json;q=0.9,*/*;q=0.8",
+  "User-Agent": `Kocteau-load-readiness/${profile}`,
+};
+
+const publicSurfaces = {
+  landing: scenario("landingSurface", profile),
+  canonical_track: scenario("canonicalTrackSurface", profile),
+  search: scenario("searchSurface", profile),
+};
+
+if (authCookie) {
+  publicSurfaces.authenticated_feed = scenario("authenticatedFeedSurface", profile);
+}
+
+export const options = {
+  discardResponseBodies: true,
+  summaryTrendStats: ["avg", "med", "p(75)", "p(90)", "p(95)", "max"],
+  scenarios: publicSurfaces,
+  thresholds: buildThresholds(Boolean(authCookie)),
+};
+
+export function setup() {
+  if (explicitTrackPath) {
+    return { trackPath: explicitTrackPath };
+  }
+
+  const response = http.get(`${baseUrl}/sitemap.xml`, {
+    headers: defaultHeaders,
+    responseType: "text",
+    tags: { surface: "setup" },
+  });
+
+  const trackPath = getFirstCanonicalTrackPath(response.body || "");
+
+  if (!trackPath) {
+    throw new Error(
+      "No canonical track route was found in /sitemap.xml. Set K6_TRACK_PATH explicitly.",
+    );
+  }
+
+  return { trackPath };
+}
+
+export function landingSurface() {
+  const response = get("/", "landing");
+
+  check(response, {
+    "landing returns 200": (result) => result.status === 200,
+  });
+  pause();
+}
+
+export function canonicalTrackSurface(data) {
+  const response = get(data.trackPath, "canonical_track");
+
+  check(response, {
+    "canonical track returns 200": (result) => result.status === 200,
+  });
+  pause();
+}
+
+export function searchSurface() {
+  const encodedQuery = encodeURIComponent(searchQuery);
+  const pageResponse = get(`/search?q=${encodedQuery}`, "search_page");
+  const apiResponse = get(`/api/search?q=${encodedQuery}`, "search_api", {
+    Accept: "application/json",
+  });
+
+  check(pageResponse, {
+    "search page returns 200": (result) => result.status === 200,
+  });
+  check(apiResponse, {
+    "search API returns 200": (result) => result.status === 200,
+    "search API is JSON": (result) =>
+      (result.headers["Content-Type"] || "").includes("application/json"),
+  });
+  pause();
+}
+
+export function authenticatedFeedSurface() {
+  const response = get("/feed?view=for-you", "authenticated_feed", {
+    Cookie: authCookie,
+  });
+
+  check(response, {
+    "authenticated feed returns 200": (result) => result.status === 200,
+    "authenticated feed does not redirect to login": (result) =>
+      !String(result.url).includes("/login"),
+  });
+  pause();
+}
+
+export function handleSummary(data) {
+  const output = {
+    stdout: formatSummary(data),
+  };
+
+  if (summaryPath) {
+    output[summaryPath] = JSON.stringify(
+      {
+        generatedAt: new Date().toISOString(),
+        target: baseUrl,
+        profile,
+        authenticatedFeedIncluded: Boolean(authCookie),
+        data,
+      },
+      null,
+      2,
+    );
+  }
+
+  return output;
+}
+
+function get(path, surface, extraHeaders = {}) {
+  return http.get(`${baseUrl}${path}`, {
+    headers: { ...defaultHeaders, ...extraHeaders },
+    redirects: 0,
+    tags: { surface },
+  });
+}
+
+function scenario(exec, selectedProfile) {
+  if (selectedProfile === "baseline") {
+    return {
+      executor: "ramping-vus",
+      exec,
+      startVUs: 0,
+      stages: [
+        { duration: "20s", target: 1 },
+        { duration: "40s", target: 3 },
+        { duration: "20s", target: 0 },
+      ],
+      gracefulRampDown: "10s",
+      tags: { profile: selectedProfile },
+    };
+  }
+
+  if (selectedProfile !== "smoke") {
+    throw new Error(`Unsupported K6_PROFILE: ${selectedProfile}`);
+  }
+
+  return {
+    executor: "shared-iterations",
+    exec,
+    vus: 1,
+    iterations: 3,
+    maxDuration: "45s",
+    tags: { profile: selectedProfile },
+  };
+}
+
+function buildThresholds(includeAuthenticatedFeed) {
+  const thresholds = {
+    checks: ["rate>0.99"],
+    "http_req_failed{surface:landing}": ["rate<0.01"],
+    "http_req_duration{surface:landing}": ["p(75)<800", "p(95)<1500"],
+    "http_req_failed{surface:canonical_track}": ["rate<0.01"],
+    "http_req_duration{surface:canonical_track}": [
+      "p(75)<1200",
+      "p(95)<2500",
+    ],
+    "http_req_failed{surface:search_page}": ["rate<0.01"],
+    "http_req_duration{surface:search_page}": ["p(75)<1000", "p(95)<2000"],
+    "http_req_failed{surface:search_api}": ["rate<0.02"],
+    "http_req_duration{surface:search_api}": ["p(75)<1500", "p(95)<3000"],
+  };
+
+  if (includeAuthenticatedFeed) {
+    thresholds["http_req_failed{surface:authenticated_feed}"] = ["rate<0.01"];
+    thresholds["http_req_duration{surface:authenticated_feed}"] = [
+      "p(75)<1200",
+      "p(95)<2500",
+    ];
+  }
+
+  return thresholds;
+}
+
+function getFirstCanonicalTrackPath(sitemap) {
+  const match = sitemap.match(/<loc>https?:\/\/[^<]+(\/tracks\/[^<]+)<\/loc>/i);
+  return match?.[1] ? decodeXml(match[1]) : "";
+}
+
+function decodeXml(value) {
+  return value.replaceAll("&amp;", "&");
+}
+
+function normalizeBaseUrl(value) {
+  return value.trim().replace(/\/+$/, "");
+}
+
+function normalizePath(value) {
+  const trimmed = value.trim();
+
+  if (!trimmed) {
+    return "";
+  }
+
+  return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+}
+
+function pause() {
+  sleep(0.35 + Math.random() * 0.65);
+}
+
+function formatSummary(data) {
+  const lines = [
+    "",
+    `Kocteau load-readiness (${profile})`,
+    `Target: ${baseUrl}`,
+    `Authenticated feed: ${authCookie ? "included" : "skipped"}`,
+    "",
+  ];
+
+  for (const surface of [
+    "landing",
+    "canonical_track",
+    "search_page",
+    "search_api",
+    "authenticated_feed",
+  ]) {
+    const duration = data.metrics[`http_req_duration{surface:${surface}}`]?.values;
+    const failures = data.metrics[`http_req_failed{surface:${surface}}`]?.values;
+
+    if (!duration) {
+      continue;
+    }
+
+    lines.push(
+      `${surface}: p75=${round(duration["p(75)"])}ms p95=${round(duration["p(95)"])}ms failures=${percent(failures?.rate)}`,
+    );
+  }
+
+  lines.push("");
+  return lines.join("\n");
+}
+
+function round(value) {
+  return Number.isFinite(value) ? Math.round(value) : "n/a";
+}
+
+function percent(value) {
+  return Number.isFinite(value) ? `${(value * 100).toFixed(2)}%` : "n/a";
+}

--- a/apps/web/tests/load/kocteau.js
+++ b/apps/web/tests/load/kocteau.js
@@ -4,6 +4,8 @@ import { check, sleep } from "k6";
 const profile = (__ENV.K6_PROFILE || "smoke").toLowerCase();
 const baseUrl = normalizeBaseUrl(__ENV.K6_BASE_URL || "http://127.0.0.1:3000");
 const authCookie = (__ENV.K6_AUTH_COOKIE || "").trim();
+const previewCookie = (__ENV.K6_PREVIEW_COOKIE || "").trim();
+const vercelBypassSecret = (__ENV.K6_VERCEL_BYPASS_SECRET || "").trim();
 const searchQuery = (__ENV.K6_SEARCH_QUERY || "cocteau").trim();
 const explicitTrackPath = normalizePath(__ENV.K6_TRACK_PATH || "");
 const summaryPath = (__ENV.K6_SUMMARY_PATH || "").trim();
@@ -11,6 +13,10 @@ const summaryPath = (__ENV.K6_SUMMARY_PATH || "").trim();
 const defaultHeaders = {
   Accept: "text/html,application/xhtml+xml,application/json;q=0.9,*/*;q=0.8",
   "User-Agent": `Kocteau-load-readiness/${profile}`,
+  ...(previewCookie ? { Cookie: previewCookie } : {}),
+  ...(vercelBypassSecret
+    ? { "x-vercel-protection-bypass": vercelBypassSecret }
+    : {}),
 };
 
 const publicSurfaces = {
@@ -90,7 +96,7 @@ export function searchSurface() {
 
 export function authenticatedFeedSurface() {
   const response = get("/feed?view=for-you", "authenticated_feed", {
-    Cookie: authCookie,
+    Cookie: joinCookies(previewCookie, authCookie),
   });
 
   check(response, {
@@ -113,6 +119,7 @@ export function handleSummary(data) {
         target: baseUrl,
         profile,
         authenticatedFeedIncluded: Boolean(authCookie),
+        protectedPreviewBypassIncluded: Boolean(previewCookie || vercelBypassSecret),
         data,
       },
       null,
@@ -209,6 +216,10 @@ function normalizePath(value) {
   }
 
   return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+}
+
+function joinCookies(...cookies) {
+  return cookies.filter(Boolean).join("; ");
 }
 
 function pause() {

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@
 - [Local development](./setup/local-development.md): local-first setup with Supabase CLI.
 - [Environment and secrets](./security/environment.md): safe handling for local, staging, and production configuration.
 - [Operations](./operations.md): production setup notes, post-deploy checks, Supabase scripts, and recommendation health checks.
+- [Load readiness](./load-readiness.md): k6 profiles, latency thresholds, database snapshots, and rollback criteria.
 - [Supabase maintainer workflow](./maintainers/supabase-workflow.md): cloud migrations, staging, production, and contributor boundaries.
 
 ## Maintainer Workflows

--- a/docs/load-readiness.md
+++ b/docs/load-readiness.md
@@ -1,0 +1,120 @@
+# Load readiness
+
+[Operations](./operations.md) | [Environment and secrets](./security/environment.md)
+
+Kocteau uses a small, reproducible k6 suite to catch application, database, and platform regressions before traffic grows. Run the gradual profile against a Vercel preview or staging environment. Production should receive only the smoke profile and only during an intentional maintainer check.
+
+## Covered surfaces
+
+- `/` exercises the cached public landing.
+- A canonical `/tracks/{slug}/{id}` route is discovered from `/sitemap.xml` unless `K6_TRACK_PATH` is provided.
+- `/search?q=…` exercises the server-rendered discovery surface.
+- `/api/search?q=…` exercises Kocteau-first search plus the external catalog fallback.
+- `/feed?view=for-you` is included only when `K6_AUTH_COOKIE` is provided.
+
+The suite performs read-only requests. It does not publish reviews, mutate analytics, or create synthetic users.
+
+## Install k6
+
+Windows:
+
+```powershell
+winget install --exact --id GrafanaLabs.k6 --source winget
+```
+
+Other platforms should use the official Grafana k6 package for that platform.
+
+## Smoke profile
+
+The smoke profile runs three iterations per public surface with one virtual user. Use it to validate a fresh preview:
+
+```powershell
+$env:K6_BASE_URL = "https://preview.example.com"
+$env:K6_SUMMARY_PATH = "tmp/load-tests/smoke.json"
+pnpm perf:load:smoke
+```
+
+## Gradual baseline
+
+The baseline ramps each public surface from zero to three virtual users over 80 seconds. Run it only after smoke passes:
+
+```powershell
+$env:K6_BASE_URL = "https://preview.example.com"
+$env:K6_SUMMARY_PATH = "tmp/load-tests/baseline.json"
+pnpm perf:load:baseline
+```
+
+Override discovery when a known canonical track should be measured:
+
+```powershell
+$env:K6_TRACK_PATH = "/tracks/sea-swallow-me/known-short-id"
+```
+
+## Authenticated feed
+
+Copy the complete `Cookie` request header from an intentionally-created test session. Keep it only in the current shell and never commit it:
+
+```powershell
+$env:K6_AUTH_COOKIE = "sb-project-auth-token=redacted"
+pnpm perf:load:smoke
+Remove-Item Env:K6_AUTH_COOKIE
+```
+
+Without the variable, the authenticated scenario is omitted instead of measuring the login redirect as a successful feed response.
+
+## Thresholds
+
+| Surface | P75 | P95 | Failed requests |
+| --- | ---: | ---: | ---: |
+| Landing | < 800 ms | < 1,500 ms | < 1% |
+| Canonical track | < 1,200 ms | < 2,500 ms | < 1% |
+| Search page | < 1,000 ms | < 2,000 ms | < 1% |
+| Search API | < 1,500 ms | < 3,000 ms | < 2% |
+| Authenticated feed | < 1,200 ms | < 2,500 ms | < 1% |
+
+Search API has a slightly wider budget because it can use an external catalog fallback. Treat repeated fallback latency as an integration/cache problem, not automatically as a Postgres problem.
+
+## Database snapshots
+
+Capture read-only snapshots immediately before and after the baseline:
+
+```powershell
+pnpm exec supabase inspect db db-stats --linked
+pnpm exec supabase inspect db role-stats --linked
+pnpm exec supabase inspect db outliers --linked
+pnpm exec supabase inspect db traffic-profile --linked
+```
+
+Review:
+
+- cache-hit ratio and database size;
+- active role connections and pool pressure;
+- high-call or high-total-time statements;
+- unexpected writes during a read-only run;
+- lock or error growth.
+
+Do not reset `pg_stat_statements` on production merely to isolate a test. Compare the before/after call counts or use a staging database.
+
+## Vercel review
+
+For the same test window, record from Vercel Observability:
+
+- function invocations per tested route;
+- P75/P95 duration and time to first byte;
+- active CPU and memory;
+- error rate and cold-start percentage;
+- external API duration for search.
+
+The k6 summary measures client-visible latency; Vercel and Supabase observations identify where that time was spent.
+
+## Stop and rollback criteria
+
+Stop a run when any of the following occurs:
+
+- error rate reaches 5% for one minute;
+- P95 exceeds twice its threshold for one minute;
+- database connections approach 80% of the available pool;
+- lock waits, CPU saturation, or memory pressure continue rising after load stops;
+- external API failures cascade into application errors.
+
+Roll back the application change under test when the regression reproduces against the previous deployment with the same profile and data conditions. Otherwise open a focused issue for the responsible layer: application, query/index, cache/external API, or platform capacity.

--- a/docs/load-readiness.md
+++ b/docs/load-readiness.md
@@ -44,6 +44,32 @@ $env:K6_SUMMARY_PATH = "tmp/load-tests/baseline.json"
 pnpm perf:load:baseline
 ```
 
+### Protected Vercel previews
+
+Keep Deployment Protection enabled. Either provide an existing automation bypass secret through `K6_VERCEL_BYPASS_SECRET`, or let the authenticated Vercel CLI create a temporary cookie for the current preview:
+
+```powershell
+New-Item -ItemType Directory -Force -Path tmp/load-tests | Out-Null
+vercel curl "$env:K6_BASE_URL/sitemap.xml" `
+  -H "x-vercel-set-bypass-cookie: true" `
+  -L `
+  -c tmp/load-tests/vercel.cookies `
+  -o tmp/load-tests/protected-sitemap.xml `
+  --silent `
+  --show-error
+
+$cookieLine = Get-Content tmp/load-tests/vercel.cookies |
+  Where-Object { $_ -match "_vercel_jwt" } |
+  Select-Object -Last 1
+$cookieFields = $cookieLine -split "`t"
+$env:K6_PREVIEW_COOKIE = "$($cookieFields[5])=$($cookieFields[6])"
+
+pnpm perf:load:baseline
+Remove-Item Env:K6_PREVIEW_COOKIE
+```
+
+The cookie and generated reports remain under ignored `tmp/`. Never copy either value into documentation, an issue, or a commit.
+
 Override discovery when a known canonical track should be measured:
 
 ```powershell
@@ -118,3 +144,27 @@ Stop a run when any of the following occurs:
 - external API failures cascade into application errors.
 
 Roll back the application change under test when the regression reproduces against the previous deployment with the same profile and data conditions. Otherwise open a focused issue for the responsible layer: application, query/index, cache/external API, or platform capacity.
+
+## Recorded baseline
+
+The first gradual baseline ran on July 23, 2026 against the protected Vercel preview for PR #146. It covered public traffic only; authenticated feed measurement remains opt-in because no test-session cookie was committed or shared.
+
+| Surface | P75 | P95 | Maximum | Failed requests |
+| --- | ---: | ---: | ---: | ---: |
+| Landing | 305 ms | 393 ms | 1,022 ms | 0% |
+| Canonical track | 1,115 ms | 1,437 ms | 5,392 ms | 0% |
+| Search page | 548 ms | 612 ms | 3,016 ms | 0% |
+| Search API | 917 ms | 1,213 ms | 1,787 ms | 0% |
+
+The run completed 211 iterations and 261 requests, with nine VUs at peak and a 100% check pass rate. Every P75, P95, and error-rate threshold passed.
+
+Supabase remained stable across the window:
+
+- active connections returned from 16 before the run to 14 after it;
+- `authenticator` remained at 9 active connections;
+- no role approached 80% of its connection limit;
+- database size remained 21 MB;
+- table and index hit rates remained 100%;
+- the cumulative query outliers were Supabase Dashboard introspection queries, not Kocteau application queries.
+
+The isolated maximums on canonical track and search page show a cold-tail opportunity, but they did not persist through P95 under gradual load. Investigate those paths separately before raising concurrency or changing database capacity.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -2,6 +2,8 @@
 
 [Docs index](./README.md) | [Local development](./setup/local-development.md) | [Supabase maintainer workflow](./maintainers/supabase-workflow.md) | [Environment and secrets](./security/environment.md) | [Discovery and curation](./discovery-curation.md) | [Release automation](./maintainers/release.md)
 
+Load testing and launch thresholds are documented in [Load readiness](./load-readiness.md).
+
 This file captures the production setup that lives outside the codebase.
 
 ## Supabase Auth

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
     "eve:curation:build": "pnpm --filter @kocteau/curation-agent eve:build",
     "import:apple-playlist": "tsx apps/web/scripts/export-apple-music-playlist.ts",
     "sync:apple-starter-source": "tsx apps/web/scripts/sync-apple-starter-source.ts",
+    "perf:load:smoke": "k6 run -e K6_PROFILE=smoke apps/web/tests/load/kocteau.js",
+    "perf:load:baseline": "k6 run -e K6_PROFILE=baseline apps/web/tests/load/kocteau.js",
     "build": "turbo run build",
     "lint": "turbo run lint",
     "check": "pnpm lint && pnpm --filter web build"


### PR DESCRIPTION
## Summary
- add configurable k6 smoke and gradual baseline scenarios for landing, canonical track, search, and optional authenticated feed
- support protected Vercel previews without committing bypass secrets
- define per-surface P75/P95/error thresholds and JSON summaries
- document Supabase snapshots, Vercel observations, stop conditions, rollback criteria, and the recorded baseline

## Recorded preview baseline
Protected Vercel preview, public traffic only:
- 211 iterations / 261 requests / 9 VUs peak
- 100% checks, 0% failed requests
- landing: P75 305 ms / P95 393 ms
- canonical track: P75 1,115 ms / P95 1,437 ms
- search page: P75 548 ms / P95 612 ms
- search API: P75 917 ms / P95 1,213 ms

Supabase connections returned from 16 to 14 after the run, authenticator stayed at 9, no role approached 80% capacity, and table/index hit rates remained 100%.

The isolated cold maximums are tracked separately in #147 and do not block this PR because every gradual threshold passed.

## Verification
- k6 inspect for smoke and baseline profiles
- production smoke harness validation
- protected-preview gradual baseline
- pnpm --filter web lint
- pnpm --filter web build
- git diff --check

Closes #143