### PR TITLE
feat(search): refine immersive discovery routes

### DIFF
--- a/apps/web/components/app-shell.tsx
+++ b/apps/web/components/app-shell.tsx
@@ -65,7 +65,7 @@ export default async function AppShell({
       >
         <Header profile={safeProfile} />
         <DesktopScrollBridge />
-        <div className="kocteau-content-frame mx-auto flex min-h-0 w-full max-w-[82rem] flex-1 flex-col px-3.5 pt-[calc(env(safe-area-inset-top)+4rem)] pb-[calc(env(safe-area-inset-bottom)+6.5rem)] sm:px-6 sm:pt-[calc(env(safe-area-inset-top)+4.75rem)] sm:pb-28 lg:max-w-none lg:overflow-hidden lg:px-7 lg:py-6 xl:px-8">
+        <div className="kocteau-content-frame mx-auto flex min-h-0 w-full max-w-[82rem] flex-1 flex-col px-3.5 pt-[calc(env(safe-area-inset-top)+4rem)] pb-[calc(env(safe-area-inset-bottom)+6.5rem)] has-[[data-kocteau-search-surface]]:!max-w-none has-[[data-kocteau-search-surface]]:!p-0 sm:px-6 sm:pt-[calc(env(safe-area-inset-top)+4.75rem)] sm:pb-28 lg:max-w-none lg:overflow-hidden lg:px-7 lg:py-6 xl:px-8">
           {isStudio ? (
             <div className="mx-auto flex min-h-0 w-full max-w-none flex-1 lg:h-full">
               <main

--- a/apps/web/components/discovery-map.tsx
+++ b/apps/web/components/discovery-map.tsx
@@ -16,12 +16,14 @@ import DiscoveryOrbit, {
 } from "@/components/discovery-orbit";
 import DiscoverySeedActions from "@/components/discovery-seed-actions";
 import EntityCoverImage from "@/components/entity-cover-image";
+import { KocteauSearchIcon } from "@/components/kocteau-icons";
 import { Input } from "@/components/ui/input";
-import { Search, XIcon } from "@/components/ui/icons";
+import { XIcon } from "@/components/ui/icons";
 import {
   useKocteauSearch,
   type KocteauSearchResult,
 } from "@/hooks/use-kocteau-search";
+import { useIsMobile } from "@/hooks/use-mobile";
 import { getDiscoverySeedPath, type DiscoverySeed } from "@/lib/discovery/seed";
 import type {
   TrackRecommendationCandidate,
@@ -65,6 +67,10 @@ function getMobileSearchDockSnapshot() {
 
 function getMobileSearchDockServerSnapshot() {
   return null;
+}
+
+function getSearchPortalTargetSnapshot() {
+  return document.querySelector<HTMLElement>("[data-kocteau-scroll-boundary]");
 }
 
 function mapStarterTrackToSeed(track: StarterTrack): DiscoverySeed {
@@ -324,6 +330,12 @@ function DiscoverySearch({
 }: DiscoverySearchProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [isFocused, setIsFocused] = useState(false);
+  const isMobileViewport = useIsMobile();
+  const portalTarget = useSyncExternalStore(
+    subscribeToMobileSearchDock,
+    getSearchPortalTargetSnapshot,
+    getMobileSearchDockServerSnapshot,
+  );
   const hasQuery = query.trim().length >= 2;
   const resultListId = mobile
     ? "mobile-discovery-seed-results"
@@ -333,73 +345,74 @@ function DiscoverySearch({
     : "discovery-seed-search";
 
   const chooseResult = (result: KocteauSearchResult) => {
-    if (mobile) {
-      inputRef.current?.blur();
-      setIsFocused(false);
-    }
+    inputRef.current?.blur();
+    setIsFocused(false);
 
     onChooseResult(result);
   };
 
-  const resultList = hasQuery && (!mobile || isFocused) ? (
+  const resultList =
+    mobile === isMobileViewport && hasQuery && (!mobile || isFocused) ? (
     <div
-      id={resultListId}
-      className={cn(
-        "absolute inset-x-0 z-40 overflow-hidden bg-[var(--kocteau-surface-raised)] p-1.5",
-        mobile
-          ? "bottom-[calc(100%+0.5rem)] max-h-[min(23rem,calc(100dvh-9rem))] overflow-y-auto rounded-[0.9rem]"
-          : "top-[calc(100%+0.35rem)] rounded-[0.75rem] shadow-[var(--kocteau-shadow-card)]",
-      )}
+      className="fixed inset-0 z-[100000] overflow-y-auto bg-[var(--kocteau-landing-canvas)] px-3 pb-[calc(env(safe-area-inset-bottom)+6.5rem)] pt-[calc(env(safe-area-inset-top)+4.5rem)] sm:px-6 md:pb-8 md:pl-[calc(var(--sidebar-width)+0.625rem)] md:pt-[9.5rem]"
     >
-      {results.length > 0 ? (
-        <div className="grid gap-0.5">
-          {results.map((result) => (
-            <button
-              key={`${result.provider}:${result.type}:${result.provider_id}`}
-              type="button"
-              onPointerDown={(event) => {
-                if (mobile) event.preventDefault();
-              }}
-              onClick={() => chooseResult(result)}
-              className="grid min-w-0 grid-cols-[2.75rem_minmax(0,1fr)_auto] items-center gap-2.5 rounded-[0.6rem] p-1.5 text-left outline-none transition-colors duration-150 hover:bg-foreground/[0.045] focus-visible:ring-2 focus-visible:ring-ring/40"
-            >
-              <EntityCoverImage
-                src={result.cover_url}
-                alt=""
-                sizes="44px"
-                quality={70}
-                variant="thumbnail"
-                className={cn(
-                  "size-11 bg-muted/30",
-                  result.type === "artist"
-                    ? "rounded-full"
-                    : "rounded-[0.5rem]",
-                )}
-                iconClassName="size-3.5"
-              />
-              <span className="min-w-0">
-                <span className="block truncate font-pixel text-[12px] font-medium text-foreground/88">
-                  {result.title}
+      <div
+        id={resultListId}
+        className="mx-auto w-full max-w-2xl"
+      >
+        {results.length > 0 ? (
+          <div className="grid gap-1">
+            {results.map((result) => (
+              <button
+                key={`${result.provider}:${result.type}:${result.provider_id}`}
+                type="button"
+                onPointerDown={(event) => {
+                  if (mobile) event.preventDefault();
+                }}
+                onClick={() => chooseResult(result)}
+                className="grid min-h-16 min-w-0 grid-cols-[3.25rem_minmax(0,1fr)_auto] items-center gap-3 rounded-[0.75rem] px-2 py-1.5 text-left outline-none transition-colors duration-150 hover:bg-foreground/[0.055] focus-visible:ring-2 focus-visible:ring-ring/55"
+              >
+                <EntityCoverImage
+                  src={result.cover_url}
+                  alt=""
+                  sizes="52px"
+                  quality={70}
+                  variant="thumbnail"
+                  className={cn(
+                    "size-[3.25rem] bg-muted/30",
+                    result.type === "artist"
+                      ? "rounded-full"
+                      : "rounded-[0.6rem]",
+                  )}
+                  iconClassName="size-3.5"
+                />
+                <span className="min-w-0">
+                  <span className="block truncate font-pixel text-[12px] font-medium text-foreground/92">
+                    {result.title}
+                  </span>
+                  <span className="mt-1 block truncate text-[11px] text-muted-foreground/62">
+                    {result.type === "artist"
+                      ? "Artist"
+                      : result.artist_name || "Unknown artist"}
+                  </span>
                 </span>
-                <span className="block truncate text-[11px] text-muted-foreground/56">
-                  {result.type === "artist"
-                    ? "Artist"
-                    : result.artist_name || "Unknown artist"}
+                <span className="pr-1 text-[9px] uppercase tracking-[0.12em] text-muted-foreground/48">
+                  {getResultTypeLabel(result)}
                 </span>
-              </span>
-              <span className="pr-1 text-[9px] uppercase tracking-[0.12em] text-muted-foreground/42">
-                {getResultTypeLabel(result)}
-              </span>
-            </button>
-          ))}
-        </div>
-      ) : (
-        <p className="px-3 py-4 text-[11px] text-muted-foreground/58">
-          {isSearching ? "Searching the catalog…" : "No matches. Try another name."}
-        </p>
-      )}
+              </button>
+            ))}
+          </div>
+        ) : (
+          <p className="px-3 py-4 text-[11px] text-muted-foreground/58">
+            {isSearching ? "Searching the catalog…" : "No matches. Try another name."}
+          </p>
+        )}
+      </div>
     </div>
-  ) : null;
+    ) : null;
+  const portaledResultList = resultList && portalTarget
+    ? createPortal(resultList, portalTarget)
+    : null;
 
   if (mobile) {
     return (
@@ -425,7 +438,7 @@ function DiscoverySearch({
           <label htmlFor={inputId} className="sr-only">
             Search a song, album, or artist to start
           </label>
-          <Search className="pointer-events-none absolute left-3.5 top-1/2 z-10 size-[1.08rem] -translate-y-1/2 text-muted-foreground/62" />
+          <KocteauSearchIcon className="pointer-events-none absolute left-3.5 top-1/2 z-10 size-[1.08rem] -translate-y-1/2 text-muted-foreground/62" />
           <Input
             ref={inputRef}
             id={inputId}
@@ -448,20 +461,9 @@ function DiscoverySearch({
             maxLength={80}
             aria-expanded={Boolean(isFocused && hasQuery)}
             aria-controls={resultListId}
-            className="h-11 rounded-full border-transparent bg-white/[0.08] pl-10 pr-11 text-base shadow-none placeholder:text-muted-foreground/58 focus-visible:border-transparent focus-visible:ring-2 focus-visible:ring-ring/70"
+            className="h-11 rounded-full border-transparent bg-white/[0.08] pl-10 pr-4 text-base shadow-none placeholder:text-muted-foreground/58 focus-visible:border-transparent focus-visible:ring-2 focus-visible:ring-ring/70"
           />
-          {query ? (
-            <button
-              type="button"
-              aria-label="Clear search"
-              onPointerDown={(event) => event.preventDefault()}
-              onClick={() => onQueryChange("")}
-              className="absolute right-2 top-1/2 flex size-7 -translate-y-1/2 items-center justify-center rounded-full bg-white/[0.14] text-muted-foreground/72 transition-[transform,color,background-color] duration-150 hover:bg-white/[0.2] hover:text-foreground active:scale-[0.96] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/70"
-            >
-              <XIcon className="size-3.5" />
-            </button>
-          ) : null}
-          {resultList}
+          {portaledResultList}
         </form>
 
         <div className="overflow-hidden">
@@ -472,6 +474,7 @@ function DiscoverySearch({
             tabIndex={isFocused ? 0 : -1}
             onPointerDown={(event) => event.preventDefault()}
             onClick={() => {
+              onQueryChange("");
               inputRef.current?.blur();
               setIsFocused(false);
             }}
@@ -492,25 +495,38 @@ function DiscoverySearch({
       className="relative min-w-0 flex-1"
       onSubmit={(event) => {
         event.preventDefault();
-        onSubmit();
+        if (onSubmit()) {
+          inputRef.current?.blur();
+          setIsFocused(false);
+        }
       }}
       role="search"
     >
       <label htmlFor={inputId} className="sr-only">
         Search a song, album, or artist to start
       </label>
-      <Search className="pointer-events-none absolute left-3.5 top-[1.35rem] z-10 size-4 -translate-y-1/2 text-muted-foreground/62" />
+      <KocteauSearchIcon className="pointer-events-none absolute left-3.5 top-[1.35rem] z-10 size-4 -translate-y-1/2 text-muted-foreground/62" />
       <Input
+        ref={inputRef}
         id={inputId}
         data-global-search-input="true"
         value={query}
         onChange={(event) => onQueryChange(event.target.value)}
+        onFocus={() => setIsFocused(true)}
+        onKeyDown={(event: KeyboardEvent<HTMLInputElement>) => {
+          if (event.key !== "Escape") return;
+
+          event.preventDefault();
+          onQueryChange("");
+          inputRef.current?.blur();
+          setIsFocused(false);
+        }}
         placeholder="Search a song, album, or artist…"
         autoComplete="off"
         maxLength={80}
         aria-expanded={results.length > 0}
         aria-controls={resultListId}
-        className="h-11 rounded-[var(--kocteau-radius-control)] border-transparent bg-[var(--kocteau-surface-control)] pl-10 pr-12 text-base shadow-[var(--kocteau-shadow-control)] placeholder:text-muted-foreground/58 sm:text-[13px]"
+        className="h-11 rounded-full border-transparent bg-white/[0.08] pl-10 pr-12 text-base shadow-none placeholder:text-muted-foreground/58 focus-visible:border-transparent focus-visible:ring-2 focus-visible:ring-ring/70 sm:text-[13px]"
       />
       {isExpanding ? (
         <span
@@ -518,7 +534,25 @@ function DiscoverySearch({
           aria-hidden="true"
         />
       ) : null}
-      {resultList}
+      <button
+        type="button"
+        aria-label="Close search"
+        aria-hidden={!isFocused}
+        tabIndex={isFocused ? 0 : -1}
+        onPointerDown={(event) => event.preventDefault()}
+        onClick={() => {
+          onQueryChange("");
+          inputRef.current?.blur();
+          setIsFocused(false);
+        }}
+        className={cn(
+          "absolute left-[calc(100%+0.75rem)] top-0 flex size-11 items-center justify-center rounded-full bg-white/[0.08] text-foreground transition-[opacity,scale,background-color] duration-150 hover:bg-white/[0.12] active:scale-[0.96] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/70",
+          isFocused ? "opacity-100 scale-100" : "pointer-events-none opacity-0 scale-95",
+        )}
+      >
+        <XIcon className="size-5" />
+      </button>
+      {portaledResultList}
     </form>
   );
 }
@@ -700,9 +734,10 @@ export default function DiscoveryMap({
 
   return (
     <section
-      className="relative h-[calc(100svh-10.5rem)] min-h-0 overflow-hidden bg-transparent lg:h-full"
+      className="relative h-svh min-h-0 overflow-hidden bg-transparent lg:h-full"
       aria-labelledby="discovery-map-title"
       data-kocteau-full-width
+      data-kocteau-search-surface
     >
       <h2 id="discovery-map-title" className="sr-only">
         Music discovery map
@@ -715,7 +750,7 @@ export default function DiscoveryMap({
 
       <div
         className={cn(
-          "absolute inset-x-0 z-40 mx-auto hidden w-full max-w-2xl items-start px-4 transition-[top,transform] duration-250 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none md:flex md:px-6 lg:px-0",
+          "absolute inset-x-0 z-[100001] mx-auto hidden w-full max-w-2xl items-start px-4 transition-[top,transform] duration-250 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none md:flex md:px-6 lg:px-0",
           hasExplorationIntent
             ? "top-4 sm:top-5 lg:top-6"
             : "top-1/2 -translate-y-1/2",

--- a/apps/web/components/discovery-seed-actions.tsx
+++ b/apps/web/components/discovery-seed-actions.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import EntityCoverImage from "@/components/entity-cover-image";
 import PrefetchLink from "@/components/prefetch-link";
 import ReviewGlyphIcon from "@/components/review-glyph-icon";
 import { Button } from "@/components/ui/button";
-import { ExternalLink, Music2 } from "@/components/ui/icons";
+import { ExternalLink } from "@/components/ui/icons";
 import { openTrackReviewComposer } from "@/hooks/use-global-shortcuts";
 import type { DiscoverySeed } from "@/lib/discovery/seed";
 import { buildEntityCanonicalPath } from "@/lib/seo-routes";
@@ -34,11 +35,21 @@ function getSupportingLabel(seed: DiscoverySeed) {
   return seed.artist_name || (seed.type === "album" ? "Album" : "Unknown artist");
 }
 
+function getProviderHref(seed: DiscoverySeed) {
+  return `https://www.deezer.com/${seed.type}/${seed.provider_id}`;
+}
+
+function getOpenLabel(seed: DiscoverySeed) {
+  if (seed.type === "artist") return "Open artist";
+  if (seed.type === "album") return "Open album";
+  return "Open track";
+}
+
 export default function DiscoverySeedActions({ seed }: DiscoverySeedActionsProps) {
   const shouldReduceMotion = useReducedMotion();
 
   return (
-    <div className="pointer-events-none absolute inset-x-3 bottom-3 z-40 flex justify-center sm:bottom-5 lg:justify-end lg:px-6">
+    <div className="pointer-events-none absolute inset-x-3 bottom-[calc(env(safe-area-inset-bottom)+5.75rem)] z-40 flex justify-center md:bottom-5 lg:justify-end lg:px-6">
       <AnimatePresence initial={false} mode="popLayout">
         {seed ? (
           <motion.div
@@ -58,15 +69,23 @@ export default function DiscoverySeedActions({ seed }: DiscoverySeedActionsProps
               duration: shouldReduceMotion ? 0 : 0.25,
               ease: smoothOut,
             }}
-            className="mobile-liquid-bar pointer-events-auto flex w-full max-w-[24rem] items-center gap-1 rounded-full p-1 sm:w-auto sm:min-w-[18rem]"
+            className="mobile-liquid-bar pointer-events-auto flex w-full max-w-[28rem] items-center gap-1 rounded-full p-1 sm:w-auto sm:min-w-[23rem]"
             aria-live="polite"
           >
             <PrefetchLink
               href={getEntityHref(seed)}
               aria-label={`Open ${seed.title}`}
-              className="group flex h-10 min-w-0 flex-1 items-center gap-2 rounded-full border border-foreground/10 bg-foreground/10 px-3 text-left text-foreground outline-none transition-[transform,background-color,border-color] duration-150 ease-out hover:border-foreground/14 hover:bg-foreground/[0.14] focus-visible:ring-2 focus-visible:ring-ring/40 active:scale-[0.98]"
+              className="group flex h-11 min-w-0 flex-1 items-center gap-2 rounded-full px-1.5 text-left text-foreground outline-none transition-[opacity,transform] duration-150 ease-out hover:opacity-90 focus-visible:ring-2 focus-visible:ring-ring/55 active:scale-[0.98]"
             >
-              <Music2 className="size-4 shrink-0" />
+              <EntityCoverImage
+                src={seed.cover_url}
+                alt=""
+                sizes="40px"
+                quality={72}
+                variant="thumbnail"
+                className={seed.type === "artist" ? "size-10 rounded-full" : "size-10 rounded-[0.55rem]"}
+                iconClassName="size-3.5"
+              />
               <span className="min-w-0 flex-1">
                 <span className="block truncate font-pixel text-[10px] leading-tight text-foreground/92">
                   {seed.title}
@@ -75,13 +94,11 @@ export default function DiscoverySeedActions({ seed }: DiscoverySeedActionsProps
                   {getSupportingLabel(seed)}
                 </span>
               </span>
-              <ExternalLink className="size-3.5 shrink-0 text-muted-foreground/62 transition-colors duration-150 group-hover:text-foreground/86" />
             </PrefetchLink>
 
             {seed.type === "track" ? (
               <Button
                 type="button"
-                size="icon-lg"
                 aria-label={`Review ${seed.title}`}
                 onClick={() =>
                   openTrackReviewComposer({
@@ -95,12 +112,24 @@ export default function DiscoverySeedActions({ seed }: DiscoverySeedActionsProps
                     entity_id: seed.entityId,
                   })
                 }
-                className="size-10 shrink-0 rounded-full border-foreground shadow-[0_10px_28px_rgba(0,0,0,0.32)] active:scale-[0.96]"
+                variant="ghost"
+                className="h-10 shrink-0 gap-1.5 rounded-full bg-foreground/10 px-3 text-[11px] text-foreground hover:bg-foreground/[0.16] active:scale-[0.96]"
               >
-                <ReviewGlyphIcon className="size-[1.05rem]" />
-                <span className="sr-only">Review</span>
+                <ReviewGlyphIcon className="size-4" weight="fill" />
+                <span>Review</span>
               </Button>
             ) : null}
+
+            <a
+              href={getProviderHref(seed)}
+              target="_blank"
+              rel="noreferrer"
+              aria-label={`${getOpenLabel(seed)} on Deezer`}
+              className="flex size-10 shrink-0 items-center justify-center rounded-full text-muted-foreground/72 outline-none transition-[transform,color,background-color] duration-150 hover:bg-foreground/10 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/55 active:scale-[0.96] sm:w-auto sm:gap-1.5 sm:px-3"
+            >
+              <ExternalLink className="size-4" />
+              <span className="hidden text-[11px] sm:inline">{getOpenLabel(seed)}</span>
+            </a>
           </motion.div>
         ) : null}
       </AnimatePresence>

--- a/apps/web/components/feed-starter-shelf.tsx
+++ b/apps/web/components/feed-starter-shelf.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import { useEffect, useMemo, useRef } from "react";
-import NewReviewDialog from "@/components/new-review-dialog";
-import ReviewGlyphIcon from "@/components/review-glyph-icon";
+import EntityCoverImage from "@/components/entity-cover-image";
+import PrefetchLink from "@/components/prefetch-link";
+import SectionLinkHeading from "@/components/section-link-heading";
 import TrackCarousel from "@/components/track-carousel";
-import TrackTile from "@/components/track-tile";
-import { Sparkles } from "@/components/ui/icons";
 import { trackAnalyticsEvent } from "@/lib/analytics/client";
+import { getDiscoverySeedPath } from "@/lib/discovery/seed";
 import type { StarterTrack } from "@/lib/starter";
 import { cn } from "@/lib/utils";
 
@@ -17,101 +17,59 @@ type FeedStarterShelfProps = {
   className?: string;
 };
 
-function StarterShelfTrigger({
+function getStarterTrackHref(track: StarterTrack) {
+  return getDiscoverySeedPath({
+    provider_id: track.provider_id,
+    title: track.title,
+    type: "track",
+  });
+}
+
+function StarterRouteCard({
   track,
-  isAuthenticated,
-  position,
+  priority,
 }: {
   track: StarterTrack;
-  isAuthenticated: boolean;
-  position: number;
+  priority: boolean;
 }) {
   return (
-    <NewReviewDialog
-      isAuthenticated={isAuthenticated}
-      initialSelection={{
-        provider: "deezer",
-        provider_id: track.provider_id,
-        type: "track",
-        title: track.title,
-        artist_name: track.artist_name,
-        cover_url: track.cover_url,
-        deezer_url: track.deezer_url,
-        entity_id: null,
-      }}
-      onSuccess={() => {
-        if (!isAuthenticated) {
-          return;
-        }
-
-        trackAnalyticsEvent({
-          eventType: "starter_review_published",
-          source: "feed:starter-mobile",
-          metadata: {
-            action: "starter_review_published",
-            starter_track_id: track.id,
-            provider_id: track.provider_id,
-            matched_tag_count: track.matched_tag_count,
-            position,
-          },
-        });
-      }}
-      trigger={
-        <button
-          type="button"
-          className="block w-full rounded-[0.78rem] text-left outline-none transition-[opacity,transform] hover:opacity-[0.88] focus-visible:ring-2 focus-visible:ring-ring/70 focus-visible:ring-offset-2 focus-visible:ring-offset-background active:scale-[0.98]"
-          aria-label={`Review ${track.title}`}
-          onClick={() => {
-            if (!isAuthenticated) {
-              return;
-            }
-
-            trackAnalyticsEvent({
-              eventType: "starter_review_cta",
-              source: "feed:starter-mobile",
-              metadata: {
-                action: "starter_review_cta",
-                starter_track_id: track.id,
-                provider_id: track.provider_id,
-                matched_tag_count: track.matched_tag_count,
-                position,
-              },
-            });
-          }}
-        >
-          <TrackTile
-            title={track.title}
-            artistName={track.artist_name}
-            coverUrl={track.cover_url}
-            sizes="132px"
-            badge={<ReviewGlyphIcon className="size-3.5" />}
-            coverClassName="rounded-[0.68rem]"
-            titleClassName="text-[12px] leading-4"
-            artistClassName="text-[11px] leading-4"
-          />
-        </button>
-      }
-    />
+    <PrefetchLink
+      href={getStarterTrackHref(track)}
+      className="group block overflow-hidden rounded-[0.9rem] bg-[var(--kocteau-surface-control)] outline-none transition-[opacity,transform] duration-150 hover:opacity-90 focus-visible:ring-2 focus-visible:ring-ring/60 active:scale-[0.985]"
+      aria-label={`Start a discovery route from ${track.title} by ${track.artist_name ?? "Unknown artist"}`}
+    >
+      <div className="relative aspect-[4/5] overflow-hidden">
+        <EntityCoverImage
+          src={track.cover_url}
+          alt=""
+          sizes="(max-width: 640px) 82vw, 19rem"
+          quality={84}
+          variant="card"
+          priority={priority}
+          className="absolute inset-0 h-full w-full"
+          imageClassName="transition-transform duration-300 ease-out group-hover:scale-[1.015] motion-reduce:transition-none"
+          iconClassName="size-8"
+        />
+        <div className="absolute inset-x-2 bottom-2 rounded-[0.68rem] bg-black/72 px-3 py-2.5 backdrop-blur-md">
+          <p className="truncate font-pixel text-[12px] leading-tight text-white/94">
+            {track.title}
+          </p>
+          <p className="mt-1 truncate text-[11px] leading-tight text-white/66">
+            {track.artist_name ?? "Unknown artist"}
+          </p>
+        </div>
+      </div>
+    </PrefetchLink>
   );
 }
 
 export default function FeedStarterShelf({
   tracks,
   isAuthenticated,
-  variant = "personalized",
   className,
 }: FeedStarterShelfProps) {
   const trackedImpressionIdsRef = useRef(new Set<string>());
   const visibleTracks = useMemo(() => tracks.slice(0, 6), [tracks]);
-  const shelfCopy = variant === "editorial"
-    ? {
-        label: "Starter picks",
-        description: "Start with something worth reviewing.",
-      }
-    : {
-        label: "Starter picks",
-        description: "Find your next review.",
-      };
 
   useEffect(() => {
     if (!isAuthenticated || visibleTracks.length === 0) {
@@ -143,39 +101,27 @@ export default function FeedStarterShelf({
 
   return (
     <section
-      className={cn(
-        "space-y-3 border-y border-border/14 py-3.5",
-        className,
-      )}
-      aria-label="Starter picks"
+      className={cn("space-y-2.5 py-2", className)}
+      aria-labelledby="feed-starter-route-title"
     >
-      <div className="flex items-start gap-3 px-0.5">
-        <div className="min-w-0">
-          <div className="flex items-center gap-2 text-[12px] font-medium leading-none text-muted-foreground/74">
-            <Sparkles className="size-3.5" />
-            {shelfCopy.label}
-          </div>
-          <p className="mt-1 text-[13px] leading-5 text-muted-foreground/82">
-            {shelfCopy.description}
-          </p>
-        </div>
-      </div>
+      <SectionLinkHeading id="feed-starter-route-title" href="/search">
+        Start a route
+      </SectionLinkHeading>
 
       <TrackCarousel
-        ariaLabel="Starter picks"
+        ariaLabel="Discovery starting points"
         compactControls
         contentClassName="gap-3"
-        controlClassName="[--kocteau-carousel-cover-size:7.35rem]"
+        controlClassName="[--kocteau-carousel-cover-size:min(82vw,19rem)]"
         fadeClassName="kocteau-carousel-mask-r-from-tight"
-        itemClassName="basis-[7.35rem] sm:basis-[7.85rem]"
-        viewportClassName="-mr-3 pr-3"
+        itemClassName="basis-[min(82vw,19rem)]"
+        viewportClassName="-mr-3.5 pr-7"
       >
-        {visibleTracks.map((track, position) => (
-          <StarterShelfTrigger
+        {visibleTracks.map((track, index) => (
+          <StarterRouteCard
             key={track.id}
             track={track}
-            isAuthenticated={isAuthenticated}
-            position={position}
+            priority={index < 2}
           />
         ))}
       </TrackCarousel>

--- a/apps/web/components/kocteau-icons.tsx
+++ b/apps/web/components/kocteau-icons.tsx
@@ -63,8 +63,7 @@ ReviewGlyphIcon.displayName = "ReviewGlyphIcon";
 export const KocteauSearchIcon = forwardRef<SVGSVGElement, KocteauIconProps>(
   (iconProps, ref) => {
     const { className, strokeWidth, weight, ...props } = splitIconProps(iconProps);
-    void strokeWidth;
-    void weight;
+    const isFilled = weight === "fill";
 
     return (
       <svg
@@ -77,8 +76,16 @@ export const KocteauSearchIcon = forwardRef<SVGSVGElement, KocteauIconProps>(
         {...props}
       >
         <path
-          d="M3 11C3 6.58172 6.58172 3 11 3C15.4183 3 19 6.58172 19 11C19 12.9388 18.3096 14.7174 17.1624 16.1018L20.5303 19.4697C20.8232 19.7626 20.8232 20.2374 20.5303 20.5303C20.2374 20.8232 19.7625 20.8232 19.4696 20.5303L16.1017 17.1624C14.7174 18.3096 12.9388 19 11 19C6.58172 19 3 15.4183 3 11Z"
-          fill="currentColor"
+          d={
+            isFilled
+              ? "M3 11C3 6.58172 6.58172 3 11 3C15.4183 3 19 6.58172 19 11C19 12.9388 18.3096 14.7174 17.1624 16.1018L20.5303 19.4697C20.8232 19.7626 20.8232 20.2374 20.5303 20.5303C20.2374 20.8232 19.7625 20.8232 19.4696 20.5303L16.1017 17.1624C14.7174 18.3096 12.9388 19 11 19C6.58172 19 3 15.4183 3 11Z"
+              : "M20 20L16.1265 16.1265M16.1265 16.1265C17.4385 14.8145 18.25 13.002 18.25 11C18.25 6.99594 15.0041 3.75 11 3.75C6.99594 3.75 3.75 6.99594 3.75 11C3.75 15.0041 6.99594 18.25 11 18.25C13.002 18.25 14.8145 17.4385 16.1265 16.1265Z"
+          }
+          fill={isFilled ? "currentColor" : "none"}
+          stroke={isFilled ? "none" : "currentColor"}
+          strokeWidth={isFilled ? undefined : strokeWidthForWeight(weight, strokeWidth)}
+          strokeLinecap="round"
+          strokeLinejoin="round"
         />
       </svg>
     );
@@ -118,8 +125,7 @@ KocteauHomeIcon.displayName = "KocteauHomeIcon";
 export const KocteauLibraryIcon = forwardRef<SVGSVGElement, KocteauIconProps>(
   (iconProps, ref) => {
     const { className, strokeWidth, weight, ...props } = splitIconProps(iconProps);
-    void strokeWidth;
-    void weight;
+    const isFilled = weight === "fill";
 
     return (
       <svg
@@ -131,22 +137,39 @@ export const KocteauLibraryIcon = forwardRef<SVGSVGElement, KocteauIconProps>(
         fill="none"
         {...props}
       >
-        <path
-          fillRule="evenodd"
-          clipRule="evenodd"
-          d="M14.2324 8.35396C13.966 7.4249 14.5031 6.45579 15.4322 6.18939L16.8741 5.77593C17.8032 5.50953 18.7723 6.04672 19.0387 6.97577L22.2085 18.0303C22.4749 18.9593 21.9377 19.9285 21.0087 20.1949L19.5668 20.6083C18.6377 20.8747 17.6686 20.3375 17.4022 19.4085L14.2324 8.35396Z"
-          fill="currentColor"
-        />
-        <path
-          fillRule="evenodd"
-          clipRule="evenodd"
-          d="M8.75 3C7.7835 3 7 3.7835 7 4.75V19.25C7 20.2165 7.7835 21 8.75 21H12.25C13.2165 21 14 20.2165 14 19.25V4.75C14 3.7835 13.2165 3 12.25 3H8.75ZM8.5 7.75C8.5 7.33579 8.83579 7 9.25 7H11.75C12.1642 7 12.5 7.33579 12.5 7.75C12.5 8.16421 12.1642 8.5 11.75 8.5H9.25C8.83579 8.5 8.5 8.16421 8.5 7.75ZM12.5 16.25C12.5 15.8358 12.1642 15.5 11.75 15.5H9.25C8.83579 15.5 8.5 15.8358 8.5 16.25C8.5 16.6642 8.83579 17 9.25 17H11.75C12.1642 17 12.5 16.6642 12.5 16.25Z"
-          fill="currentColor"
-        />
-        <path
-          d="M3.75 5C2.7835 5 2 5.7835 2 6.75V19.25C2 20.2165 2.7835 21 3.75 21H4.25C5.2165 21 6 20.2165 6 19.25V6.75C6 5.7835 5.2165 5 4.25 5H3.75Z"
-          fill="currentColor"
-        />
+        {isFilled ? (
+          <>
+            <path
+              fillRule="evenodd"
+              clipRule="evenodd"
+              d="M14.2324 8.35396C13.966 7.4249 14.5031 6.45579 15.4322 6.18939L16.8741 5.77593C17.8032 5.50953 18.7723 6.04672 19.0387 6.97577L22.2085 18.0303C22.4749 18.9593 21.9377 19.9285 21.0087 20.1949L19.5668 20.6083C18.6377 20.8747 17.6686 20.3375 17.4022 19.4085L14.2324 8.35396Z"
+              fill="currentColor"
+            />
+            <path
+              fillRule="evenodd"
+              clipRule="evenodd"
+              d="M8.75 3C7.7835 3 7 3.7835 7 4.75V19.25C7 20.2165 7.7835 21 8.75 21H12.25C13.2165 21 14 20.2165 14 19.25V4.75C14 3.7835 13.2165 3 12.25 3H8.75ZM8.5 7.75C8.5 7.33579 8.83579 7 9.25 7H11.75C12.1642 7 12.5 7.33579 12.5 7.75C12.5 8.16421 12.1642 8.5 11.75 8.5H9.25C8.83579 8.5 8.5 8.16421 8.5 7.75ZM12.5 16.25C12.5 15.8358 12.1642 15.5 11.75 15.5H9.25C8.83579 15.5 8.5 15.8358 8.5 16.25C8.5 16.6642 8.83579 17 9.25 17H11.75C12.1642 17 12.5 16.6642 12.5 16.25Z"
+              fill="currentColor"
+            />
+            <path
+              d="M3.75 5C2.7835 5 2 5.7835 2 6.75V19.25C2 20.2165 2.7835 21 3.75 21H4.25C5.2165 21 6 20.2165 6 19.25V6.75C6 5.7835 5.2165 5 4.25 5H3.75Z"
+              fill="currentColor"
+            />
+          </>
+        ) : (
+          <g
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={strokeWidthForWeight(weight, strokeWidth)}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M8.75 6.75H15.25" />
+            <path d="M19.25 16V3.75C19.25 3.19772 18.8023 2.75 18.25 2.75H7.75C6.09315 2.75 4.75 4.09315 4.75 5.75V19.75" />
+            <path d="M19.25 15.25H6.25C5.42157 15.25 4.75 15.9216 4.75 16.75C4.75 17.5784 5.42157 18.25 6.25 18.25H19.25V15.25Z" />
+            <path d="M19.25 18.25H6.25C5.42157 18.25 4.75 18.9216 4.75 19.75C4.75 20.5784 5.42157 21.25 6.25 21.25H19.25V18.25Z" />
+          </g>
+        )}
       </svg>
     );
   },

--- a/apps/web/components/mobile-bottom-bar.tsx
+++ b/apps/web/components/mobile-bottom-bar.tsx
@@ -73,7 +73,7 @@ function NavTab({
       <span className="relative z-[1] flex items-center gap-1.5">
         <Icon
           className={cn("size-[1.04rem] shrink-0", active && "text-foreground")}
-          weight="fill"
+          weight={active ? "fill" : "regular"}
         />
         {active ? (
           <span aria-hidden="true" className="whitespace-nowrap text-[12px] font-medium leading-none">

--- a/apps/web/components/nav-main.tsx
+++ b/apps/web/components/nav-main.tsx
@@ -47,12 +47,12 @@ export function NavMain({
               >
                 {item.external ? (
                   <a href={item.url} target="_blank" rel="noreferrer" onClick={onNavigate}>
-                    <item.icon weight="fill" />
+                    <item.icon weight={item.isActive ? "fill" : "regular"} />
                     <span className="kocteau-sidebar-label">{item.title}</span>
                   </a>
                 ) : (
                   <Link href={item.url} onClick={onNavigate}>
-                    <item.icon weight="fill" />
+                    <item.icon weight={item.isActive ? "fill" : "regular"} />
                     <span className="kocteau-sidebar-label">{item.title}</span>
                   </Link>
                 )}

--- a/apps/web/components/nav-secondary.tsx
+++ b/apps/web/components/nav-secondary.tsx
@@ -44,7 +44,7 @@ export function NavSecondary({
                 className={sidebarNavButtonClassName}
               >
                 <Link href={item.url} onClick={onNavigate}>
-                  <item.icon weight="fill" />
+                  <item.icon weight={item.isActive ? "fill" : "regular"} />
                   <span className="kocteau-sidebar-label">{item.title}</span>
                 </Link>
               </SidebarMenuButton>


### PR DESCRIPTION
## Summary
- make Search edge-to-edge and let the 3D canvas use the full app surface
- present catalog results in a full-screen layer with one external clear control
- add a selected-entity dock with cover, review action, and provider link
- switch route icons between outline and solid states
- turn mobile starter picks into large portrait discovery routes

## Verification
- pnpm --filter web exec tsc --noEmit
- pnpm --filter web lint
- pnpm --filter web build
- git diff --check
- Playwright: 390x844 and 1440x900 Search flows

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Search immersive and edge-to-edge with a full-screen results overlay, and let the 3D discovery map use the full app surface. Adds a selected-entity dock with cover, quick review, and a Deezer link; starter picks on mobile are now large portrait routes.

- New Features
  - Full-screen search results overlay (portaled to the scroll boundary), with safe-area padding and close/escape behavior on desktop and mobile.
  - Search field uses `KocteauSearchIcon`; results show cover, title, artist, and type label; choosing a result dismisses the overlay.
  - Selected-entity dock shows cover + metadata, a Review button for tracks, and an external Deezer link with context-aware label.
  - Mobile “Starter picks” are now large portrait discovery route cards; updated carousel sizing and a “Start a route” section header.

- Refactors
  - Icons support outline/solid via the `weight` prop; nav and bottom bar now switch between `regular` and `fill` based on active state.
  - Edge-to-edge content for search surfaces via `data-kocteau-search-surface`; discovery map height set to `h-svh` with raised z-index for overlay.
  - Simplified starter shelf: replaced modal review triggers with `PrefetchLink` cards using `EntityCoverImage`.

<sup>Written for commit 6d492ed8486f224524088e43ac20205ce72e9fe3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/francozeta/kocteau/pull/171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

