### PR TITLE
fix(search): use solid desktop action surface

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1060,6 +1060,16 @@
     background: rgba(255, 255, 255, 0.08);
   }
 
+  @media (min-width: 768px) {
+    .kocteau-liquid-bar,
+    .dark .kocteau-liquid-bar {
+      border-color: transparent;
+      background: var(--kocteau-surface-control);
+      backdrop-filter: none;
+      -webkit-backdrop-filter: none;
+    }
+  }
+
   @media (min-width: 1024px) {
     .kocteau-app-frame {
       border: 1px solid var(--kocteau-line);


### PR DESCRIPTION
## Summary
- use the same --kocteau-surface-control background as the Search input for the selected-track dock on desktop
- disable backdrop blur only at desktop widths
- keep the current mobile liquid treatment unchanged

## Verification
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the selected-track dock on desktop use a solid control surface that matches the Search input, and remove the blur effect. Mobile stays unchanged.

- **Bug Fixes**
  - At ≥768px, apply solid `--kocteau-surface-control` background to `.kocteau-liquid-bar` and make the border transparent.
  - Disable `backdrop-filter` on desktop to remove the blur.

<sup>Written for commit 20023dec3110108d113dc0f9de721221344b3e71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/francozeta/kocteau/pull/174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

