### PR TITLE
docs(product): define v0.4 release scope

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@
 ## Product Direction
 
 - [MVP baseline](./mvp.md): current product loop, scope, and out-of-scope guardrails.
+- [v0.4.0 scope board](./v0.4-release-scope.md): release thesis, prioritized lanes, success gates, and model orchestration policy.
 - [Web roadmap](./web-roadmap.md): phased web product direction and execution order.
 - [Discovery and curation](./discovery-curation.md): hybrid recommendation philosophy, signal contract, starter curation, and future RFC lanes.
 - [Knowledge Layer and Search](./knowledge-layer.md): source policy, taste taxonomy, and explainable discovery direction.

--- a/docs/v0.4-release-scope.md
+++ b/docs/v0.4-release-scope.md
@@ -1,0 +1,221 @@
+# Kocteau v0.4.0 Scope Board
+
+[Docs index](./README.md) | [MVP baseline](./mvp.md) | [Web roadmap](./web-roadmap.md) | [Public backlog](./backlog.md)
+
+## Status
+
+- Stage: proposed release scope
+- Release type: product-loop release, not a surface-expansion release
+- Baseline: `v0.3.12`, with the `v0.3.13` Release Please PR pending review
+- Primary surface: `apps/web`
+
+## Release Thesis
+
+Kocteau v0.4.0 should prove one coherent loop:
+
+> Start from any song, album, or artist; travel through an explainable route; save or review a meaningful find; and return to a feed that remembers the signal.
+
+The release should make the product feel connected rather than larger. Search, reviews, the feed, the library, onboarding, and curator tools already exist. The next risk is not missing surface area. It is whether those surfaces form a reliable and repeatable behavior.
+
+## Product Diagnosis
+
+| Surface | Current strength | Release gap | v0.4 decision |
+| --- | --- | --- | --- |
+| Public entry | The landing page and signed-out browsing explain the visual tone. | The first useful music action can still feel separate from the product promise. | Lead visitors toward Search without requiring an account. |
+| Search | Routed 3D discovery is Kocteau's clearest product signature. | Route depth, evidence, action continuity, and performance still need a stable contract. | Make Search the discovery core. Do not revive Atlas as a competing primary destination. |
+| Reviews | Review creation, detail routes, reactions, bookmarks, and comments exist. | Discovery does not always resolve naturally into a review or saved signal. | Make review/save the natural end of a discovery route. |
+| Feed | For You, editorial fallback, and first-party signals exist. | Sparse content and weak feedback visibility can make personalization feel abstract. | Show that discovery and review behavior affects the next session. |
+| Library | Songs, albums, artists, and bookmarked reviews have dedicated routes. | Its role in the discovery loop is not yet obvious to a new listener. | Treat Library as private taste memory, not a playlist product. |
+| Curators | Applications, review workflow, Starter Studio, and candidate queues exist. | The program is not yet proven operationally or by content quality. | Run a small curator pilot; do not expand the admin system. |
+| Atlas | Legacy routes still exist. | It competes conceptually with the new Search direction. | Keep compatibility only; no v0.4 product investment. |
+
+## Core User Journeys
+
+### Guest
+
+1. Open Search without an account.
+2. Choose a song, album, or artist as a seed.
+3. See a useful route with distinct, non-duplicated candidates.
+4. Understand the short reason behind a connection.
+5. Open the canonical entity or attempt to save/review it.
+6. Authenticate only when the action requires identity, then return to the same intent.
+
+### Signed-in listener
+
+1. Enter through Search or For You.
+2. Explore, skip, save, review, or follow.
+3. See the action reflected in Library and recommendation signals.
+4. Return to a For You feed with a clearer reason for what appears.
+
+### Curator
+
+1. Review a candidate or search the catalog.
+2. Add evidence, editorial framing, and controlled taste tags.
+3. Publish a starter route through the existing reviewed workflow.
+4. Inspect aggregate route and starter health without raw private analytics.
+
+## Scope Board
+
+| ID | Lane | Priority | State | Primary model | Acceptance |
+| --- | --- | --- | --- | --- | --- |
+| V04-01 | Release baseline and critical-flow audit | P0 | Ready | Terra, Sol gate | OTP, onboarding, first review, Search, and Library pass signed-out/signed-in smoke tests on desktop and mobile. No known blocker remains hidden inside a polish task. |
+| V04-02 | Exact seed selection and route identity | P0 | In progress | Terra | Representative artist, album, and track queries return the intended entity; the selected seed stays visually and canonically identifiable; route changes preserve URL and back-button behavior. |
+| V04-03 | Explainable discovery lanes | P0 | Ready after V04-02 | Terra, Sol contract | Candidate generation exposes controlled lanes such as nearby, deeper, stranger, and serendipity. Every explanation is backed by catalog, tag, review, library, or curator evidence. |
+| V04-04 | Discovery-to-action continuity | P0 | Ready | Terra | Review, Library, and canonical-link actions are reachable from the selected entity. Guest auth returns to the original entity/action instead of dropping intent. |
+| V04-05 | Feed feedback and re-entry | P0 | Needs baseline | Terra, Sol review | Discovery and review actions emit the agreed safe events. For You can consume existing signals without a new opaque ranking system. Sparse accounts retain editorial fallback. |
+| V04-06 | Curator pilot and coverage | P1 | Operational | Luna/Terra, human approval | Run a small pilot with 3-5 curators or maintainers, cover 4-6 distinct taste areas, and review route quality before increasing access. No automatic promotion to production. |
+| V04-07 | Perceived performance and structural loading | P0 | Ready | Terra/Luna | Search and track cold-tail latency are profiled; structural skeletons preserve layout; no duplicate covers, mobile overflow, desktop dead zone, or blocking spinner on core paths. |
+| V04-08 | Release evaluation | P0 | Blocked by V04-01 to V04-07 | Sol | Five to eight usability sessions cover guest discovery and signed-in review. Critical issues are resolved or explicitly accepted before the release PR. |
+
+## Metrics Contract
+
+v0.4.0 should establish a baseline before promising growth percentages. Measure the funnel, then set targets from real use.
+
+### Activation
+
+- guest Search visit -> seed selected
+- seed selected -> route candidate opened
+- route candidate opened -> Library add or review started
+- OTP verified -> onboarding completed
+- onboarding completed -> first review published
+
+### Quality
+
+- exact-entity success on a maintained fixture set
+- unique provider/entity ratio per discovery view
+- discovery requests with useful candidates and without fallback
+- route explanation evidence coverage
+- review publish success and recoverable error rate
+
+### Retention
+
+- first-review users who return within seven days
+- For You loads followed by a meaningful review action
+- Library additions that later lead to a review or entity reopen
+- starter impressions, passes, review intent, and published reviews by taste area
+
+### Release gates
+
+- no open P0 auth, onboarding, review-publish, or navigation defect
+- at least 85% completion for the guest discovery and first-review usability tasks
+- exact entity selected in at least 14 of 15 maintained search fixtures
+- no duplicate entity or cover within one rendered discovery route
+- all new analytics payloads pass the privacy and signal contract
+- mobile and desktop visual checks attached to each UI PR
+
+Performance budgets should be based on a captured production baseline. Do not invent a latency target before issue `#147` records the current cold and warm paths.
+
+## Curator and External-Source Policy
+
+The curator program should fill coverage gaps, not manufacture activity.
+
+- Start with a small reviewed cohort and explicit taste areas.
+- Keep curator decisions human-approved.
+- Treat Pitchfork, MusicBrainz, Discogs, Wikidata, Musicboard, and similar sources according to their actual role and rights.
+- External catalog facts or links may become candidate evidence when permitted.
+- Do not copy third-party reviews, ratings, or editorial text into Kocteau without a clear license and attribution policy.
+- Do not let an LLM turn an external mention into a factual relationship without stored evidence.
+
+## Explicitly Out of Scope
+
+- a second discovery core under Atlas
+- broad visual redesign of the entire application
+- native mobile application work
+- playlists or playback infrastructure
+- direct messages
+- automatic ingestion of publisher reviews
+- heavy embeddings, vector search, or graph infrastructure
+- automatic curator promotion or automatic starter publishing
+- first-class album and artist review systems
+- a larger Studio or moderation dashboard
+
+## Backlog Reconciliation
+
+Before implementation begins, reconcile the public issues with the shipped product:
+
+- `#126`: close, rewrite, or relabel the Atlas scope so it does not compete with Search.
+- `#127`: rename the outdated Eve wording and use it as the explainable Search-route contract.
+- `#88`: audit what remains after artist and album search shipped; keep only users/categories if they still support the release thesis.
+- `#89`: fold candidate-finder requirements into V04-03 instead of building a parallel surface.
+- `#92`: evaluate starter diversity after the v0.4 signal baseline exists.
+- `#82`, `#87`, and `#147`: use as the reliability, loading, and performance inputs to V04-01/V04-07.
+- `#124` and `#125`: keep the Knowledge Layer policy/taxonomy work as a controlled dependency, not a reason to build a new graph engine.
+
+## Execution Phases
+
+### Phase A: Freeze and measure
+
+- Merge or close the pending release and dependency PRs deliberately.
+- Land the package-manager migration separately from product work.
+- Reconcile stale issues and capture auth/Search/performance baselines.
+- Freeze the discovery candidate and explanation contracts.
+
+### Phase B: Ship one vertical discovery slice
+
+- exact seed
+- related candidates
+- one evidence-backed reason per candidate
+- route URL
+- Library and Review actions
+- guest-to-auth intent recovery
+
+Do not build every lane first. Prove one complete route, then extend the same contract.
+
+### Phase C: Close the return loop
+
+- connect existing actions to safe analytics
+- verify For You and Library reflect the signals
+- run the small curator coverage pilot
+- resolve loading, error, and empty states across the loop
+
+### Phase D: Validate and release
+
+- test with 5-8 representative listeners
+- resolve all P0 findings
+- record accepted P1 limitations
+- run desktop/mobile, authenticated/guest, sparse-data, and cold-path checks
+- open the `v0.4.0` release PR only after the gates pass
+
+## Model Orchestration Policy
+
+### Roles
+
+| Model | Default role | Use it for | Avoid using it for |
+| --- | --- | --- | --- |
+| GPT-5.6 Sol | Orchestrator and quality gate | product scope, architecture contracts, sensitive Supabase/auth decisions, cross-cutting risk analysis, final integrated review | routine file discovery, repetitive edits, isolated components, running ordinary checks |
+| GPT-5.6 Terra | Default implementation model | bounded UI slices, API/routes, tests, refactors, bug fixes, performance work, implementation review | redefining product scope mid-task without returning to the release contract |
+| GPT-5.6 Luna | High-volume support where available | inventories, fixture generation, documentation normalization, mechanical audits, test matrices, repetitive QA summaries | final product judgment, sensitive migrations, ambiguous cross-system changes |
+
+The current Codex collaboration runtime may expose Sol and Terra without exposing Luna as a subagent override. In that environment, use Terra for Luna-shaped tasks with low or medium reasoning instead of inventing an unavailable model route.
+
+### Task packet
+
+Every delegated task must include:
+
+```text
+Outcome:
+Why it matters to v0.4:
+In-scope files/systems:
+Non-goals:
+Acceptance criteria:
+Required verification:
+Mutation/approval boundary:
+Expected handoff:
+```
+
+### Token and coordination rules
+
+1. Sol creates the release contract and acceptance criteria once.
+2. Delegate only concrete, bounded work. Do not send the full conversation when the scope document and a task packet are sufficient.
+3. Use Terra as the default developer. Raise reasoning only for measured difficulty.
+4. Use Luna, when available, for mechanical or high-volume work whose output can be checked deterministically.
+5. Parallelize only independent lanes with non-overlapping files or contracts.
+6. Keep one vertical slice per PR. An agent should not redesign adjacent surfaces while implementing its ticket.
+7. Terra performs local verification and reports the exact changed files, tests, and remaining risks.
+8. Sol reviews the integrated diff at milestone gates, not every intermediate thought or trivial edit.
+9. Escalate back to Sol when a task changes data contracts, auth, RLS, product scope, or more than one core journey.
+10. Track success, total tokens, latency, retries, and review findings by task type. A cheaper run only wins if it passes the same acceptance criteria.
+
+## Definition of Done
+
+v0.4.0 is done when a guest can discover something meaningful without an account, a signed-in listener can convert that discovery into taste data, and the next session visibly benefits from that data. The release is not done merely because the 3D interaction looks finished or because more catalog results are available.


