### PR TITLE
fix(search): align discovery action docks

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1047,6 +1047,19 @@
     scale: 0.96;
   }
 
+  .kocteau-liquid-bar {
+    border: 1px solid var(--kocteau-line);
+    background: color-mix(in oklch, var(--foreground) 7%, transparent);
+    box-shadow: none;
+    backdrop-filter: blur(14px) saturate(108%);
+    -webkit-backdrop-filter: blur(14px) saturate(108%);
+  }
+
+  .dark .kocteau-liquid-bar {
+    border-color: rgba(255, 255, 255, 0.1);
+    background: rgba(255, 255, 255, 0.08);
+  }
+
   @media (min-width: 1024px) {
     .kocteau-app-frame {
       border: 1px solid var(--kocteau-line);
@@ -1087,15 +1100,6 @@
       transform: scale(0.96);
     }
 
-    .mobile-liquid-bar {
-      @apply backdrop-blur-md backdrop-saturate-100;
-      border: 1px solid var(--kocteau-line) !important;
-      background: color-mix(in oklch, var(--background) 84%, transparent) !important;
-      box-shadow: none !important;
-      backdrop-filter: blur(14px) saturate(108%) !important;
-      -webkit-backdrop-filter: blur(14px) saturate(108%) !important;
-    }
-
     .mobile-liquid-panel {
       @apply backdrop-blur-md backdrop-saturate-100;
       border: 1px solid var(--kocteau-line-soft) !important;
@@ -1118,12 +1122,6 @@
 
     .dark .mobile-liquid-button:hover {
       background: rgba(20, 20, 23, 0.92) !important;
-    }
-
-    .dark .mobile-liquid-bar {
-      border-color: rgba(255, 255, 255, 0.1) !important;
-      background: rgba(10, 10, 12, 0.88) !important;
-      box-shadow: none !important;
     }
 
     .dark .mobile-liquid-panel {

--- a/apps/web/components/discovery-seed-actions.tsx
+++ b/apps/web/components/discovery-seed-actions.tsx
@@ -49,7 +49,7 @@ export default function DiscoverySeedActions({ seed }: DiscoverySeedActionsProps
   const shouldReduceMotion = useReducedMotion();
 
   return (
-    <div className="pointer-events-none absolute inset-x-3 bottom-[calc(env(safe-area-inset-bottom)+5.75rem)] z-40 flex justify-center md:bottom-5 lg:justify-end lg:px-6">
+    <div className="pointer-events-none absolute inset-x-4 top-[calc(50%+7rem)] z-40 flex justify-center md:px-6">
       <AnimatePresence initial={false} mode="popLayout">
         {seed ? (
           <motion.div
@@ -69,21 +69,25 @@ export default function DiscoverySeedActions({ seed }: DiscoverySeedActionsProps
               duration: shouldReduceMotion ? 0 : 0.25,
               ease: smoothOut,
             }}
-            className="mobile-liquid-bar pointer-events-auto flex w-full max-w-[28rem] items-center gap-1 rounded-full p-1 sm:w-auto sm:min-w-[23rem]"
+            className="kocteau-liquid-bar pointer-events-auto flex h-11 w-full max-w-[28rem] items-center gap-0.5 rounded-full p-0.5"
             aria-live="polite"
           >
             <PrefetchLink
               href={getEntityHref(seed)}
               aria-label={`Open ${seed.title}`}
-              className="group flex h-11 min-w-0 flex-1 items-center gap-2 rounded-full px-1.5 text-left text-foreground outline-none transition-[opacity,transform] duration-150 ease-out hover:opacity-90 focus-visible:ring-2 focus-visible:ring-ring/55 active:scale-[0.98]"
+              className="group flex h-10 min-w-0 flex-1 items-center gap-2 rounded-full px-1 text-left text-foreground outline-none transition-[opacity,transform] duration-150 ease-out hover:opacity-90 focus-visible:ring-2 focus-visible:ring-ring/55 active:scale-[0.98]"
             >
               <EntityCoverImage
                 src={seed.cover_url}
                 alt=""
-                sizes="40px"
+                sizes="36px"
                 quality={72}
                 variant="thumbnail"
-                className={seed.type === "artist" ? "size-10 rounded-full" : "size-10 rounded-[0.55rem]"}
+                className={
+                  seed.type === "artist"
+                    ? "size-9 rounded-full outline outline-1 -outline-offset-1 outline-black/10 dark:outline-white/10"
+                    : "size-9 rounded-[0.45rem] outline outline-1 -outline-offset-1 outline-black/10 dark:outline-white/10"
+                }
                 iconClassName="size-3.5"
               />
               <span className="min-w-0 flex-1">

--- a/apps/web/components/mobile-bottom-bar.tsx
+++ b/apps/web/components/mobile-bottom-bar.tsx
@@ -162,7 +162,7 @@ export default function MobileBottomBar({ profile }: MobileBottomBarProps) {
         className="fixed bottom-[calc(env(safe-area-inset-bottom)+1rem)] left-1/2 z-50 -translate-x-1/2 md:hidden"
       >
         <div className="flex items-center gap-2">
-          <div className="flex items-center gap-1 rounded-full bg-white/[0.08] p-1 backdrop-blur-2xl backdrop-saturate-150">
+          <div className="flex h-11 items-center gap-1 rounded-full bg-white/[0.08] backdrop-blur-2xl backdrop-saturate-150">
             {navItems.map((item) => (
               <NavTab key={item.href} item={item} pathname={pathname} />
             ))}


### PR DESCRIPTION
## Summary
- match the mobile navigation and selected-track dock to the 44px search input proportions
- center the selected entity actions directly below the anchored cover on mobile and desktop
- share the raised liquid surface across breakpoints for clearer grouping

## Verification
- pnpm --filter web lint
- pnpm --filter web exec tsc --noEmit
- git diff --check
- Playwright visual checks at 390x844 and 1440x900

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligned the discovery action docks with the 44px search input and centered the selected-entity actions under the anchored cover on mobile and desktop. Unified the “liquid” bar styling across breakpoints for clearer grouping and consistency.

- **Bug Fixes**
  - Set mobile nav and seed action docks to 44px height; adjusted padding and 36px thumbnails with subtle outlines.
  - Moved selected-entity action bar to sit directly beneath the anchored cover (repositioned from bottom to centered offset).
  - Replaced `mobile-liquid-bar` with shared `.kocteau-liquid-bar` and refined backdrop/border styles for light/dark modes.

<sup>Written for commit ab0ba7bba867f27981b0f357c4af9f4d2e4f9c14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/francozeta/kocteau/pull/173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

