### PR TITLE
fix(catalog): harden MusicBrainz enrichment

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,13 +1,18 @@
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
 NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321
 NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=replace_with_local_anon_key_from_supabase_status
+
+# Server-only. Never prefix these with NEXT_PUBLIC_.
 SUPABASE_SECRET_KEY=replace_with_server_only_secret_key
 CRON_SECRET=replace_with_a_random_secret_at_least_16_characters
 
-NEXT_PUBLIC_OPENPANEL_CLIENT_ID=
-OPENPANEL_CLIENT_SECRET=
+# Optional product integrations.
 V0_REFERRAL_URL=
+APPLE_MUSIC_DEVELOPER_TOKEN=
+SENTRY_AUTH_TOKEN=
 
+# Optional server performance logging.
 KOCTEAU_PERF_SLOW_MS=300
+KOCTEAU_PERF_SAMPLE_RATE=0
 KOCTEAU_PERF_LOGS=0
 KOCTEAU_PERF_VERBOSE=0

--- a/apps/web/app/api/cron/enrich-catalog/route.ts
+++ b/apps/web/app/api/cron/enrich-catalog/route.ts
@@ -13,7 +13,7 @@ export async function GET(request: Request) {
   }
 
   try {
-    const result = await processCatalogEnrichmentBatch(8);
+    const result = await processCatalogEnrichmentBatch(18);
     return NextResponse.json(result, {
       headers: { "Cache-Control": "no-store" },
     });

--- a/apps/web/lib/catalog/enrichment.ts
+++ b/apps/web/lib/catalog/enrichment.ts
@@ -338,6 +338,19 @@ async function claimJob() {
   return data[0] ?? null;
 }
 
+async function prepareJobs() {
+  const supabase = supabaseAdmin();
+  const { data, error } = await supabase.rpc(
+    "prepare_catalog_enrichment_jobs",
+  );
+
+  if (error) {
+    throw error;
+  }
+
+  return data ?? 0;
+}
+
 async function processJob(job: CatalogJob) {
   const supabase = supabaseAdmin();
 
@@ -377,7 +390,8 @@ async function processJob(job: CatalogJob) {
 }
 
 export async function processCatalogEnrichmentBatch(limit = 8) {
-  const safeLimit = Math.max(1, Math.min(12, Math.floor(limit)));
+  const safeLimit = Math.max(1, Math.min(24, Math.floor(limit)));
+  const prepared = await prepareJobs();
   let completed = 0;
   let failed = 0;
 
@@ -403,5 +417,5 @@ export async function processCatalogEnrichmentBatch(limit = 8) {
     }
   }
 
-  return { completed, failed };
+  return { prepared, completed, failed };
 }

--- a/apps/web/lib/supabase/database.types.ts
+++ b/apps/web/lib/supabase/database.types.ts
@@ -1431,6 +1431,10 @@ export type Database = {
           review_id: string
         }[]
       }