### PR DESCRIPTION
## Summary
- define the v0.4 product-loop thesis and prioritized scope board
- establish measurable release gates and explicit non-goals
- reconcile current discovery issues with the Search-first direction
- document the Sol/Terra/Luna orchestration and token policy

## Notes
- this is intentionally a draft for product review
- existing local pnpm migration changes are not included

## Verification
- git diff --check
- documentation links resolved locally

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the v0.4 scope board and links it from the docs index to align the release around one Search-first discovery loop, explicit success gates, and model orchestration policy.

- New doc `docs/v0.4-release-scope.md`; `docs/README.md` links it under Product Direction. Validates a single loop: Search → explainable route → save/review → feed that remembers, with Atlas kept for compatibility only and a small curator pilot.
- Prioritizes P0 lanes (V04-01…V04-08) and defines release gates (exact-entity search fixtures, duplicate suppression within routes, no open P0 in auth/onboarding/review/navigation, 5–8 usability sessions with ≥85% task completion).
- Sets activation/quality/retention metrics and a privacy-respecting analytics contract; performance budgets to be set from a captured baseline.
- Establishes model roles and rules (Sol orchestration, Terra implementation, Luna high-volume support) plus a required task packet format and coordination boundaries.
- Declares explicit non-goals to prevent scope creep (no second discovery core, native apps, playlists, heavy embeddings/graph infra, or broader admin surfaces).
- Rollout follows Phases A–D; no runtime changes in this PR. Reviewers should verify the new link, sign off on the scope/gates, and reconcile the referenced backlog items (`#126`, `#127`, `#88`, `#89`, `#92`, `#82`, `#87`, `#147`, `#124`, `#125`) into actionable tickets.

<sup>Written for commit dd5bc10d2e8af282981b7fee393d07ebcc3984d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/francozeta/kocteau/pull/177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

