### PR TITLE
docs: add discovery signal payload examples

### DIFF
--- a/docs/discovery-curation.md
+++ b/docs/discovery-curation.md
@@ -175,7 +175,7 @@ These examples use placeholder IDs and include only the fields needed to support
   "metadata": {
     "review_id": "review_example_01",
     "entity_id": "track_example_01",
-    "reason": "taste_affinity",
+    "reason": "taste_match",
     "position": 3
   }
 }
@@ -212,7 +212,7 @@ These examples use placeholder IDs and include only the fields needed to support
   "metadata": {
     "review_id": "review_example_02",
     "entity_id": "track_example_02",
-    "reason": "editorial_affinity"
+    "reason": "author_affinity"
   }
 }
 ```

--- a/docs/discovery-curation.md
+++ b/docs/discovery-curation.md
@@ -162,6 +162,65 @@ Use only fields that help answer a product question:
 | `starter_review_cta` | `starter_track_id`, `provider_id` | Which starter picks invite reviews? |
 | `starter_review_published` | `starter_track_id`, `provider_id` | Which starter picks convert into reviews? |
 
+### Example Payloads
+
+These examples use placeholder IDs and include only the fields needed to support a product decision. The required envelope fields are `event_type`, `source`, and `metadata`.
+
+#### For You Review Impression
+
+```json
+{
+  "event_type": "review_impression",
+  "source": "feed:for-you",
+  "metadata": {
+    "review_id": "review_example_01",
+    "entity_id": "track_example_01",
+    "reason": "taste_affinity",
+    "position": 3
+  }
+}
+```
+
+- Required metadata: `review_id`, `entity_id`, and `reason`.
+- Optional metadata: `position` when the review appears in an ordered surface.
+- Product decision: compare impressions with opens and actions by recommendation reason before tuning For You ranking.
+
+#### Starter Pick Pass
+
+```json
+{
+  "event_type": "starter_pass",
+  "source": "feed:starter",
+  "metadata": {
+    "starter_track_id": "starter_example_01",
+    "provider_id": "provider_track_example_01",
+    "matched_tag_count": 2
+  }
+}
+```
+
+- Required metadata: `starter_track_id` and `provider_id`.
+- Optional metadata: `matched_tag_count` when the pick was selected from taste-tag matches.
+- Product decision: identify starter picks that should be downranked, reframed, or replaced after repeated passes.
+
+#### Review Read Depth
+
+```json
+{
+  "event_type": "review_read_90",
+  "source": "feed:for-you",
+  "metadata": {
+    "review_id": "review_example_02",
+    "entity_id": "track_example_02",
+    "reason": "editorial_affinity"
+  }
+}
+```
+
+- Required metadata: `review_id`, `entity_id`, and `reason`.
+- Optional metadata: none for the minimal event; do not attach raw review text or granular scroll traces.
+- Product decision: find recommendation reasons that lead to sustained reading rather than impressions alone.
+
 ### Signal Rules
 
 - One event should answer one question.


### PR DESCRIPTION
## What changed

- add three example discovery event payloads
- identify required and optional metadata
- connect each signal to a concrete product decision
- keep the examples free of sensitive or private data

## Verification

- parsed all JSON examples successfully
- ran `git diff --check`

Closes #85

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds three example discovery-signal payloads to docs/discovery-curation.md to standardize instrumentation and align recommendation reason labels with our taxonomy.

- Adds an “Example Payloads” section for For You review impression, Starter pick pass, and Review read depth, with required envelope fields (`event_type`, `source`, `metadata`) and per-event metadata; notes optional `position` and `matched_tag_count`.
- Uses valid recommendation reason labels in examples (e.g., `taste_match`, `author_affinity`).
- Provides privacy guidance to exclude raw review text and granular scroll traces.
- Docs only; no runtime changes.

<sup>Written for commit 795cc35cc5561751c4fff57101e7d8422114649d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/francozeta/kocteau/pull/180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added example JSON payloads for For You review impressions, starter-pick passes, and review read-depth events.
  * Documented required and optional fields, event metadata, and related product decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->