### PR TITLE
feat(curators): add editorial application program

### DIFF
--- a/apps/web/app/(main)/curators/page.tsx
+++ b/apps/web/app/(main)/curators/page.tsx
@@ -1,0 +1,85 @@
+import Link from "next/link";
+import CuratorApplicationClient from "@/components/curator-application-client";
+import { Button } from "@/components/ui/button";
+import type { CuratorApplication } from "@/lib/curators";
+import { getCurrentUserId } from "@/lib/auth/server";
+import { createPageMetadata } from "@/lib/metadata";
+import { supabaseServer } from "@/lib/supabase/server";
+
+export const metadata = createPageMetadata({
+  title: "Curate for Kocteau",
+  description: "Help surface independent music through a human editorial lens.",
+  path: "/curators",
+});
+
+export default async function CuratorsPage() {
+  const userId = await getCurrentUserId();
+  let application: CuratorApplication | null = null;
+
+  if (userId) {
+    const supabase = await supabaseServer();
+    const result = await supabase
+      .from("curator_applications")
+      .select("*")
+      .eq("user_id", userId)
+      .order("submitted_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (result.error) {
+      console.error("[curators.page] application read failed", {
+        code: result.error.code ?? null,
+        message: result.error.message ?? null,
+        userId,
+      });
+    } else {
+      application = result.data;
+    }
+  }
+
+  return (
+    <section className="mx-auto w-full max-w-3xl space-y-8 pb-10 pt-2 sm:pt-5">
+      <header className="max-w-2xl space-y-3">
+        <p className="text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground/68">
+          Kocteau curators
+        </p>
+        <h1 className="text-balance font-heading text-3xl font-medium tracking-[-0.025em] text-foreground sm:text-4xl">
+          Help someone find the record they did not know to look for.
+        </h1>
+        <p className="max-w-xl text-pretty text-sm leading-6 text-muted-foreground">
+          We are inviting listeners with a clear point of view to scout catalog candidates,
+          shape quiet editorial routes, and strengthen discovery before the community is large.
+        </p>
+      </header>
+
+      <div className="grid gap-px overflow-hidden rounded-[var(--kocteau-radius-card)] border border-border/20 bg-border/20 sm:grid-cols-3">
+        {[
+          ["Find", "Surface overlooked tracks, albums, and artists."],
+          ["Frame", "Add a short, factual reason a candidate belongs."],
+          ["Route", "Send it into a shared queue before publication."],
+        ].map(([title, note]) => (
+          <div key={title} className="bg-[var(--kocteau-shell)] px-4 py-4">
+            <p className="text-[12px] font-medium text-foreground">{title}</p>
+            <p className="mt-1 text-[12px] leading-5 text-muted-foreground">{note}</p>
+          </div>
+        ))}
+      </div>
+
+      {userId ? (
+        <CuratorApplicationClient initialApplication={application} />
+      ) : (
+        <div className="flex flex-col items-start gap-4 rounded-[var(--kocteau-radius-card)] border border-border/22 bg-card/20 px-5 py-5 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="text-sm font-medium text-foreground">Apply with your Kocteau profile</p>
+            <p className="mt-1 text-[12px] leading-5 text-muted-foreground">
+              Your reviews and profile provide the context. We will not ask for your email again.
+            </p>
+          </div>
+          <Button asChild size="lg">
+            <Link href="/login?next=%2Fcurators">Log in to apply</Link>
+          </Button>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/app/(studio)/studio/curators/page.tsx
+++ b/apps/web/app/(studio)/studio/curators/page.tsx
@@ -1,0 +1,71 @@
+import { notFound, redirect } from "next/navigation";
+import CuratorApplicationsStudioClient, {
+  type StudioCuratorApplication,
+} from "@/components/curator-applications-studio-client";
+import { getCurrentUser } from "@/lib/auth/server";
+import { createPageMetadata } from "@/lib/metadata";
+import { getKocteauAdminAccess } from "@/lib/queries/curation";
+import { supabaseServer } from "@/lib/supabase/server";
+
+export const metadata = createPageMetadata({
+  title: "Curator Applications",
+  description: "Review applications for Kocteau editorial access.",
+  path: "/studio/curators",
+  noIndex: true,
+});
+
+export default async function CuratorApplicationsPage() {
+  const user = await getCurrentUser();
+
+  if (!user) {
+    redirect("/login?next=%2Fstudio%2Fcurators");
+  }
+
+  if (!(await getKocteauAdminAccess())) {
+    notFound();
+  }
+
+  const supabase = await supabaseServer();
+  const { data, error } = await supabase
+    .from("curator_applications")
+    .select(`
+      *,
+      applicant:profiles!curator_applications_user_id_fkey (
+        avatar_url,
+        display_name,
+        username
+      )
+    `)
+    .order("submitted_at", { ascending: false })
+    .limit(50)
+    .returns<StudioCuratorApplication[]>();
+
+  if (error) {
+    console.error("[studio.curators] application read failed", {
+      code: error.code ?? null,
+      message: error.message ?? null,
+    });
+  }
+
+  return (
+    <section className="w-full max-w-5xl space-y-6 pb-8">
+      <header className="space-y-1">
+        <p className="text-[12px] font-medium text-muted-foreground/72">Studio</p>
+        <h1 className="font-heading text-2xl font-medium text-foreground">
+          Curator applications
+        </h1>
+        <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
+          Grant catalog scouting access without turning applications into public content.
+        </p>
+      </header>
+
+      {error ? (
+        <div className="rounded-[var(--kocteau-radius-card)] border border-destructive/24 bg-destructive/8 px-4 py-3 text-sm text-destructive">
+          Applications could not be loaded.
+        </div>
+      ) : (
+        <CuratorApplicationsStudioClient initialApplications={data ?? []} />
+      )}
+    </section>
+  );
+}

--- a/apps/web/app/api/curator-applications/route.ts
+++ b/apps/web/app/api/curator-applications/route.ts
@@ -1,0 +1,70 @@
+import { revalidatePath } from "next/cache";
+import { NextResponse } from "next/server";
+import { enforceRateLimit, rateLimits } from "@/lib/rate-limit";
+import { supabaseServer } from "@/lib/supabase/server";
+import { curatorApplicationSchema } from "@/lib/validation/schemas";
+import { validationErrorResponse } from "@/lib/validation/server";
+
+export async function POST(request: Request) {
+  const supabase = await supabaseServer();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const rateLimited = await enforceRateLimit(
+    rateLimits.createCuratorApplication,
+    user.id,
+  );
+
+  if (rateLimited) {
+    return rateLimited;
+  }
+
+  const payload = (await request.json().catch(() => null)) as unknown;
+  const parsed = curatorApplicationSchema.safeParse(payload);
+
+  if (!parsed.success) {
+    return validationErrorResponse(parsed.error, "Please review your application.");
+  }
+
+  const { data, error } = await supabase
+    .from("curator_applications")
+    .insert({
+      user_id: user.id,
+      taste_focus: parsed.data.taste_focus,
+      motivation: parsed.data.motivation,
+      sample_links: parsed.data.sample_links,
+      availability: parsed.data.availability,
+    })
+    .select("*")
+    .single();
+
+  if (error) {
+    if (error.code === "23505") {
+      return NextResponse.json(
+        { error: "You already have an active curator application." },
+        { status: 409 },
+      );
+    }
+
+    console.error("[curator-applications.create] failed", {
+      code: error.code ?? null,
+      message: error.message ?? null,
+      userId: user.id,
+    });
+
+    return NextResponse.json(
+      { error: "We could not submit your application. Please try again." },
+      { status: error.code === "42501" ? 403 : 500 },
+    );
+  }
+
+  revalidatePath("/curators");
+  revalidatePath("/studio/curators");
+
+  return NextResponse.json({ application: data }, { status: 201 });
+}

--- a/apps/web/app/api/studio/curator-applications/route.ts
+++ b/apps/web/app/api/studio/curator-applications/route.ts
@@ -1,0 +1,70 @@
+import { revalidatePath } from "next/cache";
+import { NextResponse } from "next/server";
+import { requireKocteauAdmin } from "@/lib/curation/access";
+import { curatorApplicationDecisionSchema } from "@/lib/validation/schemas";
+import { validationErrorResponse } from "@/lib/validation/server";
+
+function decisionErrorResponse(error: {
+  code?: string | null;
+  message?: string | null;
+}) {
+  if (error.code === "42501") {
+    return NextResponse.json({ error: "Not allowed" }, { status: 403 });
+  }
+
+  if (error.code === "02000") {
+    return NextResponse.json({ error: "Application not found" }, { status: 404 });
+  }
+
+  if (error.code === "22023") {
+    return NextResponse.json(
+      { error: error.message ?? "This application can no longer be changed." },
+      { status: 409 },
+    );
+  }
+
+  return NextResponse.json(
+    { error: "We could not update the curator application." },
+    { status: 500 },
+  );
+}
+
+export async function PATCH(request: Request) {
+  const admin = await requireKocteauAdmin();
+
+  if (!admin.ok) {
+    return admin.response;
+  }
+
+  const payload = (await request.json().catch(() => null)) as unknown;
+  const parsed = curatorApplicationDecisionSchema.safeParse(payload);
+
+  if (!parsed.success) {
+    return validationErrorResponse(parsed.error, "Curator decision is invalid.");
+  }
+
+  const { data, error } = await admin.supabase.rpc(
+    "decide_curator_application",
+    {
+      p_application_id: parsed.data.id,
+      p_status: parsed.data.status,
+      p_decision_note: parsed.data.decision_note ?? undefined,
+    },
+  );
+
+  if (error) {
+    console.error("[studio.curator-applications.decide] failed", {
+      code: error.code ?? null,
+      message: error.message ?? null,
+      adminId: admin.user.id,
+      applicationId: parsed.data.id,
+    });
+
+    return decisionErrorResponse(error);
+  }
+
+  revalidatePath("/curators");
+  revalidatePath("/studio/curators");
+
+  return NextResponse.json({ application: data });
+}

--- a/apps/web/components/app-shell.tsx
+++ b/apps/web/components/app-shell.tsx
@@ -16,7 +16,10 @@ import {
   getCurrentUserId,
   getCurrentViewerProfile,
 } from "@/lib/auth/server";
-import { getStarterCuratorAccess } from "@/lib/queries/curation";
+import {
+  getKocteauAdminAccess,
+  getStarterCuratorAccess,
+} from "@/lib/queries/curation";
 import { cn } from "@/lib/utils";
 
 type AppShellVariant = "feed" | "studio";
@@ -45,7 +48,12 @@ export default async function AppShell({
     redirect("/onboarding/taste");
   }
 
-  const canAccessStudio = userId ? await getStarterCuratorAccess() : false;
+  const [canAccessStudio, canManageCurators] = userId
+    ? await Promise.all([
+        getStarterCuratorAccess(),
+        getKocteauAdminAccess(),
+      ])
+    : [false, false];
   const isStudio = variant === "studio";
 
   const content = (
@@ -111,6 +119,7 @@ export default async function AppShell({
           profile={safeProfile}
           unreadCount={initialUnreadCount}
           canAccessStudio={canAccessStudio}
+          canManageCurators={canManageCurators}
         />
         <SidebarInset
           className={cn(

--- a/apps/web/components/app-sidebar.tsx
+++ b/apps/web/components/app-sidebar.tsx
@@ -55,6 +55,7 @@ type AppSidebarProps = React.ComponentProps<typeof Sidebar> & {
   profile: AppSidebarProfile | null;
   unreadCount?: number;
   canAccessStudio?: boolean;
+  canManageCurators?: boolean;
 };
 
 function SidebarHeaderAction({
@@ -123,6 +124,7 @@ export default function AppSidebar({
   profile,
   unreadCount: initialUnreadCount = 0,
   canAccessStudio = false,
+  canManageCurators = false,
   ...props
 }: AppSidebarProps) {
   const pathname = usePathname();
@@ -213,6 +215,16 @@ export default function AppSidebar({
           icon: KocteauHealthIcon,
           isActive: pathname.startsWith("/studio/health"),
         },
+        ...(canManageCurators
+          ? [
+              {
+                title: "Curators",
+                url: "/studio/curators",
+                icon: KocteauStarterIcon,
+                isActive: pathname.startsWith("/studio/curators"),
+              },
+            ]
+          : []),
       ]
     : [];
 

--- a/apps/web/components/app-sidebar.tsx
+++ b/apps/web/components/app-sidebar.tsx
@@ -3,9 +3,6 @@
 import { type ReactNode, useCallback, useEffect, useRef } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { usePathname } from "next/navigation";
-import {
-  MagnifyingGlassIcon,
-} from "@/components/ui/icons";
 import BrandLogo from "@/components/brand-logo";
 import {
   KocteauActivityIcon,
@@ -173,7 +170,7 @@ export default function AppSidebar({
     {
       title: "Search",
       url: "/search",
-      icon: MagnifyingGlassIcon,
+      icon: KocteauSearchIcon,
       isActive: pathname.startsWith("/search") || pathname.startsWith("/track"),
     },
     {

--- a/apps/web/components/curator-application-client.tsx
+++ b/apps/web/components/curator-application-client.tsx
@@ -1,0 +1,236 @@
+"use client";
+
+import { useState } from "react";
+import { SpinnerGapIcon } from "@/components/ui/icons";
+import { Button } from "@/components/ui/button";
+import { Field, FieldDescription, FieldError, FieldLabel } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  curatorAvailabilityOptions,
+  getCuratorStatusLabel,
+  type CuratorApplication,
+  type CuratorAvailability,
+} from "@/lib/curators";
+import { createApiError, getFirstFieldError } from "@/lib/validation/errors";
+import { curatorApplicationSchema } from "@/lib/validation/schemas";
+import { cn } from "@/lib/utils";
+
+type ApplicationErrors = Partial<
+  Record<"taste_focus" | "motivation" | "sample_links" | "availability", string>
+>;
+
+function ApplicationStatus({ application }: { application: CuratorApplication }) {
+  const statusLabel = getCuratorStatusLabel(application.status);
+  const canApplyAgain = application.status === "declined";
+
+  return (
+    <div className="rounded-[var(--kocteau-radius-card)] border border-border/24 bg-card/22 px-4 py-4 sm:px-5">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <p className="text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground/70">
+            Your application
+          </p>
+          <p className="mt-1 text-sm font-medium text-foreground">{statusLabel}</p>
+        </div>
+        <span className="rounded-full bg-foreground/[0.08] px-2.5 py-1 text-[11px] font-medium text-foreground/82">
+          {new Intl.DateTimeFormat("en", {
+            month: "short",
+            day: "numeric",
+            year: "numeric",
+          }).format(new Date(application.submitted_at))}
+        </span>
+      </div>
+      <p className="mt-3 max-w-xl text-[13px] leading-5 text-muted-foreground">
+        {application.status === "accepted"
+          ? "You now have access to Kocteau Studio. Your picks will still pass through the same editorial queue."
+          : application.status === "reviewing"
+            ? "We are reading your profile, reviews, and listening perspective."
+            : canApplyAgain
+              ? application.decision_note ?? "This round was not the right fit. You can apply again with a clearer focus."
+              : "We received it. We will review your profile and the perspective you want to bring."}
+      </p>
+    </div>
+  );
+}
+export default function CuratorApplicationClient({
+  initialApplication,
+}: {
+  initialApplication: CuratorApplication | null;
+}) {
+  const [application, setApplication] = useState(initialApplication);
+  const [tasteFocus, setTasteFocus] = useState("");
+  const [motivation, setMotivation] = useState("");
+  const [sampleLinks, setSampleLinks] = useState(["", "", ""]);
+  const [availability, setAvailability] =
+    useState<CuratorAvailability>("occasional");
+  const [fieldErrors, setFieldErrors] = useState<ApplicationErrors>({});
+  const [message, setMessage] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const canApply = !application || application.status === "declined";
+
+  async function submitApplication(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setMessage(null);
+
+    const payload = {
+      taste_focus: tasteFocus,
+      motivation,
+      sample_links: sampleLinks.map((link) => link.trim()).filter(Boolean),
+      availability,
+    };
+    const parsed = curatorApplicationSchema.safeParse(payload);
+
+    if (!parsed.success) {
+      const errors = parsed.error.flatten().fieldErrors;
+      setFieldErrors({
+        taste_focus: getFirstFieldError(errors, "taste_focus") ?? undefined,
+        motivation: getFirstFieldError(errors, "motivation") ?? undefined,
+        sample_links: getFirstFieldError(errors, "sample_links") ?? undefined,
+        availability: getFirstFieldError(errors, "availability") ?? undefined,
+      });
+      return;
+    }
+
+    setFieldErrors({});
+    setSubmitting(true);
+
+    try {
+      const response = await fetch("/api/curator-applications", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(parsed.data),
+      });
+
+      if (!response.ok) {
+        throw await createApiError(response, "We could not submit your application.");
+      }
+
+      const result = (await response.json()) as { application: CuratorApplication };
+      setApplication(result.application);
+      setTasteFocus("");
+      setMotivation("");
+      setSampleLinks(["", "", ""]);
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "We could not submit your application.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="space-y-5">
+      {application ? <ApplicationStatus application={application} /> : null}
+
+      {canApply ? (
+        <form onSubmit={submitApplication} className="space-y-5" noValidate>
+          <Field data-invalid={Boolean(fieldErrors.taste_focus)}>
+            <FieldLabel htmlFor="curator-taste-focus">What do you listen for?</FieldLabel>
+            <FieldDescription>
+              Scenes, genres, local movements, eras, or overlooked corners you know well.
+            </FieldDescription>
+            <Textarea
+              id="curator-taste-focus"
+              value={tasteFocus}
+              onChange={(event) => setTasteFocus(event.target.value)}
+              placeholder="I follow…"
+              maxLength={600}
+              aria-invalid={Boolean(fieldErrors.taste_focus)}
+              className="min-h-24 rounded-[0.7rem] border-border/22 bg-black/20 px-3 py-2.5 text-[13px] leading-5"
+            />
+            <FieldError>{fieldErrors.taste_focus}</FieldError>
+          </Field>
+
+          <Field data-invalid={Boolean(fieldErrors.motivation)}>
+            <FieldLabel htmlFor="curator-motivation">What perspective would you bring?</FieldLabel>
+            <FieldDescription>
+              Tell us how your selections could help someone hear something they would otherwise miss.
+            </FieldDescription>
+            <Textarea
+              id="curator-motivation"
+              value={motivation}
+              onChange={(event) => setMotivation(event.target.value)}
+              placeholder="My point of view is…"
+              maxLength={1200}
+              aria-invalid={Boolean(fieldErrors.motivation)}
+              className="min-h-32 rounded-[0.7rem] border-border/22 bg-black/20 px-3 py-2.5 text-[13px] leading-5"
+            />
+            <FieldError>{fieldErrors.motivation}</FieldError>
+          </Field>
+
+          <Field data-invalid={Boolean(fieldErrors.sample_links)}>
+            <FieldLabel>Optional work</FieldLabel>
+            <FieldDescription>
+              Up to three links to Kocteau reviews, writing, radio, mixes, or another relevant archive.
+            </FieldDescription>
+            <div className="grid gap-2">
+              {sampleLinks.map((link, index) => (
+                <Input
+                  key={index}
+                  type="url"
+                  inputMode="url"
+                  aria-label={`Work sample ${index + 1}`}
+                  value={link}
+                  onChange={(event) => {
+                    const nextLinks = [...sampleLinks];
+                    nextLinks[index] = event.target.value;
+                    setSampleLinks(nextLinks);
+                  }}
+                  placeholder={index === 0 ? "https://…" : "Another link…"}
+                  className="h-9 rounded-full border-border/22 bg-black/20 px-3 text-[13px]"
+                />
+              ))}
+            </div>
+            <FieldError>{fieldErrors.sample_links}</FieldError>
+          </Field>
+
+          <fieldset className="space-y-2.5">
+            <legend className="text-[12px] font-medium text-foreground/88">Rhythm</legend>
+            <div className="grid gap-2 sm:grid-cols-3">
+              {curatorAvailabilityOptions.map((option) => (
+                <label
+                  key={option.value}
+                  className={cn(
+                    "cursor-pointer rounded-[0.7rem] border px-3 py-3 transition-colors",
+                    availability === option.value
+                      ? "border-foreground/24 bg-foreground/[0.08]"
+                      : "border-border/20 bg-card/16 hover:bg-card/28",
+                  )}
+                >
+                  <input
+                    type="radio"
+                    name="availability"
+                    value={option.value}
+                    checked={availability === option.value}
+                    onChange={() => setAvailability(option.value)}
+                    className="sr-only"
+                  />
+                  <span className="block text-[12px] font-medium text-foreground">
+                    {option.label}
+                  </span>
+                  <span className="mt-1 block text-[11px] leading-4 text-muted-foreground">
+                    {option.note}
+                  </span>
+                </label>
+              ))}
+            </div>
+            <FieldError>{fieldErrors.availability}</FieldError>
+          </fieldset>
+
+          {message ? <p role="alert" className="text-[12px] text-destructive">{message}</p> : null}
+
+          <div className="flex items-center justify-between gap-4 border-t border-border/16 pt-4">
+            <p className="max-w-sm text-[11px] leading-4 text-muted-foreground/70">
+              Curators route catalog candidates. They do not publish reviews on behalf of Kocteau.
+            </p>
+            <Button type="submit" size="lg" disabled={submitting}>
+              {submitting ? <SpinnerGapIcon className="size-3.5 animate-spin" /> : null}
+              Submit
+            </Button>
+          </div>
+        </form>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/components/curator-applications-studio-client.tsx
+++ b/apps/web/components/curator-applications-studio-client.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { SpinnerGapIcon } from "@/components/ui/icons";
+import { toast } from "sonner";
+import UserAvatar from "@/components/user-avatar";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  getCuratorStatusLabel,
+  type CuratorApplication,
+} from "@/lib/curators";
+import { createApiError } from "@/lib/validation/errors";
+
+export type StudioCuratorApplication = CuratorApplication & {
+  applicant: {
+    avatar_url: string | null;
+    display_name: string | null;
+    username: string | null;
+  } | null;
+};
+
+export default function CuratorApplicationsStudioClient({
+  initialApplications,
+}: {
+  initialApplications: StudioCuratorApplication[];
+}) {
+  const [applications, setApplications] = useState(initialApplications);
+  const [notes, setNotes] = useState<Record<string, string>>({});
+  const [pendingId, setPendingId] = useState<string | null>(null);
+
+  async function decide(
+    application: StudioCuratorApplication,
+    status: "reviewing" | "accepted" | "declined",
+  ) {
+    setPendingId(application.id);
+
+    try {
+      const response = await fetch("/api/studio/curator-applications", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          id: application.id,
+          status,
+          decision_note: notes[application.id]?.trim() || null,
+        }),
+      });
+
+      if (!response.ok) {
+        throw await createApiError(response, "We could not update this application.");
+      }
+
+      const result = (await response.json()) as { application: CuratorApplication };
+      setApplications((current) =>
+        current.map((item) =>
+          item.id === application.id
+            ? { ...item, ...result.application }
+            : item,
+        ),
+      );
+      toast.success(
+        status === "accepted"
+          ? "Curator access granted."
+          : status === "declined"
+            ? "Application closed."
+            : "Application marked in review.",
+      );
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "We could not update this application.");
+    } finally {
+      setPendingId(null);
+    }
+  }
+
+  if (applications.length === 0) {
+    return (
+      <div className="rounded-[var(--kocteau-radius-card)] border border-border/22 bg-card/20 px-4 py-8 text-center text-sm text-muted-foreground">
+        No curator applications yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className="divide-y divide-border/16 overflow-hidden rounded-[var(--kocteau-radius-card)] border border-border/22 bg-card/18">
+      {applications.map((application) => {
+        const isPending = pendingId === application.id;
+        const isDecided = ["accepted", "declined"].includes(application.status);
+        const username = application.applicant?.username;
+
+        return (
+          <article key={application.id} className="space-y-4 px-4 py-4 sm:px-5">
+            <div className="flex items-start justify-between gap-4">
+              <div className="flex min-w-0 items-center gap-3">
+                <UserAvatar
+                  avatarUrl={application.applicant?.avatar_url}
+                  displayName={application.applicant?.display_name}
+                  username={username}
+                  size="sm"
+                  className="size-8"
+                />
+                <div className="min-w-0">
+                  {username ? (
+                    <Link href={`/u/${username}`} className="truncate text-[13px] font-medium text-foreground hover:underline">
+                      @{username}
+                    </Link>
+                  ) : (
+                    <p className="text-[13px] font-medium text-foreground">Kocteau listener</p>
+                  )}
+                  <p className="mt-0.5 text-[11px] text-muted-foreground">
+                    {new Intl.DateTimeFormat("en", {
+                      month: "short",
+                      day: "numeric",
+                      year: "numeric",
+                    }).format(new Date(application.submitted_at))}
+                  </p>
+                </div>
+              </div>
+              <span className="rounded-full bg-foreground/[0.08] px-2.5 py-1 text-[11px] font-medium text-foreground/82">
+                {getCuratorStatusLabel(application.status)}
+              </span>
+            </div>
+
+            <div className="grid gap-4 text-[13px] leading-5 sm:grid-cols-2">
+              <div>
+                <p className="text-[11px] font-medium uppercase tracking-[0.1em] text-muted-foreground/66">Taste focus</p>
+                <p className="mt-1.5 whitespace-pre-wrap text-foreground/88">{application.taste_focus}</p>
+              </div>
+              <div>
+                <p className="text-[11px] font-medium uppercase tracking-[0.1em] text-muted-foreground/66">Perspective</p>
+                <p className="mt-1.5 whitespace-pre-wrap text-foreground/88">{application.motivation}</p>
+              </div>
+            </div>
+
+            {application.sample_links.length > 0 ? (
+              <div className="flex flex-wrap gap-2">
+                {application.sample_links.map((href, index) => (
+                  <a
+                    key={href}
+                    href={href}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="rounded-full border border-border/22 px-2.5 py-1 text-[11px] text-muted-foreground transition-colors hover:bg-foreground/[0.06] hover:text-foreground"
+                  >
+                    Sample {index + 1}
+                  </a>
+                ))}
+              </div>
+            ) : null}
+
+            <div className="flex flex-col gap-2.5 border-t border-border/14 pt-3 sm:flex-row sm:items-center">
+              <Input
+                value={notes[application.id] ?? application.decision_note ?? ""}
+                onChange={(event) =>
+                  setNotes((current) => ({
+                    ...current,
+                    [application.id]: event.target.value,
+                  }))
+                }
+                disabled={isDecided || isPending}
+                maxLength={600}
+                placeholder="Private decision note…"
+                className="h-8 flex-1 rounded-full border-border/20 bg-black/18 px-3 text-[12px]"
+              />
+              {!isDecided ? (
+                <div className="flex shrink-0 flex-wrap gap-1.5">
+                  {application.status === "submitted" ? (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      disabled={isPending}
+                      onClick={() => void decide(application, "reviewing")}
+                    >
+                      In review
+                    </Button>
+                  ) : null}
+                  <Button
+                    type="button"
+                    variant="outline"
+                    disabled={isPending}
+                    onClick={() => void decide(application, "declined")}
+                  >
+                    Decline
+                  </Button>
+                  <Button
+                    type="button"
+                    disabled={isPending}
+                    onClick={() => void decide(application, "accepted")}
+                  >
+                    {isPending ? <SpinnerGapIcon className="size-3 animate-spin" /> : null}
+                    Accept
+                  </Button>
+                </div>
+              ) : null}
+            </div>
+          </article>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/components/guest-footer.tsx
+++ b/apps/web/components/guest-footer.tsx
@@ -21,6 +21,7 @@ const footerGroups = [
     title: "Community",
     links: [
       { label: "Join Kocteau", href: "/signup" },
+      { label: "Apply to curate", href: "/curators" },
       { label: "GitHub", href: "https://github.com/francozeta/kocteau" },
       { label: "Discord", href: "https://discord.gg/FgrNjkPa8" },
     ],

--- a/apps/web/components/guest-product-preview.tsx
+++ b/apps/web/components/guest-product-preview.tsx
@@ -22,7 +22,6 @@ import {
   Bookmark,
   ChatCircleTextIcon,
   Heart,
-  MagnifyingGlassIcon,
   MessageCircle,
   MoreHorizontal,
 } from "@/components/ui/icons";
@@ -84,7 +83,7 @@ const mockWriters = [
 
 const browseItems = [
   { label: "Feed", icon: KocteauHomeIcon, active: true },
-  { label: "Explore", icon: MagnifyingGlassIcon },
+  { label: "Explore", icon: KocteauSearchIcon },
   { label: "Atlas", icon: KocteauStarterIcon },
   { label: "Feedback", icon: ChatCircleTextIcon },
 ] as const;

--- a/apps/web/components/kocteau-icons.tsx
+++ b/apps/web/components/kocteau-icons.tsx
@@ -63,6 +63,8 @@ ReviewGlyphIcon.displayName = "ReviewGlyphIcon";
 export const KocteauSearchIcon = forwardRef<SVGSVGElement, KocteauIconProps>(
   (iconProps, ref) => {
     const { className, strokeWidth, weight, ...props } = splitIconProps(iconProps);
+    void strokeWidth;
+    void weight;
 
     return (
       <svg
@@ -75,11 +77,8 @@ export const KocteauSearchIcon = forwardRef<SVGSVGElement, KocteauIconProps>(
         {...props}
       >
         <path
-          d="M20.25 20.25L16.1265 16.1265M16.1265 16.1265C17.4385 14.8145 18.25 13.002 18.25 11C18.25 6.99594 15.0041 3.75 11 3.75C6.99594 3.75 3.75 6.99594 3.75 11C3.75 15.0041 6.99594 18.25 11 18.25C13.002 18.25 14.8145 17.4385 16.1265 16.1265Z"
-          stroke="currentColor"
-          strokeWidth={strokeWidthForWeight(weight, strokeWidth)}
-          strokeLinecap="round"
-          strokeLinejoin="round"
+          d="M3 11C3 6.58172 6.58172 3 11 3C15.4183 3 19 6.58172 19 11C19 12.9388 18.3096 14.7174 17.1624 16.1018L20.5303 19.4697C20.8232 19.7626 20.8232 20.2374 20.5303 20.5303C20.2374 20.8232 19.7625 20.8232 19.4696 20.5303L16.1017 17.1624C14.7174 18.3096 12.9388 19 11 19C6.58172 19 3 15.4183 3 11Z"
+          fill="currentColor"
         />
       </svg>
     );
@@ -119,6 +118,8 @@ KocteauHomeIcon.displayName = "KocteauHomeIcon";
 export const KocteauLibraryIcon = forwardRef<SVGSVGElement, KocteauIconProps>(
   (iconProps, ref) => {
     const { className, strokeWidth, weight, ...props } = splitIconProps(iconProps);
+    void strokeWidth;
+    void weight;
 
     return (
       <svg
@@ -131,32 +132,20 @@ export const KocteauLibraryIcon = forwardRef<SVGSVGElement, KocteauIconProps>(
         {...props}
       >
         <path
-          d="M8.75 6.75H15.25"
-          stroke="currentColor"
-          strokeWidth={strokeWidthForWeight(weight, strokeWidth)}
-          strokeLinecap="round"
-          strokeLinejoin="round"
+          fillRule="evenodd"
+          clipRule="evenodd"
+          d="M14.2324 8.35396C13.966 7.4249 14.5031 6.45579 15.4322 6.18939L16.8741 5.77593C17.8032 5.50953 18.7723 6.04672 19.0387 6.97577L22.2085 18.0303C22.4749 18.9593 21.9377 19.9285 21.0087 20.1949L19.5668 20.6083C18.6377 20.8747 17.6686 20.3375 17.4022 19.4085L14.2324 8.35396Z"
+          fill="currentColor"
         />
         <path
-          d="M19.25 16V3.75C19.25 3.19772 18.8023 2.75 18.25 2.75H7.75C6.09315 2.75 4.75 4.09315 4.75 5.75V19.75"
-          stroke="currentColor"
-          strokeWidth={strokeWidthForWeight(weight, strokeWidth)}
-          strokeLinecap="round"
-          strokeLinejoin="round"
+          fillRule="evenodd"
+          clipRule="evenodd"
+          d="M8.75 3C7.7835 3 7 3.7835 7 4.75V19.25C7 20.2165 7.7835 21 8.75 21H12.25C13.2165 21 14 20.2165 14 19.25V4.75C14 3.7835 13.2165 3 12.25 3H8.75ZM8.5 7.75C8.5 7.33579 8.83579 7 9.25 7H11.75C12.1642 7 12.5 7.33579 12.5 7.75C12.5 8.16421 12.1642 8.5 11.75 8.5H9.25C8.83579 8.5 8.5 8.16421 8.5 7.75ZM12.5 16.25C12.5 15.8358 12.1642 15.5 11.75 15.5H9.25C8.83579 15.5 8.5 15.8358 8.5 16.25C8.5 16.6642 8.83579 17 9.25 17H11.75C12.1642 17 12.5 16.6642 12.5 16.25Z"
+          fill="currentColor"
         />
         <path
-          d="M19.25 15.25H6.25C5.42157 15.25 4.75 15.9216 4.75 16.75C4.75 17.5784 5.42157 18.25 6.25 18.25H19.25V15.25Z"
-          stroke="currentColor"
-          strokeWidth={strokeWidthForWeight(weight, strokeWidth)}
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
-        <path
-          d="M19.25 18.25H6.25C5.42157 18.25 4.75 18.9216 4.75 19.75C4.75 20.5784 5.42157 21.25 6.25 21.25H19.25V18.25Z"
-          stroke="currentColor"
-          strokeWidth={strokeWidthForWeight(weight, strokeWidth)}
-          strokeLinecap="round"
-          strokeLinejoin="round"
+          d="M3.75 5C2.7835 5 2 5.7835 2 6.75V19.25C2 20.2165 2.7835 21 3.75 21H4.25C5.2165 21 6 20.2165 6 19.25V6.75C6 5.7835 5.2165 5 4.25 5H3.75Z"
+          fill="currentColor"
         />
       </svg>
     );

--- a/apps/web/components/mobile-bottom-bar.tsx
+++ b/apps/web/components/mobile-bottom-bar.tsx
@@ -2,10 +2,11 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { type Icon, MagnifyingGlassIcon } from "@/components/ui/icons";
+import type { Icon } from "@/components/ui/icons";
 import {
   KocteauHomeIcon,
   KocteauLibraryIcon,
+  KocteauSearchIcon,
 } from "@/components/kocteau-icons";
 import NewReviewDialog from "@/components/new-review-dialog";
 import ReviewCommentDock from "@/components/review-comment-dock";
@@ -136,7 +137,7 @@ export default function MobileBottomBar({ profile }: MobileBottomBarProps) {
     {
       href: "/search",
       label: "Search",
-      icon: MagnifyingGlassIcon,
+      icon: KocteauSearchIcon,
       active: (current) => current.startsWith("/search") || current.startsWith("/track"),
     },
     ...(profile

--- a/apps/web/lib/curation/access.ts
+++ b/apps/web/lib/curation/access.ts
@@ -42,3 +42,43 @@ export async function requireStarterCurator() {
 
   return { ok: true as const, supabase };
 }
+
+export async function requireKocteauAdmin() {
+  const supabase = await supabaseServer();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return {
+      ok: false as const,
+      response: NextResponse.json({ error: "Not authenticated" }, { status: 401 }),
+    };
+  }
+
+  const { data: hasAccess, error } = await supabase.rpc("is_kocteau_admin");
+
+  if (error) {
+    console.error("[curation.requireKocteauAdmin] failed", {
+      code: error.code ?? null,
+      message: error.message ?? null,
+    });
+
+    return {
+      ok: false as const,
+      response: NextResponse.json(
+        { error: "Kocteau admin roles are not configured." },
+        { status: 500 },
+      ),
+    };
+  }
+
+  if (!hasAccess) {
+    return {
+      ok: false as const,
+      response: NextResponse.json({ error: "Not allowed" }, { status: 403 }),
+    };
+  }
+
+  return { ok: true as const, supabase, user };
+}

--- a/apps/web/lib/curators.test.ts
+++ b/apps/web/lib/curators.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { curatorApplicationSchema } from "./validation/schemas";
+
+const validApplication = {
+  taste_focus: "Independent ambient and experimental music from Latin America.",
+  motivation: "I want to connect overlooked regional releases with listeners who value context.",
+  sample_links: ["https://kocteau.example/review"],
+  availability: "weekly",
+};
+
+test("accepts a focused curator application", () => {
+  assert.equal(curatorApplicationSchema.safeParse(validApplication).success, true);
+});
+
+test("rejects non-http work sample links", () => {
+  const result = curatorApplicationSchema.safeParse({
+    ...validApplication,
+    sample_links: ["javascript:alert(1)"],
+  });
+
+  assert.equal(result.success, false);
+});
+
+test("deduplicates work sample links", () => {
+  const result = curatorApplicationSchema.parse({
+    ...validApplication,
+    sample_links: [
+      "https://kocteau.example/review",
+      "https://kocteau.example/review",
+    ],
+  });
+
+  assert.deepEqual(result.sample_links, ["https://kocteau.example/review"]);
+});

--- a/apps/web/lib/curators.ts
+++ b/apps/web/lib/curators.ts
@@ -1,0 +1,60 @@
+import type { Database } from "@/lib/supabase/database.types";
+
+export const curatorAvailabilityValues = [
+  "occasional",
+  "weekly",
+  "frequent",
+] as const;
+
+export const curatorApplicationStatuses = [
+  "submitted",
+  "reviewing",
+  "accepted",
+  "declined",
+] as const;
+
+export const curatorDecisionStatuses = [
+  "reviewing",
+  "accepted",
+  "declined",
+] as const;
+
+export type CuratorAvailability = (typeof curatorAvailabilityValues)[number];
+export type CuratorApplicationStatus = (typeof curatorApplicationStatuses)[number];
+export type CuratorApplication =
+  Database["public"]["Tables"]["curator_applications"]["Row"];
+
+export const curatorAvailabilityOptions = [
+  {
+    value: "occasional",
+    label: "Occasional",
+    note: "A few thoughtful picks each month.",
+  },
+  {
+    value: "weekly",
+    label: "Weekly",
+    note: "A steady weekly contribution.",
+  },
+  {
+    value: "frequent",
+    label: "Frequent",
+    note: "Several listening sessions each week.",
+  },
+] as const satisfies readonly {
+  value: CuratorAvailability;
+  label: string;
+  note: string;
+}[];
+
+export function getCuratorStatusLabel(status: string) {
+  switch (status) {
+    case "reviewing":
+      return "In review";
+    case "accepted":
+      return "Accepted";
+    case "declined":
+      return "Not selected";
+    default:
+      return "Submitted";
+  }
+}

--- a/apps/web/lib/queries/curation.ts
+++ b/apps/web/lib/queries/curation.ts
@@ -17,3 +17,19 @@ export async function getStarterCuratorAccess() {
 
   return Boolean(data);
 }
+
+export async function getKocteauAdminAccess() {
+  const supabase = await supabaseServer();
+  const { data, error } = await supabase.rpc("is_kocteau_admin");
+
+  if (error) {
+    console.error("[curation.getKocteauAdminAccess] failed", {
+      code: error.code ?? null,
+      message: error.message ?? null,
+    });
+
+    return false;
+  }
+
+  return Boolean(data);
+}

--- a/apps/web/lib/rate-limit.ts
+++ b/apps/web/lib/rate-limit.ts
@@ -26,6 +26,11 @@ export const rateLimits = {
     limit: 10,
     windowMs: 10 * 60_000,
   },
+  createCuratorApplication: {
+    name: "curator-application:create",
+    limit: 3,
+    windowMs: 24 * 60 * 60_000,
+  },
   updateReview: {
     name: "review:update",
     limit: 30,

--- a/apps/web/lib/supabase/database.types.ts
+++ b/apps/web/lib/supabase/database.types.ts
@@ -173,6 +173,66 @@ export type Database = {
         }
         Relationships: []
       }
+      curator_applications: {
+        Row: {
+          availability: string
+          decision_note: string | null
+          id: string
+          motivation: string
+          reviewed_at: string | null
+          reviewed_by: string | null
+          sample_links: string[]
+          status: string
+          submitted_at: string
+          taste_focus: string
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          availability: string
+          decision_note?: string | null
+          id?: string
+          motivation: string
+          reviewed_at?: string | null
+          reviewed_by?: string | null
+          sample_links?: string[]
+          status?: string
+          submitted_at?: string
+          taste_focus: string
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          availability?: string
+          decision_note?: string | null
+          id?: string
+          motivation?: string
+          reviewed_at?: string | null
+          reviewed_by?: string | null
+          sample_links?: string[]
+          status?: string
+          submitted_at?: string
+          taste_focus?: string
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "curator_applications_reviewed_by_fkey"
+            columns: ["reviewed_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "curator_applications_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       editorial_candidates: {
         Row: {
           artist_name: string | null
@@ -1431,6 +1491,33 @@ export type Database = {
           review_id: string
         }[]
       }
+      decide_curator_application: {
+        Args: {
+          p_application_id: string
+          p_decision_note?: string
+          p_status: string
+        }
+        Returns: {
+          availability: string
+          decision_note: string | null
+          id: string
+          motivation: string
+          reviewed_at: string | null
+          reviewed_by: string | null
+          sample_links: string[]
+          status: string
+          submitted_at: string
+          taste_focus: string
+          updated_at: string
+          user_id: string
+        }
+        SetofOptions: {
+          from: "*"
+          to: "curator_applications"
+          isOneToOne: true
+          isSetofReturn: false
+        }
+      }
       enqueue_catalog_enrichment_target: {
         Args: { p_target_id: string; p_target_type: string }
         Returns: undefined
@@ -1515,6 +1602,7 @@ export type Database = {
         Args: { p_entity_id: string; p_signal_weight?: number }
         Returns: number
       }
+      is_kocteau_admin: { Args: never; Returns: boolean }
       is_starter_curator: { Args: never; Returns: boolean }
       notification_channel_topic: {
         Args: { recipient_id: string }

--- a/apps/web/lib/validation/schemas.ts
+++ b/apps/web/lib/validation/schemas.ts
@@ -6,6 +6,10 @@ import {
 } from "@/lib/analytics/events";
 import { searchableEntityTypes, searchScopes } from "@/lib/search-types";
 import { editorialCandidateStatuses } from "@/lib/starter/candidate-queue";
+import {
+  curatorAvailabilityValues,
+  curatorDecisionStatuses,
+} from "@/lib/curators";
 import { tasteOnboardingMaxTags, tasteOnboardingMinTags } from "@/lib/taste";
 import { entityLibraryItemTypes } from "@/lib/library/entity-library";
 
@@ -135,7 +139,13 @@ export const editorialCandidateUpsertSchema = z.object({
   artist_name: optionalTrimmedString(160),
   cover_url: z.string().trim().url("Cover URL must be valid.").nullable().optional().transform((value) => value ?? null),
   deezer_url: z.string().trim().url("Deezer URL must be valid.").nullable().optional().transform((value) => value ?? null),
-  source: z.enum(["related-seed", "deep-cut", "manual", "system-signal"]),
+  source: z.enum([
+    "related-seed",
+    "deep-cut",
+    "manual",
+    "system-signal",
+    "external-source",
+  ]),
   source_label: z.string().trim().min(2).max(48),
   seed_label: optionalTrimmedString(120),
   tier: z.enum(["emerging", "undercovered", "familiar", "deep-cut", "obvious"]),
@@ -149,6 +159,40 @@ export const editorialCandidateDecisionSchema = z.object({
   status: z.enum(editorialCandidateStatuses),
   decision_note: optionalTrimmedString(240),
   starter_track_id: z.string().uuid("Invalid starter track id.").nullable().optional().transform((value) => value ?? null),
+});
+
+export const curatorApplicationSchema = z.object({
+  taste_focus: z
+    .string()
+    .trim()
+    .min(20, "Tell us a little more about the music you follow.")
+    .max(600, "Keep your taste focus to 600 characters or fewer."),
+  motivation: z
+    .string()
+    .trim()
+    .min(40, "Tell us a little more about the perspective you would bring.")
+    .max(1200, "Keep your note to 1,200 characters or fewer."),
+  sample_links: z
+    .array(
+      z
+        .string()
+        .trim()
+        .max(500, "Links must be 500 characters or fewer.")
+        .url("Use a complete, valid URL.")
+        .refine(
+          (value) => ["http:", "https:"].includes(new URL(value).protocol),
+          "Use an http or https URL.",
+        ),
+    )
+    .max(3, "Add up to three links.")
+    .transform((links) => Array.from(new Set(links))),
+  availability: z.enum(curatorAvailabilityValues),
+});
+
+export const curatorApplicationDecisionSchema = z.object({
+  id: z.string().uuid("Invalid curator application id."),
+  status: z.enum(curatorDecisionStatuses),
+  decision_note: optionalTrimmedString(600),
 });
 
 export const loginSchema = z.object({

--- a/supabase/migrations/20260811145044_curator_applications.sql
+++ b/supabase/migrations/20260811145044_curator_applications.sql
@@ -1,0 +1,176 @@
+-- Curator applications and an admin-only decision flow.
+-- External editorial sources remain candidate signals and never publish reviews.
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '90s';
+
+CREATE OR REPLACE FUNCTION public.is_kocteau_admin()
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.profile_roles role
+    WHERE role.user_id = auth.uid()
+      AND role.role = 'admin'
+  );
+$$;
+
+REVOKE ALL ON FUNCTION public.is_kocteau_admin() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.is_kocteau_admin() TO authenticated;
+
+CREATE TABLE public.curator_applications (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  taste_focus text NOT NULL,
+  motivation text NOT NULL,
+  sample_links text[] NOT NULL DEFAULT ARRAY[]::text[],
+  availability text NOT NULL,
+  status text NOT NULL DEFAULT 'submitted',
+  decision_note text,
+  submitted_at timestamp with time zone NOT NULL DEFAULT now(),
+  updated_at timestamp with time zone NOT NULL DEFAULT now(),
+  reviewed_at timestamp with time zone,
+  reviewed_by uuid REFERENCES public.profiles(id) ON DELETE SET NULL,
+  CONSTRAINT curator_applications_taste_focus_check
+    CHECK (char_length(btrim(taste_focus)) BETWEEN 20 AND 600),
+  CONSTRAINT curator_applications_motivation_check
+    CHECK (char_length(btrim(motivation)) BETWEEN 40 AND 1200),
+  CONSTRAINT curator_applications_sample_links_check
+    CHECK (
+      cardinality(sample_links) <= 3
+      AND array_position(sample_links, NULL) IS NULL
+    ),
+  CONSTRAINT curator_applications_availability_check
+    CHECK (availability IN ('occasional', 'weekly', 'frequent')),
+  CONSTRAINT curator_applications_status_check
+    CHECK (status IN ('submitted', 'reviewing', 'accepted', 'declined')),
+  CONSTRAINT curator_applications_decision_note_check
+    CHECK (decision_note IS NULL OR char_length(decision_note) <= 600)
+);
+
+CREATE UNIQUE INDEX curator_applications_one_active_per_user_idx
+  ON public.curator_applications (user_id)
+  WHERE status IN ('submitted', 'reviewing', 'accepted');
+
+CREATE INDEX curator_applications_status_submitted_idx
+  ON public.curator_applications (status, submitted_at ASC);
+
+ALTER TABLE public.curator_applications ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can read their own curator applications"
+  ON public.curator_applications
+  FOR SELECT
+  TO authenticated
+  USING (user_id = (SELECT auth.uid()));
+
+CREATE POLICY "Admins can read curator applications"
+  ON public.curator_applications
+  FOR SELECT
+  TO authenticated
+  USING ((SELECT public.is_kocteau_admin()));
+
+CREATE POLICY "Users can submit their own curator applications"
+  ON public.curator_applications
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    user_id = (SELECT auth.uid())
+    AND status = 'submitted'
+    AND reviewed_by IS NULL
+    AND reviewed_at IS NULL
+  );
+
+GRANT SELECT, INSERT ON public.curator_applications TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.decide_curator_application(
+  p_application_id uuid,
+  p_status text,
+  p_decision_note text DEFAULT NULL
+)
+RETURNS public.curator_applications
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_application public.curator_applications%rowtype;
+BEGIN
+  IF NOT public.is_kocteau_admin() THEN
+    RAISE EXCEPTION 'Not allowed to decide curator applications.'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF p_status NOT IN ('reviewing', 'accepted', 'declined') THEN
+    RAISE EXCEPTION 'Curator application status is invalid.'
+      USING ERRCODE = '22023';
+  END IF;
+
+  SELECT *
+  INTO v_application
+  FROM public.curator_applications
+  WHERE id = p_application_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Curator application not found.'
+      USING ERRCODE = '02000';
+  END IF;
+
+  IF v_application.status IN ('accepted', 'declined') THEN
+    RAISE EXCEPTION 'Curator application has already been decided.'
+      USING ERRCODE = '22023';
+  END IF;
+
+  UPDATE public.curator_applications
+  SET
+    status = p_status,
+    decision_note = nullif(btrim(coalesce(p_decision_note, '')), ''),
+    reviewed_by = auth.uid(),
+    reviewed_at = CASE
+      WHEN p_status IN ('accepted', 'declined') THEN now()
+      ELSE NULL
+    END,
+    updated_at = now()
+  WHERE id = p_application_id
+  RETURNING * INTO v_application;
+
+  IF p_status = 'accepted' THEN
+    INSERT INTO public.profile_roles (user_id, role)
+    VALUES (v_application.user_id, 'curator')
+    ON CONFLICT (user_id, role) DO NOTHING;
+  END IF;
+
+  RETURN v_application;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.decide_curator_application(uuid, text, text)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.decide_curator_application(uuid, text, text)
+  TO authenticated;
+
+COMMENT ON TABLE public.curator_applications IS
+  'User-submitted applications for Kocteau editorial curator access.';
+
+ALTER TABLE public.editorial_candidates
+  DROP CONSTRAINT editorial_candidates_source_check;
+
+ALTER TABLE public.editorial_candidates
+  ADD CONSTRAINT editorial_candidates_source_check
+  CHECK (
+    source IN (
+      'related-seed',
+      'deep-cut',
+      'manual',
+      'system-signal',
+      'external-source'
+    )
+  );
+
+COMMIT;

--- a/supabase/migrations/20260811150421_restrict_curator_application_grants.sql
+++ b/supabase/migrations/20260811150421_restrict_curator_application_grants.sql
@@ -1,0 +1,11 @@
+-- Keep curator applications readable and insertable only through the intended flows.
+
+BEGIN;
+
+REVOKE ALL ON TABLE public.curator_applications
+  FROM PUBLIC, anon, authenticated;
+
+GRANT SELECT, INSERT ON TABLE public.curator_applications
+  TO authenticated;
+
+COMMIT;

--- a/supabase/migrations/20260811150635_restrict_admin_access_function.sql
+++ b/supabase/migrations/20260811150635_restrict_admin_access_function.sql
@@ -1,0 +1,11 @@
+-- Admin access checks are internal to authenticated app and RLS flows.
+
+BEGIN;
+
+REVOKE ALL ON FUNCTION public.is_kocteau_admin()
+  FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.is_kocteau_admin()
+  TO authenticated;
+
+COMMIT;

--- a/supabase/migrations/20260811151132_validate_curator_application_links.sql
+++ b/supabase/migrations/20260811151132_validate_curator_application_links.sql
@@ -1,0 +1,13 @@
+-- Work samples are rendered as outbound links in Studio.
+
+BEGIN;
+
+ALTER TABLE public.curator_applications
+  ADD CONSTRAINT curator_applications_sample_link_protocol_check
+  CHECK (
+    (sample_links[1] IS NULL OR sample_links[1] ~* '^https?://')
+    AND (sample_links[2] IS NULL OR sample_links[2] ~* '^https?://')
+    AND (sample_links[3] IS NULL OR sample_links[3] ~* '^https?://')
+  );
+
+COMMIT;


### PR DESCRIPTION
## Summary
- add a public, auth-aware curator application route and status flow
- add an admin-only Studio queue that grants curator roles atomically
- enforce RLS, minimal table/function grants, URL safety, and rate limits
- allow external editorial provenance in the human-reviewed candidate queue

## Product boundary
External sources can create catalog candidates with provenance. They cannot create user reviews or publish editorial content automatically.

## Verification
- `pnpm --filter web exec tsc --noEmit`
- `pnpm --filter web lint`
- `pnpm --filter web build`
- `pnpm --filter web exec tsx --test lib/curators.test.ts`
- `supabase db lint --linked --schema public --fail-on error`
- linked migrations and generated types are in sync
- guest desktop and 390x844 mobile browser check; no horizontal overflow

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a public curator application flow and an admin-only Studio queue to review and grant curator roles, with strict RLS, validation, and rate limits. Also allows external editorial provenance for candidate signals without publishing reviews automatically.

- **New Features**
  - Public `/curators` page: auth-aware application form with status updates; guest CTA added to the footer.
  - API: `POST /api/curator-applications` with zod validation, RLS, and a daily rate limit; admin `PATCH /api/studio/curator-applications` to decide applications; both revalidate `/curators` and `/studio/curators`.
  - Studio: `/studio/curators` queue for admins to review apps, add private notes, and accept/decline via `decide_curator_application` RPC; sidebar link gated by `is_kocteau_admin`.
  - Access and safety: RLS policies, minimal table/function grants, URL protocol checks for links, unique “one active application per user” constraint.
  - Editorial queue: adds `external-source` option for candidate provenance (no auto-publishing).
  - DX: tests for schema validation; Supabase types updated.
  - UI: refreshed `KocteauSearchIcon` and `KocteauLibraryIcon` and updated uses across navigation.

- **Migration**
  - Run Supabase migrations; ensure admin users have `profile_roles.role = 'admin'` to access the Studio queue.

<sup>Written for commit 115b7a5a83a49a5d282704fb5ebb7c014fb1d793. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/francozeta/kocteau/pull/170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a curator application page with guidance, application status, and submission form.
  * Applicants can provide their focus, motivation, sample links, and availability.
  * Declined applications can be resubmitted.
  * Added a curator application management area for authorized staff to review, accept, or decline submissions with notes.
  * Added “Apply to curate” navigation in the community footer.
* **Validation**
  * Added field validation, duplicate-link prevention, secure link requirements, and submission rate limits.
* **Bug Fixes**
  * Expanded editorial candidate sources to support external sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->