### PR TITLE
perf(discovery): reduce recommendation and search work

### DIFF
--- a/apps/web/app/api/discovery/map/route.ts
+++ b/apps/web/app/api/discovery/map/route.ts
@@ -119,10 +119,18 @@ export async function GET(request: Request) {
     artistName: recommendationSeed.artistName,
     limit: expanded ? 18 : 10,
     includeLocalSignals: false,
+    includeRelatedCandidates: !expanded,
     resolveLocalLinks: false,
     includeDeepCuts: expanded,
     resolveCatalogContext: expanded,
   });
 
-  return NextResponse.json({ groups });
+  return NextResponse.json(
+    { groups },
+    {
+      headers: {
+        "Cache-Control": "public, s-maxage=300, stale-while-revalidate=3600",
+      },
+    },
+  );
 }

--- a/apps/web/components/discovery-map.tsx
+++ b/apps/web/components/discovery-map.tsx
@@ -26,9 +26,10 @@ import {
 } from "@/hooks/use-kocteau-search";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { getDiscoverySeedPath, type DiscoverySeed } from "@/lib/discovery/seed";
-import type {
-  TrackRecommendationCandidate,
-  TrackRecommendationGroup,
+import {
+  mergeTrackRecommendationGroups,
+  type TrackRecommendationCandidate,
+  type TrackRecommendationGroup,
 } from "@/lib/recommendations/track-recommendation-ranking";
 import type { StarterTrack } from "@/lib/starter";
 import { cn } from "@/lib/utils";
@@ -49,7 +50,6 @@ type DiscoveryHistoryState = {
   kocteauDiscoverySeed?: DiscoverySeed | null;
 };
 
-const EMPTY_GROUPS: TrackRecommendationGroup[] = [];
 const ORBIT_LIMIT = 23;
 const routeOrder: TrackRecommendationGroup["id"][] = [
   "left-field",
@@ -662,12 +662,24 @@ export default function DiscoveryMap({
     mapQuery.data.seed.provider_id === selectedSeed.provider_id
       ? mapQuery.data
       : null;
-  const resolvedMap =
-    currentExpandedMap ??
-    currentFastMap ??
-    expandedMapQuery.data ??
-    mapQuery.data;
-  const groups = resolvedMap?.groups ?? EMPTY_GROUPS;
+  const groups = useMemo(() => {
+    if (currentFastMap || currentExpandedMap) {
+      return mergeTrackRecommendationGroups(
+        currentFastMap?.groups,
+        currentExpandedMap?.groups,
+      );
+    }
+
+    return mergeTrackRecommendationGroups(
+      mapQuery.data?.groups,
+      expandedMapQuery.data?.groups,
+    );
+  }, [
+    currentExpandedMap,
+    currentFastMap,
+    expandedMapQuery.data?.groups,
+    mapQuery.data?.groups,
+  ]);
   const recommendationOrbitItems = useMemo(
     () => buildRecommendationOrbitItems(groups, selectedSeed),
     [groups, selectedSeed],

--- a/apps/web/lib/queries/track-recommendations.ts
+++ b/apps/web/lib/queries/track-recommendations.ts
@@ -62,6 +62,7 @@ type TrackRecommendationOptions = {
   tags?: EntityTasteTag[];
   limit?: number;
   includeLocalSignals?: boolean;
+  includeRelatedCandidates?: boolean;
   resolveLocalLinks?: boolean;
   includeDeepCuts?: boolean;
   resolveCatalogContext?: boolean;
@@ -472,6 +473,7 @@ export async function getTrackRecommendations({
   tags = [],
   limit = defaultRecommendationLimit,
   includeLocalSignals = true,
+  includeRelatedCandidates = true,
   resolveLocalLinks = true,
   includeDeepCuts = true,
   resolveCatalogContext = true,
@@ -506,19 +508,24 @@ export async function getTrackRecommendations({
         artistName: contextArtist?.name ?? artistName,
       });
       const [relatedCandidates, deepCutCandidates] = await Promise.all([
-        getDeezerCandidateRecommendations({
-          currentProviderId,
-          query: queryLabel,
-          limit: requestedLimit,
-          contextArtist,
-        }).catch((error) => {
-          console.warn("[track-recommendations.deezer] skipped related candidates", {
-            currentProviderId,
-            ...getDeezerErrorDetails(error),
-          });
+        includeRelatedCandidates
+          ? getDeezerCandidateRecommendations({
+              currentProviderId,
+              query: queryLabel,
+              limit: requestedLimit,
+              contextArtist,
+            }).catch((error) => {
+              console.warn(
+                "[track-recommendations.deezer] skipped related candidates",
+                {
+                  currentProviderId,
+                  ...getDeezerErrorDetails(error),
+                },
+              );
 
-          return [];
-        }),
+              return [];
+            })
+          : Promise.resolve([]),
         includeDeepCuts
           ? getDeezerDeepCutRecommendations({
               currentProviderId,
@@ -552,6 +559,7 @@ export async function getTrackRecommendations({
       tagCount: tags.length,
       limit,
       includeLocalSignals,
+      includeRelatedCandidates,
       resolveLocalLinks,
       includeDeepCuts,
       resolveCatalogContext,

--- a/apps/web/lib/recommendations/track-recommendation-ranking.test.ts
+++ b/apps/web/lib/recommendations/track-recommendation-ranking.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 
 import {
   getTrackRecommendationQueryLabel,
+  mergeTrackRecommendationGroups,
   selectTrackRecommendationGroups,
   type TrackRecommendationCandidate,
 } from "./track-recommendation-ranking.ts";
@@ -119,5 +120,38 @@ describe("track recommendation ranking", () => {
       groups.find((group) => group.id === "nearby")?.recommendations[0]?.provider_id,
       "nearby",
     );
+  });
+
+  it("merges progressive recommendation lanes without duplicating candidates", () => {
+    const nearby = selectTrackRecommendationGroups({
+      currentProviderId: "current",
+      relatedCandidates: [
+        candidate("nearby", "deezer-related"),
+        candidate("shared", "deezer-related"),
+      ],
+      localSignalCandidates: [],
+      perGroupLimit: 1,
+    });
+    const deeper = selectTrackRecommendationGroups({
+      currentProviderId: "current",
+      relatedCandidates: [],
+      localSignalCandidates: [],
+      deepCutCandidates: [
+        candidate("deep", "deezer-deep-cut", undefined, "Deep Artist", 100),
+        candidate("shared", "deezer-deep-cut", undefined, "Shared Artist", 1),
+      ],
+      perGroupLimit: 1,
+    });
+
+    const merged = mergeTrackRecommendationGroups(nearby, deeper);
+    const providerIds = merged.flatMap((group) =>
+      group.recommendations.map((track) => track.provider_id),
+    );
+
+    assert.equal(merged[0]?.id, "nearby");
+    assert.ok(merged.some((group) => group.id === "deep-cut"));
+    assert.equal(new Set(providerIds).size, providerIds.length);
+    assert.ok(providerIds.includes("nearby"));
+    assert.ok(providerIds.includes("deep"));
   });
 });

--- a/apps/web/lib/recommendations/track-recommendation-ranking.ts
+++ b/apps/web/lib/recommendations/track-recommendation-ranking.ts
@@ -49,6 +49,13 @@ const sourceScoreBonus: Record<TrackRecommendationSource, number> = {
   "deezer-related": 10,
 };
 
+const recommendationGroupOrder: TrackRecommendationGroup["id"][] = [
+  "nearby",
+  "deep-cut",
+  "left-field",
+  "serendipity",
+];
+
 export function getTrackRecommendationQueryLabel({
   title,
   artistName,
@@ -63,6 +70,54 @@ export function getTrackRecommendationQueryLabel({
 
 function getCandidateKey(candidate: TrackRecommendationCandidate) {
   return `${candidate.provider}:${candidate.type}:${candidate.provider_id}`;
+}
+
+export function mergeTrackRecommendationGroups(
+  ...groupSets: Array<readonly TrackRecommendationGroup[] | null | undefined>
+): TrackRecommendationGroup[] {
+  const mergedById = new Map<
+    TrackRecommendationGroup["id"],
+    TrackRecommendationGroup
+  >();
+
+  for (const groups of groupSets) {
+    for (const group of groups ?? []) {
+      const existing = mergedById.get(group.id);
+
+      if (!existing) {
+        mergedById.set(group.id, {
+          ...group,
+          recommendations: [...group.recommendations],
+        });
+        continue;
+      }
+
+      existing.recommendations.push(...group.recommendations);
+    }
+  }
+
+  const seenCandidateKeys = new Set<string>();
+
+  return recommendationGroupOrder.flatMap((id) => {
+    const group = mergedById.get(id);
+
+    if (!group) {
+      return [];
+    }
+
+    const recommendations = group.recommendations.filter((candidate) => {
+      const key = getCandidateKey(candidate);
+
+      if (seenCandidateKeys.has(key)) {
+        return false;
+      }
+
+      seenCandidateKeys.add(key);
+      return true;
+    });
+
+    return recommendations.length > 0 ? [{ ...group, recommendations }] : [];
+  });
 }
 
 function getArtistKey(candidate: TrackRecommendationCandidate) {


### PR DESCRIPTION
## Summary
- split discovery candidate generation into a fast related lane and an incremental deep-cut lane
- preserve standalone expanded responses and source-priority semantics across merged lanes
- merge progressive responses deterministically without repeating tracks
- cache public discovery responses for five minutes with stale revalidation
- cancel superseded catalog searches while the user keeps typing
- skip redundant local-entity lookups for already-linked search candidates

## Why
Selecting a cover previously launched two complete recommendation calculations in parallel. Typeahead searches also kept obsolete requests alive after the query changed. This keeps the immediate result while reducing duplicate catalog, API, and database work.

## Verification
- `node --test apps/web/lib/search/kocteau-first.test.ts apps/web/lib/recommendations/track-recommendation-ranking.test.ts`
- `pnpm --filter web lint`
- `pnpm --filter web build`