### PR TITLE
perf(search): cancel stale work and preserve discovery lanes

### DIFF
--- a/apps/web/app/api/discovery/map/route.ts
+++ b/apps/web/app/api/discovery/map/route.ts
@@ -17,6 +17,7 @@ const discoveryMapQuerySchema = z.object({
   artistName: z.string().trim().max(200).optional(),
   artistProviderId: z.string().trim().refine(isDeezerProviderId).optional(),
   entityId: z.string().uuid().optional(),
+  lane: z.enum(["fast", "deep", "full"]).optional(),
   expanded: z.enum(["true", "false"]).optional(),
 });
 
@@ -94,6 +95,7 @@ export async function GET(request: Request) {
     artistName: searchParams.get("artistName") ?? undefined,
     artistProviderId: searchParams.get("artistProviderId") ?? undefined,
     entityId: searchParams.get("entityId") ?? undefined,
+    lane: searchParams.get("lane") ?? undefined,
     expanded: searchParams.get("expanded") ?? undefined,
   });
 
@@ -101,7 +103,8 @@ export async function GET(request: Request) {
     return validationErrorResponse(parsed.error, "Discovery seed is invalid.");
   }
 
-  const expanded = parsed.data.expanded === "true";
+  const lane =
+    parsed.data.lane ?? (parsed.data.expanded === "true" ? "full" : "fast");
   const recommendationSeed = await resolveRecommendationSeed(parsed.data);
 
   if (!recommendationSeed) {
@@ -117,12 +120,12 @@ export async function GET(request: Request) {
     currentProviderId: recommendationSeed.providerId,
     title: recommendationSeed.title,
     artistName: recommendationSeed.artistName,
-    limit: expanded ? 18 : 10,
+    limit: lane === "fast" ? 10 : 18,
     includeLocalSignals: false,
-    includeRelatedCandidates: !expanded,
+    includeRelatedCandidates: lane !== "deep",
     resolveLocalLinks: false,
-    includeDeepCuts: expanded,
-    resolveCatalogContext: expanded,
+    includeDeepCuts: lane !== "fast",
+    resolveCatalogContext: lane !== "fast",
   });
 
   return NextResponse.json(

--- a/apps/web/app/api/search/route.ts
+++ b/apps/web/app/api/search/route.ts
@@ -398,6 +398,22 @@ async function getEntityIdsByProviderId(providerIds: string[]) {
   return new Map(((data ?? []) as EntityLinkRow[]).map((row) => [row.provider_id, row.id]));
 }
 
+async function attachLocalEntityIds(candidates: KocteauTrackSearchCandidate[]) {
+  const entityIdsByProviderId = await getEntityIdsByProviderId(
+    candidates.flatMap((candidate) =>
+      candidate.entity_id ? [] : [candidate.provider_id],
+    ),
+  );
+
+  return candidates.map((candidate) => ({
+    ...candidate,
+    entity_id:
+      candidate.entity_id ??
+      entityIdsByProviderId.get(candidate.provider_id) ??
+      null,
+  }));
+}
+
 async function getDeezerCandidates(query: string) {
   const candidates: KocteauTrackSearchCandidate[] = [];
   const errors: unknown[] = [];
@@ -542,16 +558,7 @@ async function getAllCatalogCandidates(query: string) {
       ? remoteArtistsResult.value.map(mapDeezerArtistCandidate)
       : [];
   const trackCandidates = [...localTracks, ...starterTracks, ...remoteTracks];
-  const entityIdsByProviderId = await getEntityIdsByProviderId(
-    trackCandidates.map((candidate) => candidate.provider_id),
-  );
-  const linkedTrackCandidates = trackCandidates.map((candidate) => ({
-    ...candidate,
-    entity_id:
-      candidate.entity_id ??
-      entityIdsByProviderId.get(candidate.provider_id) ??
-      null,
-  }));
+  const linkedTrackCandidates = await attachLocalEntityIds(trackCandidates);
   const artists = rankKocteauTrackSearchResults({
     query,
     candidates: [...localArtists, ...remoteArtists],
@@ -632,13 +639,7 @@ export async function GET(req: Request) {
     ...starterCandidates,
     ...deezerCandidatesResult.candidates,
   ];
-  const entityIdsByProviderId = await getEntityIdsByProviderId(
-    candidates.map((candidate) => candidate.provider_id),
-  );
-  const linkedCandidates = candidates.map((candidate) => ({
-    ...candidate,
-    entity_id: candidate.entity_id ?? entityIdsByProviderId.get(candidate.provider_id) ?? null,
-  }));
+  const linkedCandidates = await attachLocalEntityIds(candidates);
   const results = rankKocteauTrackSearchResults({
     query: q,
     candidates: linkedCandidates,

--- a/apps/web/components/discovery-map.tsx
+++ b/apps/web/components/discovery-map.tsx
@@ -264,7 +264,7 @@ function buildRecommendationOrbitItems(
 
 async function fetchDiscoveryMap(
   seed: DiscoverySeed,
-  { expanded = false }: { expanded?: boolean } = {},
+  { lane = "fast" }: { lane?: "fast" | "deep" } = {},
 ) {
   const params = new URLSearchParams({
     providerId: seed.provider_id,
@@ -284,8 +284,8 @@ async function fetchDiscoveryMap(
     params.set("entityId", seed.entityId);
   }
 
-  if (expanded) {
-    params.set("expanded", "true");
+  if (lane !== "fast") {
+    params.set("lane", lane);
   }
 
   const response = await fetch(`/api/discovery/map?${params.toString()}`);
@@ -644,7 +644,7 @@ export default function DiscoveryMap({
   const expandedMapQuery = useQuery({
     queryKey: ["discovery-map-expanded", seedIdentity],
     queryFn: () =>
-      fetchDiscoveryMap(selectedSeed as DiscoverySeed, { expanded: true }),
+      fetchDiscoveryMap(selectedSeed as DiscoverySeed, { lane: "deep" }),
     enabled: Boolean(selectedSeed),
     staleTime: 10 * 60 * 1000,
     retry: 0,

--- a/apps/web/lib/recommendations/track-recommendation-ranking.test.ts
+++ b/apps/web/lib/recommendations/track-recommendation-ranking.test.ts
@@ -130,7 +130,7 @@ describe("track recommendation ranking", () => {
         candidate("shared", "deezer-related"),
       ],
       localSignalCandidates: [],
-      perGroupLimit: 1,
+      perGroupLimit: 2,
     });
     const deeper = selectTrackRecommendationGroups({
       currentProviderId: "current",
@@ -140,12 +140,18 @@ describe("track recommendation ranking", () => {
         candidate("deep", "deezer-deep-cut", undefined, "Deep Artist", 100),
         candidate("shared", "deezer-deep-cut", undefined, "Shared Artist", 1),
       ],
-      perGroupLimit: 1,
+      perGroupLimit: 2,
     });
 
     const merged = mergeTrackRecommendationGroups(nearby, deeper);
     const providerIds = merged.flatMap((group) =>
       group.recommendations.map((track) => track.provider_id),
+    );
+    const sharedGroup = merged.find((group) =>
+      group.recommendations.some((track) => track.provider_id === "shared"),
+    );
+    const sharedCandidate = sharedGroup?.recommendations.find(
+      (track) => track.provider_id === "shared",
     );
 
     assert.equal(merged[0]?.id, "nearby");
@@ -153,5 +159,7 @@ describe("track recommendation ranking", () => {
     assert.equal(new Set(providerIds).size, providerIds.length);
     assert.ok(providerIds.includes("nearby"));
     assert.ok(providerIds.includes("deep"));
+    assert.equal(sharedGroup?.id, "deep-cut");
+    assert.equal(sharedCandidate?.source, "deezer-deep-cut");
   });
 });

--- a/apps/web/lib/recommendations/track-recommendation-ranking.ts
+++ b/apps/web/lib/recommendations/track-recommendation-ranking.ts
@@ -75,46 +75,58 @@ function getCandidateKey(candidate: TrackRecommendationCandidate) {
 export function mergeTrackRecommendationGroups(
   ...groupSets: Array<readonly TrackRecommendationGroup[] | null | undefined>
 ): TrackRecommendationGroup[] {
-  const mergedById = new Map<
-    TrackRecommendationGroup["id"],
-    TrackRecommendationGroup
+  const groups = groupSets.flatMap((groupSet) => groupSet ?? []);
+  const winnerByCandidateKey = new Map<
+    string,
+    {
+      groupId: TrackRecommendationGroup["id"];
+      candidate: TrackRecommendationCandidate;
+    }
   >();
 
-  for (const groups of groupSets) {
-    for (const group of groups ?? []) {
-      const existing = mergedById.get(group.id);
+  for (const group of groups) {
+    for (const candidate of group.recommendations) {
+      const key = getCandidateKey(candidate);
+      const existing = winnerByCandidateKey.get(key);
 
-      if (!existing) {
-        mergedById.set(group.id, {
-          ...group,
-          recommendations: [...group.recommendations],
-        });
-        continue;
+      if (
+        !existing ||
+        sourcePriority[candidate.source] >
+          sourcePriority[existing.candidate.source] ||
+        (candidate.source === existing.candidate.source &&
+          candidate.score > existing.candidate.score)
+      ) {
+        winnerByCandidateKey.set(key, { groupId: group.id, candidate });
       }
-
-      existing.recommendations.push(...group.recommendations);
     }
   }
 
-  const seenCandidateKeys = new Set<string>();
+  const emittedCandidateKeys = new Set<string>();
 
   return recommendationGroupOrder.flatMap((id) => {
-    const group = mergedById.get(id);
+    const group = groups.find((candidateGroup) => candidateGroup.id === id);
 
     if (!group) {
       return [];
     }
 
-    const recommendations = group.recommendations.filter((candidate) => {
-      const key = getCandidateKey(candidate);
+    const recommendations = groups
+      .filter((candidateGroup) => candidateGroup.id === id)
+      .flatMap((candidateGroup) => candidateGroup.recommendations)
+      .flatMap((candidate) => {
+        const key = getCandidateKey(candidate);
+        const winner = winnerByCandidateKey.get(key);
 
-      if (seenCandidateKeys.has(key)) {
-        return false;
-      }
+        if (
+          winner?.groupId !== id ||
+          emittedCandidateKeys.has(key)
+        ) {
+          return [];
+        }
 
-      seenCandidateKeys.add(key);
-      return true;
-    });
+        emittedCandidateKeys.add(key);
+        return [winner.candidate];
+      });
 
     return recommendations.length > 0 ? [{ ...group, recommendations }] : [];
   });

--- a/apps/web/queries/tracks.ts
+++ b/apps/web/queries/tracks.ts
@@ -63,9 +63,10 @@ export function deezerTrackSearchQueryOptions(
 
   return queryOptions({
     queryKey: trackKeys.search(type, query),
-    queryFn: async () => {
+    queryFn: async ({ signal }) => {
       const payload = await fetchJson<DeezerSearchResult[]>(
         `/api/deezer/search?${params.toString()}`,
+        { signal },
       );
 
       return Array.isArray(payload) ? payload : [];
@@ -89,9 +90,10 @@ export function kocteauTrackSearchQueryOptions(
 
   return queryOptions({
     queryKey: trackKeys.kocteauSearch(type, query),
-    queryFn: async () => {
+    queryFn: async ({ signal }) => {
       const payload = await fetchJson<KocteauSearchResult[]>(
         `/api/search?${params.toString()}`,
+        { signal },
       );
 
       return Array.isArray(payload) ? payload : [];


### PR DESCRIPTION
## Summary
- preserve deep-cut source priority when progressive recommendation lanes overlap
- keep `expanded=true` as a complete standalone response and use an explicit deep-only lane for client enrichment
- make the cross-lane deduplication test exercise a real collision
- cancel superseded Deezer and Kocteau typeahead requests
- avoid redundant entity-link lookups for candidates already linked to Kocteau

## Verification
- `node --test apps/web/lib/search/kocteau-first.test.ts apps/web/lib/recommendations/track-recommendation-ranking.test.ts`
- `pnpm --filter web lint`
- `pnpm --filter web build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reworks discovery map lanes and search ranking so progressive deep-cut recommendations keep their source priority, and cancels superseded search work to reduce stale responses.

- The discovery map API now accepts an explicit `lane` (`fast`, `deep`, or `full`); `expanded=true` is still accepted and maps to `full` for compatibility.
- The client requests the `deep` lane for enriched maps instead of using `expanded`.
- When the same track appears in nearby and deep-cut lanes, the deep-cut source wins, with the higher score breaking ties.
- Deezer and Kocteau search queries pass an `AbortSignal` so superseded requests are cancelled.
- Entity-link lookups skip candidates that already carry an `entity_id`.

<sup>Written for commit b4f948f2cbc6bb0280570757a9940b6d39e27930. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/francozeta/kocteau/pull/193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