+      enqueue_catalog_enrichment_target: {
+        Args: { p_target_id: string; p_target_type: string }
+        Returns: undefined
+      }
       get_recommendation_health_snapshot: {
         Args: { p_days?: number }
         Returns: Json
@@ -1516,6 +1520,7 @@ export type Database = {
         Args: { recipient_id: string }
         Returns: string
       }
+      prepare_catalog_enrichment_jobs: { Args: never; Returns: number }
       reconcile_review_comments_count: {
         Args: { p_review_id: string }
         Returns: {

--- a/docs/security/environment.md
+++ b/docs/security/environment.md
@@ -41,6 +41,27 @@ Never commit, paste, or include these in examples:
 
 Secrets live only in controlled systems such as Vercel environment variables, GitHub environment secrets, Supabase dashboard settings, or a maintainer password manager.
 
+## Web Runtime Inventory
+
+The web app intentionally keeps a small environment surface:
+
+| Variable | Scope | Purpose |
+| --- | --- | --- |
+| `NEXT_PUBLIC_SITE_URL` | Public | Canonical URL outside Vercel. |
+| `NEXT_PUBLIC_SUPABASE_URL` | Public | Supabase API origin. |
+| `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` | Public | RLS-protected browser access. The legacy `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY` remains a temporary deployment fallback. |
+| `SUPABASE_SECRET_KEY` | Server only | Catalog worker and other privileged server operations. |
+| `CRON_SECRET` | Server only | Authenticates Vercel Cron requests to `/api/cron/enrich-catalog`. Configure it in Project Settings → Environment Variables, not in the Cron Jobs screen. |
+| `V0_REFERRAL_URL` | Server only, optional | Creator Perks destination. |
+| `APPLE_MUSIC_DEVELOPER_TOKEN` | Server only, optional | Maintainer-only Apple Music import. |
+| `SENTRY_AUTH_TOKEN` | Build only, optional | Source-map upload during deployment. |
+| `KOCTEAU_PERF_*` | Server only, optional | Sampled performance diagnostics. |
+
+MusicBrainz does not require an API key. Kocteau identifies itself with a stable
+`User-Agent`, stores matches in Supabase, and performs enrichment only through
+the protected background worker. Do not add MusicBrainz calls to client components
+or synchronous page rendering.
+
 ## Contributor Defaults
 
 Contributors should need only:

--- a/supabase/migrations/20260727153448_make_catalog_enrichment_resilient.sql
+++ b/supabase/migrations/20260727153448_make_catalog_enrichment_resilient.sql
@@ -1,0 +1,283 @@
+CREATE OR REPLACE FUNCTION public.enqueue_catalog_enrichment_target(
+  p_target_type text,
+  p_target_id uuid
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF p_target_type NOT IN ('artist', 'entity') THEN
+    RAISE EXCEPTION 'Unsupported catalog enrichment target type: %', p_target_type;
+  END IF;
+
+  INSERT INTO public.catalog_enrichment_jobs (
+    target_type,
+    target_id,
+    status,
+    attempts,
+    next_attempt_at,
+    last_error
+  )
+  VALUES (p_target_type, p_target_id, 'pending', 0, now(), NULL)
+  ON CONFLICT (target_type, target_id)
+  DO UPDATE SET
+    status = 'pending',
+    attempts = 0,
+    next_attempt_at = now(),
+    last_error = NULL,
+    updated_at = now()
+  WHERE public.catalog_enrichment_jobs.status <> 'processing';
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.enqueue_catalog_enrichment_target(text, uuid)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.enqueue_catalog_enrichment_target(text, uuid)
+  TO service_role;
+
+CREATE OR REPLACE FUNCTION public.reset_artist_musicbrainz_context()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
+BEGIN
+  IF NEW.provider IS DISTINCT FROM OLD.provider
+     OR NEW.provider_id IS DISTINCT FROM OLD.provider_id
+     OR NEW.name IS DISTINCT FROM OLD.name THEN
+    NEW.musicbrainz_id := NULL;
+    NEW.musicbrainz_match_score := NULL;
+    NEW.artist_type := NULL;
+    NEW.country_code := NULL;
+    NEW.disambiguation := NULL;
+    NEW.life_span_begin := NULL;
+    NEW.life_span_end := NULL;
+    NEW.genres := '{}'::text[];
+    NEW.musicbrainz_synced_at := NULL;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.reset_entity_musicbrainz_context()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
+BEGIN
+  IF NEW.provider IS DISTINCT FROM OLD.provider
+     OR NEW.provider_id IS DISTINCT FROM OLD.provider_id
+     OR NEW.type IS DISTINCT FROM OLD.type
+     OR NEW.title IS DISTINCT FROM OLD.title
+     OR NEW.artist_name IS DISTINCT FROM OLD.artist_name THEN
+    NEW.musicbrainz_recording_id := NULL;
+    NEW.musicbrainz_release_group_id := NULL;
+    NEW.musicbrainz_match_score := NULL;
+    NEW.disambiguation := NULL;
+    NEW.first_release_date := NULL;
+    NEW.genres := '{}'::text[];
+    NEW.musicbrainz_synced_at := NULL;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.queue_artist_musicbrainz_context()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF TG_OP = 'INSERT'
+     OR NEW.provider IS DISTINCT FROM OLD.provider
+     OR NEW.provider_id IS DISTINCT FROM OLD.provider_id
+     OR NEW.name IS DISTINCT FROM OLD.name THEN
+    PERFORM public.enqueue_catalog_enrichment_target('artist', NEW.id);
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.queue_entity_musicbrainz_context()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF TG_OP = 'INSERT'
+     OR NEW.provider IS DISTINCT FROM OLD.provider
+     OR NEW.provider_id IS DISTINCT FROM OLD.provider_id
+     OR NEW.type IS DISTINCT FROM OLD.type
+     OR NEW.title IS DISTINCT FROM OLD.title
+     OR NEW.artist_name IS DISTINCT FROM OLD.artist_name THEN
+    PERFORM public.enqueue_catalog_enrichment_target('entity', NEW.id);
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.reset_artist_musicbrainz_context()
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.reset_entity_musicbrainz_context()
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.queue_artist_musicbrainz_context()
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.queue_entity_musicbrainz_context()
+  FROM PUBLIC, anon, authenticated;
+
+DROP TRIGGER IF EXISTS reset_artist_musicbrainz_context_on_identity_change
+  ON public.artists;
+CREATE TRIGGER reset_artist_musicbrainz_context_on_identity_change
+BEFORE UPDATE OF provider, provider_id, name ON public.artists
+FOR EACH ROW
+EXECUTE FUNCTION public.reset_artist_musicbrainz_context();
+
+DROP TRIGGER IF EXISTS reset_entity_musicbrainz_context_on_identity_change
+  ON public.entities;
+CREATE TRIGGER reset_entity_musicbrainz_context_on_identity_change
+BEFORE UPDATE OF provider, provider_id, type, title, artist_name ON public.entities
+FOR EACH ROW
+EXECUTE FUNCTION public.reset_entity_musicbrainz_context();
+
+DROP TRIGGER IF EXISTS queue_artist_musicbrainz_context_on_change
+  ON public.artists;
+CREATE TRIGGER queue_artist_musicbrainz_context_on_change
+AFTER INSERT OR UPDATE OF provider, provider_id, name ON public.artists
+FOR EACH ROW
+EXECUTE FUNCTION public.queue_artist_musicbrainz_context();
+
+DROP TRIGGER IF EXISTS queue_entity_musicbrainz_context_on_change
+  ON public.entities;
+CREATE TRIGGER queue_entity_musicbrainz_context_on_change
+AFTER INSERT OR UPDATE OF provider, provider_id, type, title, artist_name
+ON public.entities
+FOR EACH ROW
+EXECUTE FUNCTION public.queue_entity_musicbrainz_context();
+
+CREATE OR REPLACE FUNCTION public.prepare_catalog_enrichment_jobs()
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_prepared integer;
+BEGIN
+  WITH stale_targets AS (
+    SELECT
+      'artist'::text AS target_type,
+      artist.id AS target_id,
+      artist.musicbrainz_synced_at AS synced_at
+    FROM public.artists AS artist
+    WHERE artist.musicbrainz_synced_at IS NULL
+       OR artist.musicbrainz_synced_at < now() - interval '90 days'
+
+    UNION ALL
+
+    SELECT
+      'entity'::text AS target_type,
+      entity.id AS target_id,
+      entity.musicbrainz_synced_at AS synced_at
+    FROM public.entities AS entity
+    WHERE entity.musicbrainz_synced_at IS NULL
+       OR entity.musicbrainz_synced_at < now() - interval '90 days'
+  ),
+  candidates AS (
+    SELECT target_type, target_id
+    FROM stale_targets
+    ORDER BY synced_at ASC NULLS FIRST, target_id
+    LIMIT 100
+  ),
+  prepared AS (
+    INSERT INTO public.catalog_enrichment_jobs (
+      target_type,
+      target_id,
+      status,
+      attempts,
+      next_attempt_at,
+      last_error
+    )
+    SELECT
+      candidate.target_type,
+      candidate.target_id,
+      'pending',
+      0,
+      now(),
+      NULL
+    FROM candidates AS candidate
+    ON CONFLICT (target_type, target_id)
+    DO UPDATE SET
+      status = 'pending',
+      attempts = 0,
+      next_attempt_at = now(),
+      last_error = NULL,
+      updated_at = now()
+    WHERE public.catalog_enrichment_jobs.status <> 'processing'
+    RETURNING 1
+  )
+  SELECT count(*)::integer INTO v_prepared
+  FROM prepared;
+
+  RETURN coalesce(v_prepared, 0);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.prepare_catalog_enrichment_jobs()
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.prepare_catalog_enrichment_jobs()
+  TO service_role;
+
+CREATE OR REPLACE FUNCTION public.claim_catalog_enrichment_job()
+RETURNS TABLE (
+  job_id uuid,
+  target_type text,
+  target_id uuid,
+  attempts integer
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  WITH next_job AS (
+    SELECT job.id
+    FROM public.catalog_enrichment_jobs AS job
+    WHERE job.attempts < 5
+      AND (
+        (
+          job.status IN ('pending', 'failed')
+          AND job.next_attempt_at <= now()
+        )
+        OR (
+          job.status = 'processing'
+          AND job.updated_at <= now() - interval '15 minutes'
+        )
+      )
+    ORDER BY job.next_attempt_at, job.created_at
+    FOR UPDATE SKIP LOCKED
+    LIMIT 1
+  ),
+  claimed AS (
+    UPDATE public.catalog_enrichment_jobs AS job
+    SET status = 'processing',
+        attempts = job.attempts + 1,
+        last_error = NULL,
+        updated_at = now()
+    FROM next_job
+    WHERE job.id = next_job.id
+    RETURNING job.id, job.target_type, job.target_id, job.attempts
+  )
+  SELECT claimed.id, claimed.target_type, claimed.target_id, claimed.attempts
+  FROM claimed;
+$$;
+
+REVOKE ALL ON FUNCTION public.claim_catalog_enrichment_job()
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.claim_catalog_enrichment_job()
+  TO service_role;


### PR DESCRIPTION
## Summary
- keep MusicBrainz off the user request path while covering every persisted artist, album, and track
- automatically queue new or identity-changed catalog records and refresh context after 90 days
- recover enrichment jobs abandoned by hard function timeouts
- document the minimal environment inventory and protected CRON_SECRET location

## Infrastructure
- applied migration 20260727153448_make_catalog_enrichment_resilient.sql to the linked Supabase project
- rotated CRON_SECRET separately for Development and Preview/Production
- removed unused CLIENT_ID, CLIENT_SECRET, and MCP_TOKEN from Vercel

## Verification
- pnpm --filter web lint
- pnpm --filter web exec tsc --noEmit --allowImportingTsExtensions
- pnpm --filter web build
- Supabase security and performance advisors
- transactional trigger and privilege smoke checks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened MusicBrainz catalog enrichment by moving all work to background jobs, auto-queuing changes, and recovering stuck tasks. Improves reliability and keeps user requests fast while covering all artists and entities.

- **New Features**
  - Added Supabase RPCs and triggers for background enrichment:
    - `prepare_catalog_enrichment_jobs` seeds up to 100 stale/missing items and enforces a 90‑day refresh.
    - `enqueue_catalog_enrichment_target` queues on artist/entity insert or identity change; resets context when identity changes.
    - `claim_catalog_enrichment_job` recovers jobs stuck >15m and limits to 5 attempts.
  - Worker updates:
    - Each run prepares jobs first and now returns `{ prepared, completed, failed }`.
    - Increased per-run batch to 18 (capped at 24).
  - Docs and env:
    - Documented minimal web runtime inventory and where to set `CRON_SECRET` for `/api/cron/enrich-catalog`.
    - `.env.example` clarifies server-only variables; adds optional `APPLE_MUSIC_DEVELOPER_TOKEN`, `SENTRY_AUTH_TOKEN`, and perf sampling flags; removes unused Openpanel client secrets.

- **Migration**
  - Apply the new Supabase migration to create functions, triggers, and job recovery.
  - Set/rotate `CRON_SECRET` per environment in Vercel Project Settings (not Cron Jobs).
  - Remove unused `CLIENT_ID`, `CLIENT_SECRET`, and `MCP_TOKEN` from Vercel; update local `.env` as per the new template.

<sup>Written for commit 2c1be4c5c37bbeda6c5435da60099979575b9468. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/francozeta/kocteau/pull/152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved catalog enrichment reliability by automatically preparing, queuing, and recovering enrichment tasks.
  * Increased the number of catalog items processed during each scheduled enrichment run.
  * Added safeguards to refresh enrichment data when relevant catalog details change.
  * Improved handling of stalled or repeatedly failing enrichment tasks.

* **Documentation**
  * Added a web runtime environment variable inventory, including server-only, optional, and build-time configuration guidance.
  * Added guidance for protected background access to MusicBrainz data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->