### PR TITLE
perf(web): reduce RSC payload and stream track discovery

### DIFF
--- a/apps/web/app/(home)/page.tsx
+++ b/apps/web/app/(home)/page.tsx
@@ -1,6 +1,3 @@
-import { HydrationBoundary, dehydrate } from "@tanstack/react-query";
-
-import ReactQueryProvider from "@/app/providers/react-query-provider";
 import { circular, redaction } from "@/app/landing-fonts";
 import GuestHeader from "@/components/guest-header";
 import GuestHome from "@/components/guest-home";
@@ -9,12 +6,10 @@ import { createPageMetadata } from "@/lib/metadata";
 import { measureServerTask } from "@/lib/perf";
 import { getFeedPage } from "@/lib/queries/feed";
 import { getPublicStarterTracks } from "@/lib/queries/starter";
-import { createServerQueryClient } from "@/lib/react-query/server";
 import {
   buildFeedPageJsonLd,
   buildHomePageJsonLd,
 } from "@/lib/structured-data";
-import { feedKeys, type FeedInfiniteQueryData } from "@/queries/feed";
 
 export const revalidate = 300;
 
@@ -48,14 +43,6 @@ export default async function HomePage() {
     nextCursor: null,
     requiresAuth: false,
   };
-  const queryClient = createServerQueryClient();
-
-  queryClient.setQueryData(feedKeys.bundle("latest"), recentPage);
-  queryClient.setQueryData<FeedInfiniteQueryData>(feedKeys.infinite("latest"), {
-    pages: [recentPage],
-    pageParams: [null],
-  });
-
   const feedStructuredData = buildFeedPageJsonLd(
     recentPage.feed.flatMap((review) => {
       const entity = review.entities;
@@ -90,19 +77,18 @@ export default async function HomePage() {
   );
 
   return (
-    <ReactQueryProvider>
-      <div
-        className={`${circular.variable} ${redaction.variable} kocteau-guest-typography kocteau-guest-grain min-h-svh overflow-x-clip bg-[var(--kocteau-landing-canvas)] text-foreground`}
-      >
-        <GuestHeader />
-        <main className="pt-15 sm:pt-16">
-          <HydrationBoundary state={dehydrate(queryClient)}>
-            <JsonLd data={buildHomePageJsonLd()} id="home-page-structured-data" />
-            <JsonLd data={feedStructuredData} id="home-structured-data" />
-            <GuestHome recentPage={recentPage} starterTracks={starterTracks} />
-          </HydrationBoundary>
-        </main>
-      </div>
-    </ReactQueryProvider>
+    <div
+      className={`${circular.variable} ${redaction.variable} kocteau-guest-typography kocteau-guest-grain min-h-svh overflow-x-clip bg-[var(--kocteau-landing-canvas)] text-foreground`}
+    >
+      <GuestHeader />
+      <main className="pt-15 sm:pt-16">
+        <JsonLd data={buildHomePageJsonLd()} id="home-page-structured-data" />
+        <JsonLd data={feedStructuredData} id="home-structured-data" />
+        <GuestHome
+          recentReviews={recentPage.feed}
+          starterTracks={starterTracks}
+        />
+      </main>
+    </div>
   );
 }

--- a/apps/web/app/(main)/feed/page.tsx
+++ b/apps/web/app/(main)/feed/page.tsx
@@ -1,4 +1,3 @@
-import { HydrationBoundary, dehydrate } from "@tanstack/react-query";
 import { redirect } from "next/navigation";
 
 import { OnboardingWelcomeFromUrl } from "@/components/auth/onboarding-welcome-dialog";
@@ -9,8 +8,6 @@ import { createPageMetadata } from "@/lib/metadata";
 import { measureServerTask } from "@/lib/perf";
 import { getFeedPage, getFeedViewerState } from "@/lib/queries/feed";
 import { getStarterTracksForSurface } from "@/lib/queries/starter";
-import { createServerQueryClient } from "@/lib/react-query/server";
-import { feedKeys, type FeedInfiniteQueryData } from "@/queries/feed";
 
 export const dynamic = "force-dynamic";
 
@@ -36,35 +33,43 @@ export default async function FeedPage({
   }
 
   const activeView = getAuthenticatedFeedView(params.view);
-  const [feedPage, starterTracks, viewerProfile] = await measureServerTask(
-    "getAuthenticatedFeedData",
-    () =>
-      Promise.all([
-        getFeedPage({
+  const { feedPage, starterTracks, viewerProfile, viewerState } =
+    await measureServerTask(
+      "getAuthenticatedFeedData",
+      async () => {
+        const feedPagePromise = getFeedPage({
           view: activeView,
           viewerId: userId,
           includeActiveUsers: false,
-        }),
-        getStarterTracksForSurface({
+        });
+        const starterTracksPromise = getStarterTracksForSurface({
           viewerId: userId,
           limit: 6,
           surface: "home",
           contextKey: "home",
-        }),
-        getCurrentViewerProfile(),
-      ]),
-    { route: "/feed", view: activeView },
-  );
-  const viewerState =
-    feedPage.feed.length > 0
-      ? await getFeedViewerState(
-          userId,
-          feedPage.feed.map((review) => review.id),
-        )
-      : {
-          likedReviewIds: new Set<string>(),
-          bookmarkedReviewIds: new Set<string>(),
-        };
+        });
+        const viewerProfilePromise = getCurrentViewerProfile();
+        const feedPage = await feedPagePromise;
+        const viewerStatePromise =
+          feedPage.feed.length > 0
+            ? getFeedViewerState(
+                userId,
+                feedPage.feed.map((review) => review.id),
+              )
+            : Promise.resolve({
+                likedReviewIds: new Set<string>(),
+                bookmarkedReviewIds: new Set<string>(),
+              });
+        const [starterTracks, viewerProfile, viewerState] = await Promise.all([
+          starterTracksPromise,
+          viewerProfilePromise,
+          viewerStatePromise,
+        ]);
+
+        return { feedPage, starterTracks, viewerProfile, viewerState };
+      },
+      { route: "/feed", view: activeView },
+    );
   const feedData = {
     ...feedPage,
     activeUsers: [],
@@ -75,16 +80,8 @@ export default async function FeedPage({
     })),
     requiresAuth: false,
   };
-  const queryClient = createServerQueryClient();
-
-  queryClient.setQueryData(feedKeys.bundle(activeView), feedData);
-  queryClient.setQueryData<FeedInfiniteQueryData>(feedKeys.infinite(activeView), {
-    pages: [feedData],
-    pageParams: [null],
-  });
-
   return (
-    <HydrationBoundary state={dehydrate(queryClient)}>
+    <>
       {params.welcome === "kocteau" ? <OnboardingWelcomeFromUrl /> : null}
       <AuthenticatedFeedSurface
         initialView={activeView}
@@ -92,6 +89,6 @@ export default async function FeedPage({
         viewer={viewerProfile}
         starterTracks={starterTracks}
       />
-    </HydrationBoundary>
+    </>
   );
 }

--- a/apps/web/app/(main)/tracks/[slug]/[id]/page.tsx
+++ b/apps/web/app/(main)/tracks/[slug]/[id]/page.tsx
@@ -1,11 +1,13 @@
 import type { Metadata } from "next";
-import { HydrationBoundary, dehydrate } from "@tanstack/react-query";
+import { Suspense } from "react";
 import { Music2 } from "@/components/ui/icons";
 import { notFound, permanentRedirect } from "next/navigation";
 import JsonLd from "@/components/json-ld";
 import TrackPageHeaderBridge from "@/components/track-page-header-bridge";
 import TrackPageHero from "@/components/track-page-hero";
-import TrackMoreToHear from "@/components/track-more-to-hear";
+import TrackMoreToHear, {
+  TrackMoreToHearSkeleton,
+} from "@/components/track-more-to-hear";
 import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from "@/components/ui/empty";
 import { TrackReviewCard } from "@/components/review-route-cards-server";
 import { getCurrentUserId } from "@/lib/auth/server";
@@ -22,10 +24,8 @@ import {
   getViewerEntityLibraryState,
 } from "@/lib/queries/entity-library";
 import { getTrackRecommendations } from "@/lib/queries/track-recommendations";
-import { createServerQueryClient } from "@/lib/react-query/server";
 import { buildEntityCanonicalPath, isSeoRouteId } from "@/lib/seo-routes";
 import { buildTrackPageJsonLd } from "@/lib/structured-data";
-import { trackKeys } from "@/queries/tracks";
 
 type TrackRouteParams = {
   slug: string;
@@ -34,6 +34,16 @@ type TrackRouteParams = {
 
 function getRoutePath({ slug, id }: TrackRouteParams) {
   return `/tracks/${slug}/${id}`;
+}
+
+async function TrackRecommendations({
+  recommendationsPromise,
+}: {
+  recommendationsPromise: ReturnType<typeof getTrackRecommendations>;
+}) {
+  const recommendations = await recommendationsPromise;
+
+  return <TrackMoreToHear groups={recommendations} />;
 }
 
 export async function generateMetadata({
@@ -73,14 +83,16 @@ export default async function TrackPage({
   params: Promise<TrackRouteParams>;
   searchParams: Promise<{ editReview?: string }>;
 }) {
-  const routeParams = await params;
-  const query = await searchParams;
+  const [routeParams, query] = await Promise.all([params, searchParams]);
 
   if (!isSeoRouteId(routeParams.id)) {
     notFound();
   }
 
-  const entityPage = await getEntityPageByRouteId(routeParams.id);
+  const [entityPage, userId] = await Promise.all([
+    getEntityPageByRouteId(routeParams.id),
+    getCurrentUserId(),
+  ]);
 
   if (!entityPage) {
     notFound();
@@ -92,10 +104,8 @@ export default async function TrackPage({
     permanentRedirect(canonicalPath);
   }
 
-  const userIdPromise = getCurrentUserId();
   const publicBundlePromise = getTrackPublicBundle(entityPage.id);
-  const [userId, bundle, artist, album] = await Promise.all([
-    userIdPromise,
+  const [bundle, artist, album] = await Promise.all([
     publicBundlePromise,
     entityPage.artist_id ? getArtistPageById(entityPage.artist_id) : Promise.resolve(null),
     entityPage.parent_album_id
@@ -104,6 +114,15 @@ export default async function TrackPage({
   ]);
 
   if (!bundle) notFound();
+
+  const recommendationsPromise = getTrackRecommendations({
+    currentEntityId: bundle.entity.id,
+    currentProviderId: bundle.entity.provider_id,
+    title: bundle.entity.title,
+    artistName: bundle.entity.artist_name,
+    tags: bundle.tags,
+    limit: 18,
+  });
 
   const emptyViewerState = {
     likedReviewIds: new Set<string>(),
@@ -123,7 +142,6 @@ export default async function TrackPage({
     entityPage.id,
   );
 
-  const queryClient = createServerQueryClient();
   const trackData = {
     entity: bundle.entity,
     tags: bundle.tags,
@@ -135,17 +153,7 @@ export default async function TrackPage({
     })),
   };
 
-  queryClient.setQueryData(trackKeys.detail(entityPage.id), trackData);
-
   const { entity, reviews: trackReviews } = trackData;
-  const recommendations = await getTrackRecommendations({
-    currentEntityId: entity.id,
-    currentProviderId: entity.provider_id,
-    title: entity.title,
-    artistName: entity.artist_name,
-    tags: trackData.tags,
-    limit: 18,
-  });
   const { viewerReviewId } = trackData;
   const viewerReview =
     viewerReviewId
@@ -162,7 +170,7 @@ export default async function TrackPage({
       : null;
 
   return (
-    <HydrationBoundary state={dehydrate(queryClient)}>
+    <>
       <JsonLd
         data={buildTrackPageJsonLd({
           entity,
@@ -244,7 +252,11 @@ export default async function TrackPage({
           shouldOpenViewerEditor={shouldOpenViewerEditor}
         />
 
-        <TrackMoreToHear groups={recommendations} />
+        <Suspense fallback={<TrackMoreToHearSkeleton />}>
+          <TrackRecommendations
+            recommendationsPromise={recommendationsPromise}
+          />
+        </Suspense>
 
         <div className="space-y-4">
           {trackReviews.length > 0 ? (
@@ -277,6 +289,6 @@ export default async function TrackPage({
           )}
         </div>
       </section>
-    </HydrationBoundary>
+    </>
   );
 }

--- a/apps/web/components/guest-home.tsx
+++ b/apps/web/components/guest-home.tsx
@@ -14,10 +14,10 @@ import GuestTestimonials from "@/components/guest-testimonials";
 import { SpotlightLogo } from "@/components/spotlight-logo";
 import { ArrowRight, Search, Star } from "@/components/ui/icons";
 import type { StarterTrack } from "@/lib/starter";
-import type { FeedBundleQueryData } from "@/queries/feed";
+import type { FeedBundleReview } from "@/queries/feed";
 
 type GuestHomeProps = {
-  recentPage: FeedBundleQueryData;
+  recentReviews: FeedBundleReview[];
   starterTracks: StarterTrack[];
 };
 
@@ -285,7 +285,7 @@ function GuestClosingCta() {
 }
 
 export default function GuestHome({
-  recentPage,
+  recentReviews,
   starterTracks,
 }: GuestHomeProps) {
   return (
@@ -312,7 +312,7 @@ export default function GuestHome({
         <GuestTestimonials />
 
         <div className="space-y-16 pt-16 sm:space-y-20 sm:pt-20 lg:space-y-24 lg:pt-24">
-          {recentPage.feed.length > 0 ? (
+          {recentReviews.length > 0 ? (
             <section id="recent-reviews" aria-labelledby="recent-reviews-title" className="mx-auto w-full max-w-[80rem] scroll-mt-20 space-y-3 px-4 sm:px-6 lg:px-10">
               <div className="flex items-end justify-between gap-4 px-0.5">
                 <h2 id="recent-reviews-title" className="font-serif text-[1.35rem] font-semibold text-foreground">
@@ -322,7 +322,7 @@ export default function GuestHome({
                   Explore more
                 </Link>
               </div>
-              <GuestReviewList reviews={recentPage.feed} />
+              <GuestReviewList reviews={recentReviews} />
             </section>
           ) : null}
 

--- a/apps/web/components/track-more-to-hear.tsx
+++ b/apps/web/components/track-more-to-hear.tsx
@@ -11,6 +11,32 @@ type TrackMoreToHearProps = {
   className?: string;
 };
 
+export function TrackMoreToHearSkeleton() {
+  return (
+    <section
+      className="space-y-4 border-b border-border/24 pb-5"
+      aria-label="Loading recommendations"
+      aria-busy="true"
+    >
+      <div className="space-y-2 px-0.5">
+        <div className="h-2.5 w-14 rounded-full bg-foreground/[0.045]" />
+        <div className="h-4 w-28 rounded-full bg-foreground/[0.065]" />
+      </div>
+      <div className="grid gap-x-6 sm:grid-cols-2">
+        {Array.from({ length: 4 }).map((_, groupIndex) => (
+          <div
+            key={groupIndex}
+            className="space-y-3 border-t border-border/14 py-3"
+          >
+            <div className="h-2.5 w-20 rounded-full bg-foreground/[0.05]" />
+            <div className="h-[10.75rem] rounded-[0.7rem] bg-foreground/[0.025]" />
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
 function RecommendationRow({
   recommendation,
 }: {

--- a/apps/web/lib/queries/entities.ts
+++ b/apps/web/lib/queries/entities.ts
@@ -422,7 +422,9 @@ export async function getEntityTasteTags(entityId: string) {
   )();
 }
 
-export async function getTrackPublicBundle(entityId: string) {
+export const getTrackPublicBundle = cache(async function getTrackPublicBundle(
+  entityId: string,
+) {
   const [entity, reviews, tags] = await measureServerTask(
     "getTrackPublicBundle",
     async () =>
@@ -443,7 +445,7 @@ export async function getTrackPublicBundle(entityId: string) {
     tags,
     reviews,
   } satisfies TrackPagePublicBundle;
-}
+});
 
 export async function getTrackViewerState(
   viewerId: string | null | undefined,


### PR DESCRIPTION
## Summary
- remove redundant TanStack Query dehydration from landing, feed, and track routes
- deduplicate the public track bundle per request with React cache
- stream track recommendations behind a structural Suspense fallback
- overlap dependent feed viewer-state work with other server queries

## Verification
- pnpm --filter web lint
- targeted ESLint for changed files
- pnpm --filter web build
- git diff --check
- Playwright desktop and mobile smoke checks for home and track routes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts RSC payload by removing `@tanstack/react-query` hydration on home, feed, and track routes and streams track recommendations with Suspense. Public track bundles are deduplicated per request to avoid duplicate fetches; feed viewer-state fetching now overlaps with other server queries.

- Old vs new behavior:
  - Home/feed/track: previously shipped dehydrated query caches behind HydrationBoundary; now render with server data passed as props only. Side effect: smaller payload and less client JS; components must not assume a prefilled QueryClient.
  - Track recommendations: previously blocked render; now streamed behind a structural fallback skeleton. Side effect: faster first paint; recommendations appear progressively.
  - Track public bundle: repeated per-request calls executed multiple times; now wrapped in React cache to dedupe per-request calls.

- Reviewer notes and migrations:
  - Verify feed likes/bookmarks state renders correctly with overlapped fetches.
  - Confirm SEO structured data remains intact on home and track pages.
  - If importing GuestHome elsewhere, pass recentReviews (array) instead of a page bundle (renamed from recentPage).

<sup>Written for commit 752145f6af44c5049d0f2b5cca782c202f071140. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/francozeta/kocteau/pull/186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved loading efficiency across the home page, feed, and track pages by streamlining data fetching.
  - Added memoization for repeated track detail requests.

- **User Experience**
  - Added a skeleton loading state for recommended tracks, providing clearer feedback while content loads.
  - Improved concurrent loading of page content and viewer information.

- **Refactor**
  - Simplified page rendering and recent-review data handling without changing the visible content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->