### PR TITLE
feat(search): surface enriched music catalog

### DIFF
--- a/apps/web/app/(main)/search/page.tsx
+++ b/apps/web/app/(main)/search/page.tsx
@@ -5,7 +5,7 @@ import { createPageMetadata } from "@/lib/metadata";
 import { getAtlasTags } from "@/lib/queries/atlas";
 import { getRecentlyDiscussedTracks } from "@/lib/queries/discovery";
 import { getPublicStarterTracks } from "@/lib/queries/starter";
-import { isSearchEntityType } from "@/lib/search-types";
+import { isSearchScope } from "@/lib/search-types";
 
 export async function generateMetadata({
   searchParams,
@@ -18,14 +18,14 @@ export async function generateMetadata({
   if (!query) {
     return createPageMetadata({
       title: "Discover",
-      description: "Search tracks and discover music through real reviews on Kocteau.",
+      description: "Search songs, albums, and artists, then discover music through real reviews on Kocteau.",
       path: "/search",
     });
   }
 
   return createPageMetadata({
     title: `Discover: ${query}`,
-    description: `Track results for ${query} on Kocteau.`,
+    description: `Music results for ${query} on Kocteau.`,
     path: `/search?q=${encodeURIComponent(query)}`,
     noIndex: true,
   });
@@ -38,7 +38,7 @@ export default async function SearchPage({
 }) {
   const params = await searchParams;
   const initialQuery = params.q?.trim() ?? "";
-  const initialType = isSearchEntityType(params.type) ? params.type : "track";
+  const initialType = isSearchScope(params.type) ? params.type : "all";
   const discoverData = initialQuery
     ? null
     : await Promise.all([

--- a/apps/web/app/api/search/route.ts
+++ b/apps/web/app/api/search/route.ts
@@ -13,7 +13,7 @@ import {
   type KocteauTrackSearchCandidate,
 } from "@/lib/search/kocteau-first";
 import { supabasePublic } from "@/lib/supabase/public";
-import { deezerSearchQuerySchema } from "@/lib/validation/schemas";
+import { kocteauSearchQuerySchema } from "@/lib/validation/schemas";
 import { validationErrorResponse } from "@/lib/validation/server";
 
 type LocalEntityRow = {
@@ -25,6 +25,11 @@ type LocalEntityRow = {
   artist_name: string | null;
   cover_url: string | null;
   deezer_url: string | null;
+  release_date: string | null;
+  record_type: string | null;
+  disambiguation: string | null;
+  first_release_date: string | null;
+  genres: string[];
 };
 
 type LocalArtistRow = {
@@ -34,6 +39,10 @@ type LocalArtistRow = {
   name: string;
   image_url: string | null;
   deezer_url: string | null;
+  artist_type: string | null;
+  country_code: string | null;
+  disambiguation: string | null;
+  genres: string[];
 };
 
 type StarterTrackRow = {
@@ -56,6 +65,9 @@ const localSearchLimit = 18;
 const deezerSearchLimit = 18;
 const artistMatchLimit = 12;
 const responseLimit = 28;
+const groupedTrackLimit = 8;
+const groupedAlbumLimit = 4;
+const groupedArtistLimit = 3;
 
 function toIlikePattern(query: string) {
   return `%${query.replace(/[\\%_]/g, "\\$&")}%`;
@@ -86,6 +98,11 @@ function mapLocalEntityCandidate(
     cover_url: row.cover_url,
     deezer_url: row.deezer_url,
     entity_id: row.id,
+    release_date: row.release_date,
+    album_record_type: row.record_type,
+    disambiguation: row.disambiguation,
+    first_release_date: row.first_release_date,
+    genres: row.genres,
     source: "local",
     source_index: sourceIndex,
   };
@@ -104,6 +121,10 @@ function mapLocalArtistCandidate(
     cover_url: row.image_url,
     deezer_url: row.deezer_url,
     entity_id: row.id,
+    artist_type: row.artist_type,
+    country_code: row.country_code,
+    disambiguation: row.disambiguation,
+    genres: row.genres,
     source: "local",
     source_index: sourceIndex,
   };
@@ -208,6 +229,11 @@ function mapSearchResponse(result: ReturnType<typeof rankKocteauTrackSearchResul
     album_deezer_url: result.album_deezer_url ?? null,
     album_record_type: result.album_record_type ?? null,
     release_date: result.release_date ?? null,
+    artist_type: result.artist_type ?? null,
+    country_code: result.country_code ?? null,
+    disambiguation: result.disambiguation ?? null,
+    first_release_date: result.first_release_date ?? null,
+    genres: result.genres ?? [],
     cover_url: result.cover_url,
     deezer_url: result.deezer_url,
     entity_id: result.entity_id ?? null,
@@ -220,7 +246,7 @@ function mapSearchResponse(result: ReturnType<typeof rankKocteauTrackSearchResul
 async function getLocalEntityCandidates(query: string) {
   const supabase = supabasePublic();
   const pattern = toIlikePattern(query);
-  const baseSelect = "id, provider, provider_id, type, title, artist_name, cover_url, deezer_url";
+  const baseSelect = "id, provider, provider_id, type, title, artist_name, cover_url, deezer_url, release_date, record_type, disambiguation, first_release_date, genres";
 
   const [titleResult, artistResult] = await Promise.all([
     supabase
@@ -256,7 +282,7 @@ async function getLocalEntityCandidates(query: string) {
 async function getLocalAlbumCandidates(query: string) {
   const supabase = supabasePublic();
   const pattern = toIlikePattern(query);
-  const baseSelect = "id, provider, provider_id, type, title, artist_name, cover_url, deezer_url";
+  const baseSelect = "id, provider, provider_id, type, title, artist_name, cover_url, deezer_url, release_date, record_type, disambiguation, first_release_date, genres";
 
   const [titleResult, artistResult] = await Promise.all([
     supabase
@@ -294,7 +320,7 @@ async function getLocalArtistCandidates(query: string) {
   const pattern = toIlikePattern(query);
   const { data, error } = await supabase
     .from("artists")
-    .select("id, provider, provider_id, name, image_url, deezer_url")
+    .select("id, provider, provider_id, name, image_url, deezer_url, artist_type, country_code, disambiguation, genres")
     .eq("provider", "deezer")
     .ilike("name", pattern)
     .limit(localSearchLimit);
@@ -476,9 +502,105 @@ async function getCatalogCandidates(query: string, type: "album" | "artist") {
   return NextResponse.json([]);
 }
 
+async function getAllCatalogCandidates(query: string) {
+  const [
+    localTracks,
+    localAlbums,
+    localArtists,
+    starterTracks,
+    remoteResults,
+  ] = await Promise.all([
+    getLocalEntityCandidates(query),
+    getLocalAlbumCandidates(query),
+    getLocalArtistCandidates(query),
+    getStarterTrackCandidates(query),
+    Promise.allSettled([
+      searchDeezerTracks(query, deezerSearchLimit),
+      searchDeezerAlbums(query, deezerSearchLimit),
+      searchDeezerArtists(query, deezerSearchLimit),
+    ]),
+  ]);
+  const [remoteTracksResult, remoteAlbumsResult, remoteArtistsResult] = remoteResults;
+  const remoteTracks =
+    remoteTracksResult?.status === "fulfilled"
+      ? remoteTracksResult.value.map((track, index) =>
+          mapDeezerTrackCandidate({
+            track,
+            source: "deezer",
+            sourceIndex: index,
+          }),
+        )
+      : [];
+  const remoteAlbums =
+    remoteAlbumsResult?.status === "fulfilled"
+      ? remoteAlbumsResult.value.map(mapDeezerAlbumCandidate)
+      : [];
+  const remoteArtists =
+    remoteArtistsResult?.status === "fulfilled"
+      ? remoteArtistsResult.value.map(mapDeezerArtistCandidate)
+      : [];
+  const trackCandidates = [...localTracks, ...starterTracks, ...remoteTracks];
+  const entityIdsByProviderId = await getEntityIdsByProviderId(
+    trackCandidates.map((candidate) => candidate.provider_id),
+  );
+  const linkedTrackCandidates = trackCandidates.map((candidate) => ({
+    ...candidate,
+    entity_id:
+      candidate.entity_id ??
+      entityIdsByProviderId.get(candidate.provider_id) ??
+      null,
+  }));
+  const artists = rankKocteauTrackSearchResults({
+    query,
+    candidates: [...localArtists, ...remoteArtists],
+    limit: groupedArtistLimit,
+  });
+  const albums = rankKocteauTrackSearchResults({
+    query,
+    candidates: [...localAlbums, ...remoteAlbums],
+    limit: groupedAlbumLimit,
+  });
+  const tracks = rankKocteauTrackSearchResults({
+    query,
+    candidates: linkedTrackCandidates,
+    limit: groupedTrackLimit,
+  });
+  const results = [...artists, ...albums, ...tracks];
+  const remoteErrors = remoteResults.flatMap((result) =>
+    result.status === "rejected" ? [result.reason] : [],
+  );
+
+  if (results.length > 0) {
+    if (remoteErrors.length > 0) {
+      console.warn("[search.catalog] returned partial results", {
+        queryLength: query.length,
+        errorCount: remoteErrors.length,
+      });
+    }
+
+    return NextResponse.json(results.map(mapSearchResponse));
+  }
+
+  const [firstError] = remoteErrors;
+
+  if (firstError) {
+    console.error("[search.catalog] failed with no fallback", {
+      queryLength: query.length,
+      ...getDeezerErrorDetails(firstError),
+    });
+
+    return NextResponse.json(
+      { error: "Music search is taking longer than usual. Try again in a moment." },
+      { status: 502 },
+    );
+  }
+
+  return NextResponse.json([]);
+}
+
 export async function GET(req: Request) {
   const { searchParams } = new URL(req.url);
-  const parsed = deezerSearchQuerySchema.safeParse({
+  const parsed = kocteauSearchQuerySchema.safeParse({
     q: searchParams.get("q") ?? undefined,
     type: searchParams.get("type") ?? undefined,
   });
@@ -490,6 +612,9 @@ export async function GET(req: Request) {
   const { q, type } = parsed.data;
 
   if (!q) return NextResponse.json([], { status: 200 });
+  if (type === "all") {
+    return getAllCatalogCandidates(q);
+  }
   if (type === "album" || type === "artist") {
     return getCatalogCandidates(q, type);
   }

--- a/apps/web/components/discover-editorial-edition.tsx
+++ b/apps/web/components/discover-editorial-edition.tsx
@@ -116,7 +116,7 @@ function RotationTrack({ track }: { track: StarterTrack }) {
         src={track.cover_url}
         alt=""
         sizes="52px"
-        quality={76}
+        quality={75}
         variant="thumbnail"
         className="size-[3.25rem] rounded-[0.58rem] bg-muted/40 shadow-[0_0_0_1px_rgba(255,255,255,0.1)]"
         iconClassName="size-4"
@@ -188,7 +188,7 @@ export default function DiscoverEditorialEdition({
                   src={track.coverUrl}
                   alt=""
                   sizes="56px"
-                  quality={76}
+                  quality={75}
                   variant="thumbnail"
                   className="size-14 rounded-[0.62rem] bg-muted/40 shadow-[0_0_0_1px_rgba(255,255,255,0.1)]"
                   iconClassName="size-4"

--- a/apps/web/components/search-page-client.tsx
+++ b/apps/web/components/search-page-client.tsx
@@ -17,13 +17,14 @@ import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useKocteauSearch, type KocteauSearchResult } from "@/hooks/use-kocteau-search";
 import { useIsMobile } from "@/hooks/use-mobile";
-import type { SearchEntityType } from "@/lib/search-types";
+import type { SearchEntityType, SearchScope } from "@/lib/search-types";
+import { normalizeSearchText } from "@/lib/search/kocteau-first";
 import { buildEntityCanonicalPath } from "@/lib/seo-routes";
 import { cn } from "@/lib/utils";
 
 type SearchPageClientProps = {
   initialQuery: string;
-  initialType: SearchEntityType;
+  initialType: SearchScope;
   discoverContent: ReactNode;
 };
 
@@ -84,16 +85,71 @@ function notifyRecentSearchesChanged() {
 }
 
 function getResultHref(result: KocteauSearchResult) {
-  return result.entity_id
-    ? buildEntityCanonicalPath({
-        id: result.entity_id,
-        provider: result.provider,
-        provider_id: result.provider_id,
-        type: result.type,
-        title: result.title,
-        artist_name: result.artist_name,
-      })
-    : `/track/deezer/${result.provider_id}`;
+  return buildEntityCanonicalPath({
+    id: result.entity_id,
+    provider: result.provider,
+    provider_id: result.provider_id,
+    type: result.type,
+    title: result.title,
+    artist_name: result.artist_name,
+  });
+}
+
+const searchScopeOptions = [
+  { value: "all", label: "All" },
+  { value: "track", label: "Songs" },
+  { value: "album", label: "Albums" },
+  { value: "artist", label: "Artists" },
+] satisfies Array<{ value: SearchScope; label: string }>;
+
+const resultTypeOrder = ["artist", "album", "track"] satisfies SearchEntityType[];
+
+function getResultIdentity(result: KocteauSearchResult) {
+  return `${result.provider}:${result.type}:${result.provider_id}`;
+}
+
+function getReleaseYear(result: KocteauSearchResult) {
+  const date = result.first_release_date ?? result.release_date;
+  const year = date?.match(/^\d{4}/)?.[0];
+
+  return year ?? null;
+}
+
+function formatCatalogType(value: string | null | undefined) {
+  if (!value) return null;
+
+  return value
+    .replaceAll("_", " ")
+    .replace(/\b\w/g, (character) => character.toUpperCase());
+}
+
+function getResultContext(result: KocteauSearchResult) {
+  const year = getReleaseYear(result);
+  const genre = result.genres?.[0] ?? null;
+
+  if (result.type === "artist") {
+    return [formatCatalogType(result.artist_type) ?? "Artist", result.country_code, genre]
+      .filter(Boolean)
+      .join(" · ");
+  }
+
+  if (result.type === "album") {
+    return [
+      result.artist_name,
+      year,
+      formatCatalogType(result.album_record_type) ?? "Album",
+    ]
+      .filter(Boolean)
+      .join(" · ");
+  }
+
+  return [result.artist_name, year, genre].filter(Boolean).join(" · ");
+}
+
+function getResultSectionTitle(type: SearchEntityType) {
+  if (type === "artist") return "Artists";
+  if (type === "album") return "Albums";
+  return "Songs";
 }
 
 function SearchSectionLabel({ children }: { children: React.ReactNode }) {
@@ -114,12 +170,12 @@ export default function SearchPageClient({
   const pathname = usePathname();
 
   const [query, setQuery] = useState(initialQuery);
+  const [searchType, setSearchType] = useState<SearchScope>(initialType);
   const [activeIndexState, setActiveIndexState] = useState<ActiveSearchResultState>({
     key: "",
     index: -1,
   });
   const resultRefs = useRef<Array<HTMLAnchorElement | null>>([]);
-  const searchType = initialType;
   const normalizedQuery = query.trim();
   const recentSearchesSnapshot = useSyncExternalStore(
     subscribeRecentSearches,
@@ -136,13 +192,60 @@ export default function SearchPageClient({
     enabled: true,
   });
   const results = data as KocteauSearchResult[];
+  const searchGroups = useMemo(() => {
+    const visibleTypes: SearchEntityType[] =
+      searchType === "all" ? resultTypeOrder : [searchType];
+    const normalizedSearchQuery = normalizeSearchText(normalizedQuery);
+
+    const groups = visibleTypes
+      .map((type) => ({
+        type,
+        title: getResultSectionTitle(type),
+        results: results.filter((result) => result.type === type),
+      }))
+      .filter((group) => group.results.length > 0);
+
+    if (searchType !== "all") {
+      return groups;
+    }
+
+    return groups.sort((left, right) => {
+      function getIntentRank(group: (typeof groups)[number]) {
+        const exactMatches = group.results.filter(
+          (result) => normalizeSearchText(result.title) === normalizedSearchQuery,
+        );
+
+        if (exactMatches.some((result) => result.entity_id)) return 2;
+        if (exactMatches.length > 0) return 1;
+        return 0;
+      }
+
+      const intentDifference = getIntentRank(right) - getIntentRank(left);
+
+      if (intentDifference !== 0) return intentDifference;
+
+      return resultTypeOrder.indexOf(left.type) - resultTypeOrder.indexOf(right.type);
+    });
+  }, [normalizedQuery, results, searchType]);
+  const orderedResults = useMemo(
+    () => searchGroups.flatMap((group) => group.results),
+    [searchGroups],
+  );
+  const resultIndexByIdentity = useMemo(
+    () =>
+      new Map(
+        orderedResults.map((result, index) => [getResultIdentity(result), index]),
+      ),
+    [orderedResults],
+  );
   const activeResultKey = useMemo(
     () =>
       [
         normalizedQuery,
-        ...results.map((result) => `${result.provider}:${result.provider_id}`),
+        searchType,
+        ...orderedResults.map(getResultIdentity),
       ].join("|"),
-    [normalizedQuery, results],
+    [normalizedQuery, orderedResults, searchType],
   );
   const defaultActiveIndex = -1;
   const activeIndex =
@@ -185,7 +288,7 @@ export default function SearchPageClient({
         next.delete("q");
       }
 
-      if (searchType !== "track") {
+      if (searchType !== "all") {
         next.set("type", searchType);
       } else {
         next.delete("type");
@@ -206,10 +309,6 @@ export default function SearchPageClient({
   }, [normalizedQuery, pathname, searchType]);
 
   const hasQuery = normalizedQuery.length > 0;
-  const resultKind =
-    searchType === "artist" ? "artist" : searchType === "album" ? "album" : "track";
-  const resultCountLabel = `${results.length} ${resultKind}${results.length === 1 ? "" : "s"}`;
-  const resultSectionTitle = `${resultKind[0]?.toUpperCase()}${resultKind.slice(1)}s`;
 
   const showSkeletonResults =
     hasQuery && normalizedQuery.length >= 2 && isFetching && results.length === 0;
@@ -253,25 +352,27 @@ export default function SearchPageClient({
   }
 
   function handleInputKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
-    if (normalizedQuery.length < 2 || results.length === 0) {
+    if (normalizedQuery.length < 2 || orderedResults.length === 0) {
       return;
     }
 
     if (event.key === "ArrowDown") {
       event.preventDefault();
-      setActiveIndex((current) => (current + 1) % results.length);
+      setActiveIndex((current) => (current + 1) % orderedResults.length);
       return;
     }
 
     if (event.key === "ArrowUp") {
       event.preventDefault();
-      setActiveIndex((current) => (current <= 0 ? results.length - 1 : current - 1));
+      setActiveIndex((current) =>
+        current <= 0 ? orderedResults.length - 1 : current - 1,
+      );
       return;
     }
 
     if (event.key === "Enter" && activeIndex >= 0) {
       event.preventDefault();
-      const activeResult = results[activeIndex];
+      const activeResult = orderedResults[activeIndex];
       persistRecentSearch(activeResult.title);
       router.push(getResultHref(activeResult));
     }
@@ -291,11 +392,36 @@ export default function SearchPageClient({
             value={query}
             onChange={(event) => setQuery(event.target.value)}
             onKeyDown={handleInputKeyDown}
-            placeholder="Search tracks or artists…"
+            placeholder="Search songs, albums, or artists…"
             className="mobile-liquid-panel h-11 rounded-[var(--kocteau-radius-control)] border-transparent bg-[var(--kocteau-surface-control)] pl-10 text-base shadow-[var(--kocteau-shadow-control)] placeholder:text-muted-foreground/58 sm:text-[13px]"
             autoFocus={!isMobile}
             maxLength={80}
           />
+        </div>
+
+        <div
+          className="flex min-h-8 items-center gap-5 px-1"
+          role="group"
+          aria-label="Filter music search"
+        >
+          {searchScopeOptions.map((option) => {
+            const isActive = searchType === option.value;
+
+            return (
+              <button
+                key={option.value}
+                type="button"
+                aria-pressed={isActive}
+                onClick={() => setSearchType(option.value)}
+                className={cn(
+                  "relative inline-flex min-h-8 items-center text-[12px] font-medium text-muted-foreground/58 outline-none transition-colors duration-150 after:absolute after:inset-x-0 after:bottom-0 after:h-px after:origin-center after:scale-x-0 after:bg-foreground/72 after:transition-transform after:duration-150 hover:text-foreground/84 focus-visible:ring-2 focus-visible:ring-ring/35",
+                  isActive && "text-foreground after:scale-x-100",
+                )}
+              >
+                {option.label}
+              </button>
+            );
+          })}
         </div>
 
         {showSearchError ? (
@@ -351,9 +477,9 @@ export default function SearchPageClient({
         {!hasQuery ? discoverContent : null}
 
         {hasQuery ? (
-          <section className="max-w-3xl space-y-3" aria-live="polite">
+          <div className="max-w-3xl space-y-8" aria-live="polite">
             {showSkeletonResults ? (
-              <div className="grid gap-1" aria-label="Searching tracks">
+              <div className="grid gap-1" aria-label="Searching music">
                 {Array.from({ length: 4 }).map((_, index) => (
                   <div key={index} className="flex items-center gap-3 rounded-[0.75rem] p-2">
                     <Skeleton className="size-14 rounded-[0.62rem] bg-foreground/[0.065]" />
@@ -378,28 +504,37 @@ export default function SearchPageClient({
                   No matches for “{normalizedQuery}”
                 </p>
                 <p className="mt-1 text-[13px] text-muted-foreground/66">
-                  Try another track or artist.
+                  Try another song, album, or artist.
                 </p>
               </div>
             ) : null}
 
-            {results.length > 0 ? (
-              <div className="space-y-2">
-                <div className="flex items-center justify-between gap-3 px-2">
-                  <h2 className="font-pixel text-[1.05rem] font-medium text-foreground">
-                    {resultSectionTitle}
+            {searchGroups.map((group, groupIndex) => (
+              <section
+                key={group.type}
+                className="space-y-2"
+                aria-labelledby={`search-${group.type}-heading`}
+              >
+                <div className="flex min-h-6 items-center gap-2 px-2">
+                  <h2
+                    id={`search-${group.type}-heading`}
+                    className="text-[13px] font-semibold text-foreground/92"
+                  >
+                    {group.title}
                   </h2>
-                  <span className="inline-flex items-center gap-1.5 text-[11px] tabular-nums text-muted-foreground/52">
-                    {isFetching ? <LoaderCircle className="size-3 animate-spin" /> : null}
-                    {resultCountLabel}
-                  </span>
+                  {groupIndex === 0 && isFetching ? (
+                    <LoaderCircle className="size-3 animate-spin text-muted-foreground/48" />
+                  ) : null}
                 </div>
 
                 <div className="grid gap-1">
-                  {results.map((result, index) => {
+                  {group.results.map((result) => {
+                    const resultIdentity = getResultIdentity(result);
+                    const index = resultIndexByIdentity.get(resultIdentity) ?? -1;
+                    const context = getResultContext(result);
                     const resultLink = (
                       <PrefetchLink
-                        key={`${result.provider}-${result.type}-${result.provider_id}`}
+                        key={resultIdentity}
                         href={getResultHref(result)}
                         queryWarmup={
                           result.type === "track" && result.entity_id
@@ -424,7 +559,12 @@ export default function SearchPageClient({
                             sizes="56px"
                             quality={78}
                             variant="card"
-                            className="size-14 shrink-0 rounded-[0.62rem] bg-muted/50 shadow-[0_0_0_1px_rgba(255,255,255,0.1)]"
+                            className={cn(
+                              "size-14 shrink-0 bg-muted/50 shadow-[0_0_0_1px_rgba(255,255,255,0.1)]",
+                              result.type === "artist"
+                                ? "rounded-full"
+                                : "rounded-[0.62rem]",
+                            )}
                             iconClassName="size-5"
                           />
 
@@ -433,9 +573,7 @@ export default function SearchPageClient({
                               {result.title}
                             </h3>
                             <p className="line-clamp-1 text-[13px] text-muted-foreground/72">
-                              {result.type === "artist"
-                                ? "Artist"
-                                : result.artist_name ?? "Unknown artist"}
+                              {context}
                             </p>
                           </div>
                         </div>
@@ -444,7 +582,7 @@ export default function SearchPageClient({
 
                     return result.type === "track" ? (
                       <TrackContextMenu
-                        key={`${result.provider}-${result.type}-${result.provider_id}`}
+                        key={resultIdentity}
                         href={getResultHref(result)}
                         title={result.title}
                         artistName={result.artist_name}
@@ -456,9 +594,9 @@ export default function SearchPageClient({
                     );
                   })}
                 </div>
-              </div>
-            ) : null}
-          </section>
+              </section>
+            ))}
+          </div>
         ) : null}
       </div>
     </div>

--- a/apps/web/hooks/use-kocteau-search.ts
+++ b/apps/web/hooks/use-kocteau-search.ts
@@ -3,14 +3,14 @@
 import { useDeferredValue } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useDebouncedValue } from "@/hooks/use-debounced-value";
-import type { SearchEntityType } from "@/lib/search-types";
+import type { SearchScope } from "@/lib/search-types";
 import { kocteauTrackSearchQueryOptions } from "@/queries/tracks";
 
 export type { KocteauSearchResult } from "@/queries/tracks";
 
 type UseKocteauSearchOptions = {
   query: string;
-  type?: SearchEntityType;
+  type?: SearchScope;
   enabled?: boolean;
 };
 

--- a/apps/web/lib/search-types.ts
+++ b/apps/web/lib/search-types.ts
@@ -1,7 +1,13 @@
 export const searchableEntityTypes = ["track", "artist", "album"] as const;
+export const searchScopes = ["all", ...searchableEntityTypes] as const;
 
 export type SearchEntityType = (typeof searchableEntityTypes)[number];
+export type SearchScope = (typeof searchScopes)[number];
 
 export function isSearchEntityType(value: string | null | undefined): value is SearchEntityType {
   return searchableEntityTypes.includes(value as SearchEntityType);
+}
+
+export function isSearchScope(value: string | null | undefined): value is SearchScope {
+  return searchScopes.includes(value as SearchScope);
 }

--- a/apps/web/lib/search/kocteau-first.ts
+++ b/apps/web/lib/search/kocteau-first.ts
@@ -13,6 +13,11 @@ export type KocteauTrackSearchCandidate = {
   album_deezer_url?: string | null;
   album_record_type?: string | null;
   release_date?: string | null;
+  artist_type?: string | null;
+  country_code?: string | null;
+  disambiguation?: string | null;
+  first_release_date?: string | null;
+  genres?: string[];
   cover_url: string | null;
   deezer_url: string | null;
   entity_id?: string | null;
@@ -110,6 +115,12 @@ function mergeDuplicateCandidate(
     album_record_type:
       winner.album_record_type ?? fallback.album_record_type ?? null,
     release_date: winner.release_date ?? fallback.release_date ?? null,
+    artist_type: winner.artist_type ?? fallback.artist_type ?? null,
+    country_code: winner.country_code ?? fallback.country_code ?? null,
+    disambiguation: winner.disambiguation ?? fallback.disambiguation ?? null,
+    first_release_date:
+      winner.first_release_date ?? fallback.first_release_date ?? null,
+    genres: winner.genres?.length ? winner.genres : fallback.genres ?? [],
     rank: winner.rank ?? fallback.rank ?? null,
     source_index: Math.min(
       winner.source_index ?? Number.MAX_SAFE_INTEGER,

--- a/apps/web/lib/validation/schemas.ts
+++ b/apps/web/lib/validation/schemas.ts
@@ -4,7 +4,7 @@ import {
   getCanonicalAnalyticsEventType,
   isAllowedAnalyticsMetadataKey,
 } from "@/lib/analytics/events";
-import { searchableEntityTypes } from "@/lib/search-types";
+import { searchableEntityTypes, searchScopes } from "@/lib/search-types";
 import { editorialCandidateStatuses } from "@/lib/starter/candidate-queue";
 import { tasteOnboardingMaxTags, tasteOnboardingMinTags } from "@/lib/taste";
 import { entityLibraryItemTypes } from "@/lib/library/entity-library";
@@ -82,6 +82,16 @@ export const deezerSearchQuerySchema = z.object({
     .optional()
     .transform((value) => value ?? ""),
   type: z.enum(searchableEntityTypes).optional().default("track"),
+});
+
+export const kocteauSearchQuerySchema = z.object({
+  q: z
+    .string()
+    .trim()
+    .max(80, "Search queries can be up to 80 characters.")
+    .optional()
+    .transform((value) => value ?? ""),
+  type: z.enum(searchScopes).optional().default("all"),
 });
 
 export const starterCandidateQuerySchema = z.object({

--- a/apps/web/queries/tracks.ts
+++ b/apps/web/queries/tracks.ts
@@ -2,7 +2,7 @@ import type { QueryClient } from "@tanstack/react-query";
 import { keepPreviousData, queryOptions } from "@tanstack/react-query";
 import type { ReviewCardAuthor, ReviewCardData } from "@/components/review-card";
 import type { DiscoveryTrack } from "@/lib/types/discovery";
-import type { SearchEntityType } from "@/lib/search-types";
+import type { SearchEntityType, SearchScope } from "@/lib/search-types";
 import { fetchJson, isRetryableFetchJsonError } from "@/queries/http";
 
 export type TrackEntity = {
@@ -64,6 +64,11 @@ export type DeezerSearchResult = {
 
 export type KocteauSearchResult = Omit<DeezerSearchResult, "type"> & {
   type: "track" | "album" | "artist";
+  artist_type?: string | null;
+  country_code?: string | null;
+  disambiguation?: string | null;
+  first_release_date?: string | null;
+  genres?: string[];
   source?: "local" | "starter" | "artist-match" | "deezer";
   source_label?: string;
   score?: number;
@@ -76,7 +81,7 @@ export const trackKeys = {
   detail: (trackId: string) => ["tracks", "detail", trackId] as const,
   search: (type: SearchEntityType, query: string) =>
     ["tracks", "search", type, query] as const,
-  kocteauSearch: (type: SearchEntityType, query: string) =>
+  kocteauSearch: (type: SearchScope, query: string) =>
     ["tracks", "kocteau-search", type, query] as const,
 };
 
@@ -128,7 +133,7 @@ export function deezerTrackSearchQueryOptions(
 
 export function kocteauTrackSearchQueryOptions(
   query: string,
-  type: SearchEntityType = "track",
+  type: SearchScope = "track",
 ) {
   const params = new URLSearchParams({
     q: query,


### PR DESCRIPTION
## Summary
- make Discover search songs, albums, and artists in one quiet mixed view
- surface persisted MusicBrainz context such as artist type, genres, release year, and record type
- keep filters shareable in the URL and route persisted entities through canonical Kocteau pages
- retain local results when Deezer is partially unavailable
- use an allowed Next image quality to remove the development warning

## Verification
- pnpm --filter web exec tsc --noEmit --allowImportingTsExtensions
- pnpm --filter web lint
- node --test apps/web/lib/search/kocteau-first.test.ts
- pnpm --filter web build
- desktop and 390px browser checks; no horizontal overflow
- canonical artist and album routes verified without 404

No merge requested; awaiting product feedback.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies Discover search into a single, enriched music catalog view showing songs, albums, and artists with MusicBrainz context. Adds smarter ranking, canonical routing, shareable filters, and resilient fallbacks when Deezer is slow.

- **New Features**
  - Added “All” scope (default) with grouped sections: Artists, Albums, Songs.
  - Enriched results with artist type, country, genres, release year, record type, and disambiguation.
  - Ranked by intent (exact-match boosts) with limits: artists 3, albums 4, songs 8.
  - API `GET /api/search` now uses `kocteauSearchQuerySchema` (`type=all`) and merges local + starter + Deezer sources; filters persist in the URL; routes use canonical Kocteau paths.

- **Bug Fixes**
  - Keeps local results when Deezer partially fails; returns a friendly 502 only when no fallback exists.
  - Removed Next Image warning by using quality 75.

<sup>Written for commit 972702ceb855c34b00b360da4e17cf104b9fce0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/francozeta/kocteau/pull/153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

