### PR TITLE
fix(ui): refine search and feed layout

### DIFF
--- a/apps/web/components/app-shell.tsx
+++ b/apps/web/components/app-shell.tsx
@@ -4,12 +4,10 @@ import ReactQueryProvider from "@/app/providers/react-query-provider";
 import AppSidebar from "@/components/app-sidebar";
 import DeferredToaster from "@/components/deferred-toaster";
 import DesktopScrollBridge from "@/components/desktop-scroll-bridge";
-import EditorialDiscoveryRail from "@/components/editorial-discovery-rail";
 import GlobalShortcuts from "@/components/global-shortcuts";
 import Header from "@/components/header";
 import MobileBottomBar from "@/components/mobile-bottom-bar";
 import { RouteHeaderProvider } from "@/components/route-header-context";
-import { SecondaryRailProvider } from "@/components/secondary-rail-context";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 import {
   getCurrentOnboardingState,
@@ -78,22 +76,18 @@ export default async function AppShell({
           ) : (
             <div
               className={cn(
-                "kocteau-main-grid mx-auto grid min-h-0 w-full max-w-[76rem] flex-1 gap-5 lg:h-full lg:items-stretch lg:justify-center lg:has-[[data-kocteau-full-width]]:!max-w-none lg:has-[[data-kocteau-full-width]]:!grid-cols-[minmax(0,1fr)] lg:has-[[data-kocteau-full-width]]:[&>aside]:!hidden xl:gap-6",
+                "kocteau-main-grid mx-auto grid min-h-0 w-full flex-1 gap-5 lg:h-full lg:items-stretch lg:justify-center lg:grid-cols-[minmax(0,1fr)] lg:has-[[data-kocteau-full-width]]:!max-w-none xl:gap-6",
                 safeProfile
-                  ? "lg:grid-cols-[minmax(0,44rem)_16rem]"
+                  ? "lg:max-w-[64rem]"
                   : "lg:max-w-none lg:grid-cols-[minmax(0,1fr)]",
               )}
             >
               <main
                 data-kocteau-scroll-main
-                className={cn(
-                  "no-scrollbar min-w-0 lg:min-h-0 lg:overflow-x-hidden lg:overflow-y-auto",
-                  safeProfile && "lg:pr-1",
-                )}
+                className="no-scrollbar min-w-0 lg:min-h-0 lg:overflow-x-hidden lg:overflow-y-auto"
               >
                 {children}
               </main>
-              {safeProfile ? <EditorialDiscoveryRail /> : null}
             </div>
           )}
         </div>
@@ -129,9 +123,7 @@ export default async function AppShell({
               : "bg-[var(--kocteau-shell)] lg:bg-[var(--kocteau-canvas)]",
           )}
         >
-          <RouteHeaderProvider>
-            {isStudio ? content : <SecondaryRailProvider>{content}</SecondaryRailProvider>}
-          </RouteHeaderProvider>
+          <RouteHeaderProvider>{content}</RouteHeaderProvider>
         </SidebarInset>
       </SidebarProvider>
     </ReactQueryProvider>

--- a/apps/web/components/authenticated-feed-surface.tsx
+++ b/apps/web/components/authenticated-feed-surface.tsx
@@ -59,7 +59,7 @@ export default function AuthenticatedFeedSurface({
   );
 
   return (
-    <section className="w-full max-w-5xl space-y-5 sm:space-y-6 lg:max-w-none lg:space-y-4">
+    <section className="w-full max-w-5xl space-y-5 sm:space-y-6 lg:max-w-none lg:space-y-5">
       <div className="lg:hidden">
         <FeedViewTabs
           activeView={activeView}
@@ -67,7 +67,7 @@ export default function AuthenticatedFeedSurface({
           onViewChange={handleViewChange}
         />
       </div>
-      <div className="hidden justify-start lg:flex">
+      <div className="hidden max-w-[44rem] justify-start lg:flex">
         <FeedViewTabs
           activeView={activeView}
           onViewChange={handleViewChange}
@@ -76,7 +76,7 @@ export default function AuthenticatedFeedSurface({
       {activeView === "for-you" ? (
         <FeedInRotationShelf tracks={starterTracks} />
       ) : null}
-      <div className="space-y-4">
+      <div className="max-w-[44rem] space-y-4">
         <FeedReviewList
           view={activeView}
           initialPage={activeView === initialView ? initialPage : undefined}

--- a/apps/web/components/discovery-map.tsx
+++ b/apps/web/components/discovery-map.tsx
@@ -19,6 +19,7 @@ import EntityCoverImage from "@/components/entity-cover-image";
 import { KocteauSearchIcon } from "@/components/kocteau-icons";
 import { Input } from "@/components/ui/input";
 import { XIcon } from "@/components/ui/icons";
+import { Skeleton } from "@/components/ui/skeleton";
 import {
   useKocteauSearch,
   type KocteauSearchResult,
@@ -71,6 +72,10 @@ function getMobileSearchDockServerSnapshot() {
 
 function getSearchPortalTargetSnapshot() {
   return document.querySelector<HTMLElement>("[data-kocteau-scroll-boundary]");
+}
+
+function getDesktopSearchPortalTargetSnapshot() {
+  return document.querySelector<HTMLElement>("[data-kocteau-search-surface]");
 }
 
 function mapStarterTrackToSeed(track: StarterTrack): DiscoverySeed {
@@ -333,7 +338,9 @@ function DiscoverySearch({
   const isMobileViewport = useIsMobile();
   const portalTarget = useSyncExternalStore(
     subscribeToMobileSearchDock,
-    getSearchPortalTargetSnapshot,
+    mobile
+      ? getSearchPortalTargetSnapshot
+      : getDesktopSearchPortalTargetSnapshot,
     getMobileSearchDockServerSnapshot,
   );
   const hasQuery = query.trim().length >= 2;
@@ -353,62 +360,85 @@ function DiscoverySearch({
 
   const resultList =
     mobile === isMobileViewport && hasQuery && (!mobile || isFocused) ? (
-    <div
-      className="fixed inset-0 z-[100000] overflow-y-auto bg-[var(--kocteau-landing-canvas)] px-3 pb-[calc(env(safe-area-inset-bottom)+6.5rem)] pt-[calc(env(safe-area-inset-top)+4.5rem)] sm:px-6 md:pb-8 md:pl-[calc(var(--sidebar-width)+0.625rem)] md:pt-[9.5rem]"
-    >
       <div
-        id={resultListId}
-        className="mx-auto w-full max-w-2xl"
-      >
-        {results.length > 0 ? (
-          <div className="grid gap-1">
-            {results.map((result) => (
-              <button
-                key={`${result.provider}:${result.type}:${result.provider_id}`}
-                type="button"
-                onPointerDown={(event) => {
-                  if (mobile) event.preventDefault();
-                }}
-                onClick={() => chooseResult(result)}
-                className="grid min-h-16 min-w-0 grid-cols-[3.25rem_minmax(0,1fr)_auto] items-center gap-3 rounded-[0.75rem] px-2 py-1.5 text-left outline-none transition-colors duration-150 hover:bg-foreground/[0.055] focus-visible:ring-2 focus-visible:ring-ring/55"
-              >
-                <EntityCoverImage
-                  src={result.cover_url}
-                  alt=""
-                  sizes="52px"
-                  quality={70}
-                  variant="thumbnail"
-                  className={cn(
-                    "size-[3.25rem] bg-muted/30",
-                    result.type === "artist"
-                      ? "rounded-full"
-                      : "rounded-[0.6rem]",
-                  )}
-                  iconClassName="size-3.5"
-                />
-                <span className="min-w-0">
-                  <span className="block truncate font-pixel text-[12px] font-medium text-foreground/92">
-                    {result.title}
-                  </span>
-                  <span className="mt-1 block truncate text-[11px] text-muted-foreground/62">
-                    {result.type === "artist"
-                      ? "Artist"
-                      : result.artist_name || "Unknown artist"}
-                  </span>
-                </span>
-                <span className="pr-1 text-[9px] uppercase tracking-[0.12em] text-muted-foreground/48">
-                  {getResultTypeLabel(result)}
-                </span>
-              </button>
-            ))}
-          </div>
-        ) : (
-          <p className="px-3 py-4 text-[11px] text-muted-foreground/58">
-            {isSearching ? "Searching the catalog…" : "No matches. Try another name."}
-          </p>
+        className={cn(
+          "z-[100000] overflow-y-auto bg-background",
+          mobile
+            ? "fixed inset-0 px-3 pb-[calc(env(safe-area-inset-bottom)+6.5rem)] pt-[calc(env(safe-area-inset-top)+4.5rem)] sm:px-6"
+            : "absolute inset-0 px-6 pb-8 pt-20",
         )}
+      >
+        <div id={resultListId} className="mx-auto w-full max-w-2xl">
+          {isSearching ? (
+            <div
+              aria-busy="true"
+              aria-label="Searching the catalog"
+              className="grid gap-1"
+            >
+              {Array.from({ length: 6 }, (_, index) => (
+                <div
+                  key={index}
+                  aria-hidden="true"
+                  className="grid min-h-16 grid-cols-[3.25rem_minmax(0,1fr)_3rem] items-center gap-3 px-2 py-1.5"
+                >
+                  <Skeleton className="size-[3.25rem] rounded-[0.6rem] bg-muted-foreground/[0.1]" />
+                  <div className="space-y-2">
+                    <Skeleton className="h-3 w-[min(14rem,62%)] rounded-full bg-muted-foreground/[0.12]" />
+                    <Skeleton className="h-2.5 w-[min(9rem,42%)] rounded-full bg-muted-foreground/[0.08]" />
+                  </div>
+                  <Skeleton className="h-2 w-10 justify-self-end rounded-full bg-muted-foreground/[0.08]" />
+                </div>
+              ))}
+            </div>
+          ) : results.length > 0 ? (
+            <div className="grid gap-1">
+              {results.map((result) => (
+                <button
+                  key={`${result.provider}:${result.type}:${result.provider_id}`}
+                  type="button"
+                  onPointerDown={(event) => {
+                    if (mobile) event.preventDefault();
+                  }}
+                  onClick={() => chooseResult(result)}
+                  className="grid min-h-16 min-w-0 grid-cols-[3.25rem_minmax(0,1fr)_auto] items-center gap-3 rounded-[0.75rem] px-2 py-1.5 text-left outline-none transition-colors duration-150 hover:bg-foreground/[0.055] focus-visible:ring-2 focus-visible:ring-ring/55"
+                >
+                  <EntityCoverImage
+                    src={result.cover_url}
+                    alt=""
+                    sizes="52px"
+                    quality={70}
+                    variant="thumbnail"
+                    className={cn(
+                      "size-[3.25rem] bg-muted/30",
+                      result.type === "artist"
+                        ? "rounded-full"
+                        : "rounded-[0.6rem]",
+                    )}
+                    iconClassName="size-3.5"
+                  />
+                  <span className="min-w-0">
+                    <span className="block truncate font-pixel text-[12px] font-medium text-foreground/92">
+                      {result.title}
+                    </span>
+                    <span className="mt-1 block truncate text-[11px] text-muted-foreground/62">
+                      {result.type === "artist"
+                        ? "Artist"
+                        : result.artist_name || "Unknown artist"}
+                    </span>
+                  </span>
+                  <span className="pr-1 text-[9px] uppercase tracking-[0.12em] text-muted-foreground/48">
+                    {getResultTypeLabel(result)}
+                  </span>
+                </button>
+              ))}
+            </div>
+          ) : (
+            <p className="px-3 py-4 text-[11px] text-muted-foreground/58">
+              No matches. Try another name.
+            </p>
+          )}
+        </div>
       </div>
-    </div>
     ) : null;
   const portaledResultList = resultList && portalTarget
     ? createPortal(resultList, portalTarget)
@@ -461,7 +491,7 @@ function DiscoverySearch({
             maxLength={80}
             aria-expanded={Boolean(isFocused && hasQuery)}
             aria-controls={resultListId}
-            className="h-11 rounded-full border-transparent bg-white/[0.08] pl-10 pr-4 text-base shadow-none placeholder:text-muted-foreground/58 focus-visible:border-transparent focus-visible:ring-2 focus-visible:ring-ring/70"
+            className="h-11 rounded-full border-transparent bg-[var(--kocteau-surface-control)] pl-10 pr-4 text-base shadow-none placeholder:text-muted-foreground/58 focus-visible:border-transparent focus-visible:ring-2 focus-visible:ring-ring/70"
           />
           {portaledResultList}
         </form>
@@ -479,7 +509,7 @@ function DiscoverySearch({
               setIsFocused(false);
             }}
             className={cn(
-              "flex size-11 items-center justify-center rounded-full bg-white/[0.08] text-foreground transition-[opacity,scale,background-color] duration-150 hover:bg-white/[0.12] active:scale-[0.96] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/70",
+              "flex size-11 items-center justify-center rounded-full bg-[var(--kocteau-surface-control)] text-foreground transition-[opacity,scale,background-color] duration-150 hover:bg-[var(--kocteau-surface-control-hover)] active:scale-[0.96] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/70",
               isFocused ? "opacity-100 scale-100" : "pointer-events-none opacity-0 scale-95",
             )}
           >
@@ -526,7 +556,7 @@ function DiscoverySearch({
         maxLength={80}
         aria-expanded={results.length > 0}
         aria-controls={resultListId}
-        className="h-11 rounded-full border-transparent bg-white/[0.08] pl-10 pr-12 text-base shadow-none placeholder:text-muted-foreground/58 focus-visible:border-transparent focus-visible:ring-2 focus-visible:ring-ring/70 sm:text-[13px]"
+        className="h-11 rounded-full border-transparent bg-[var(--kocteau-surface-control)] pl-10 pr-12 text-base shadow-none placeholder:text-muted-foreground/58 focus-visible:border-transparent focus-visible:ring-2 focus-visible:ring-ring/70 sm:text-[13px]"
       />
       {isExpanding ? (
         <span
@@ -546,7 +576,7 @@ function DiscoverySearch({
           setIsFocused(false);
         }}
         className={cn(
-          "absolute left-[calc(100%+0.75rem)] top-0 flex size-11 items-center justify-center rounded-full bg-white/[0.08] text-foreground transition-[opacity,scale,background-color] duration-150 hover:bg-white/[0.12] active:scale-[0.96] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/70",
+          "absolute left-[calc(100%+0.75rem)] top-0 flex size-11 items-center justify-center rounded-full bg-[var(--kocteau-surface-control)] text-foreground transition-[opacity,scale,background-color] duration-150 hover:bg-[var(--kocteau-surface-control-hover)] active:scale-[0.96] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/70",
           isFocused ? "opacity-100 scale-100" : "pointer-events-none opacity-0 scale-95",
         )}
       >

--- a/apps/web/components/feed-in-rotation-shelf.tsx
+++ b/apps/web/components/feed-in-rotation-shelf.tsx
@@ -1,21 +1,11 @@
-import PrefetchLink from "@/components/prefetch-link";
 import SectionLinkHeading from "@/components/section-link-heading";
+import StarterRouteCard from "@/components/starter-route-card";
 import TrackCarousel from "@/components/track-carousel";
-import TrackTile from "@/components/track-tile";
-import { getDiscoverySeedPath } from "@/lib/discovery/seed";
 import type { StarterTrack } from "@/lib/starter";
 
 type FeedInRotationShelfProps = {
   tracks: StarterTrack[];
 };
-
-function getStarterTrackHref(track: StarterTrack) {
-  return getDiscoverySeedPath({
-    provider_id: track.provider_id,
-    title: track.title,
-    type: "track",
-  });
-}
 
 export default function FeedInRotationShelf({
   tracks,
@@ -39,30 +29,17 @@ export default function FeedInRotationShelf({
         ariaLabel="Discovery starting points"
         compactControls
         contentClassName="gap-3"
-        controlClassName="[--kocteau-carousel-cover-size:8.25rem]"
+        controlClassName="[--kocteau-carousel-cover-size:18rem]"
         fadeClassName="kocteau-carousel-mask-r-from-tight"
-        itemClassName="basis-[8.25rem]"
-        viewportClassName="-mr-2 pr-2"
+        itemClassName="basis-[13.5rem] xl:basis-[14rem]"
+        viewportClassName="-mr-7 pr-7"
       >
         {visibleTracks.map((track, index) => (
-          <PrefetchLink
+          <StarterRouteCard
             key={track.id}
-            href={getStarterTrackHref(track)}
-            className="group block rounded-[0.78rem] outline-none transition-opacity duration-150 hover:opacity-85 focus-visible:ring-2 focus-visible:ring-ring/55"
-            aria-label={`Start a discovery route from ${track.title} by ${track.artist_name ?? "Unknown artist"}`}
-          >
-            <TrackTile
-              title={track.title}
-              artistName={track.artist_name}
-              coverUrl={track.cover_url}
-              sizes="132px"
-              quality={82}
-              priority={index < 4}
-              coverClassName="rounded-[0.7rem]"
-              titleClassName="text-[13px] font-semibold leading-4 group-hover:text-foreground"
-              artistClassName="text-[12px] leading-4 text-muted-foreground/66"
-            />
-          </PrefetchLink>
+            track={track}
+            priority={index < 4}
+          />
         ))}
       </TrackCarousel>
     </section>

--- a/apps/web/components/feed-starter-shelf.tsx
+++ b/apps/web/components/feed-starter-shelf.tsx
@@ -1,12 +1,10 @@
 "use client";
 
 import { useEffect, useMemo, useRef } from "react";
-import EntityCoverImage from "@/components/entity-cover-image";
-import PrefetchLink from "@/components/prefetch-link";
 import SectionLinkHeading from "@/components/section-link-heading";
+import StarterRouteCard from "@/components/starter-route-card";
 import TrackCarousel from "@/components/track-carousel";
 import { trackAnalyticsEvent } from "@/lib/analytics/client";
-import { getDiscoverySeedPath } from "@/lib/discovery/seed";
 import type { StarterTrack } from "@/lib/starter";
 import { cn } from "@/lib/utils";
 
@@ -16,52 +14,6 @@ type FeedStarterShelfProps = {
   variant?: "editorial" | "personalized";
   className?: string;
 };
-
-function getStarterTrackHref(track: StarterTrack) {
-  return getDiscoverySeedPath({
-    provider_id: track.provider_id,
-    title: track.title,
-    type: "track",
-  });
-}
-
-function StarterRouteCard({
-  track,
-  priority,
-}: {
-  track: StarterTrack;
-  priority: boolean;
-}) {
-  return (
-    <PrefetchLink
-      href={getStarterTrackHref(track)}
-      className="group block overflow-hidden rounded-[0.9rem] bg-[var(--kocteau-surface-control)] outline-none transition-[opacity,transform] duration-150 hover:opacity-90 focus-visible:ring-2 focus-visible:ring-ring/60 active:scale-[0.985]"
-      aria-label={`Start a discovery route from ${track.title} by ${track.artist_name ?? "Unknown artist"}`}
-    >
-      <div className="relative aspect-[4/5] overflow-hidden">
-        <EntityCoverImage
-          src={track.cover_url}
-          alt=""
-          sizes="(max-width: 640px) 82vw, 19rem"
-          quality={84}
-          variant="card"
-          priority={priority}
-          className="absolute inset-0 h-full w-full"
-          imageClassName="transition-transform duration-300 ease-out group-hover:scale-[1.015] motion-reduce:transition-none"
-          iconClassName="size-8"
-        />
-        <div className="absolute inset-x-2 bottom-2 rounded-[0.68rem] bg-black/72 px-3 py-2.5 backdrop-blur-md">
-          <p className="truncate font-pixel text-[12px] leading-tight text-white/94">
-            {track.title}
-          </p>
-          <p className="mt-1 truncate text-[11px] leading-tight text-white/66">
-            {track.artist_name ?? "Unknown artist"}
-          </p>
-        </div>
-      </div>
-    </PrefetchLink>
-  );
-}
 
 export default function FeedStarterShelf({
   tracks,

--- a/apps/web/components/starter-route-card.tsx
+++ b/apps/web/components/starter-route-card.tsx
@@ -1,0 +1,52 @@
+import EntityCoverImage from "@/components/entity-cover-image";
+import PrefetchLink from "@/components/prefetch-link";
+import { getDiscoverySeedPath } from "@/lib/discovery/seed";
+import type { StarterTrack } from "@/lib/starter";
+
+type StarterRouteCardProps = {
+  track: StarterTrack;
+  priority?: boolean;
+};
+
+function getStarterTrackHref(track: StarterTrack) {
+  return getDiscoverySeedPath({
+    provider_id: track.provider_id,
+    title: track.title,
+    type: "track",
+  });
+}
+
+export default function StarterRouteCard({
+  track,
+  priority = false,
+}: StarterRouteCardProps) {
+  return (
+    <PrefetchLink
+      href={getStarterTrackHref(track)}
+      className="group block overflow-hidden rounded-[0.9rem] bg-[var(--kocteau-surface-control)] outline-none transition-[opacity,transform] duration-150 hover:opacity-90 focus-visible:ring-2 focus-visible:ring-ring/60 active:scale-[0.96]"
+      aria-label={`Start a discovery route from ${track.title} by ${track.artist_name ?? "Unknown artist"}`}
+    >
+      <div className="relative aspect-[3/4] overflow-hidden">
+        <EntityCoverImage
+          src={track.cover_url}
+          alt=""
+          sizes="(max-width: 640px) 82vw, 14rem"
+          quality={84}
+          variant="card"
+          priority={priority}
+          className="absolute inset-0 h-full w-full"
+          imageClassName="outline outline-1 -outline-offset-1 outline-black/10 transition-transform duration-300 ease-out group-hover:scale-[1.015] motion-reduce:transition-none dark:outline-white/10"
+          iconClassName="size-8"
+        />
+        <div className="absolute inset-x-0 bottom-0 bg-black/78 px-3 py-3 backdrop-blur-md">
+          <p className="truncate font-pixel text-[12px] leading-tight text-white/94">
+            {track.title}
+          </p>
+          <p className="mt-1 truncate text-[11px] leading-tight text-white/66">
+            {track.artist_name ?? "Unknown artist"}
+          </p>
+        </div>
+      </div>
+    </PrefetchLink>
+  );
+}


### PR DESCRIPTION
## Summary
- add structural search-result skeletons and opaque search controls
- keep desktop results inside the main surface while preserving mobile fullscreen search
- remove the secondary editorial rail from the core shell
- widen the feed shelf without widening review reading measure
- share large 3:4 Start a route cards with a full-width blurred caption

## Verification
- pnpm --filter web exec tsc --noEmit
- pnpm --filter web lint
- pnpm --filter web build
- git diff --check
- Playwright: Search at 390x844 and 1440x900

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the search and feed layouts to improve readability and consistency. Adds search result skeletons, keeps desktop results inside the main surface, removes the secondary editorial rail, and widens the starter shelf with shared 3:4 “Start a route” cards without changing the review reading width.

- New Features
  - Skeleton loading states for search results with accessible labels.
  - Desktop search results render within the main surface; mobile stays full-screen.
  - New shared `StarterRouteCard` (3:4) with blurred caption; updated carousel sizing.

- Refactors
  - Removed `EditorialDiscoveryRail` and `SecondaryRailProvider` from the app shell.
  - Unified search control styling using `var(--kocteau-surface-control)` and constrained desktop feed content to keep the reading measure stable.

<sup>Written for commit ed46da4c1a3c63a574e904bb400b64bdb87932db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/francozeta/kocteau/pull/172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

